### PR TITLE
Add support for joining by library ID

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -72,14 +72,11 @@ workflow{
   map_quant_feature(feature_ch)
   
   // combine feature & RNA quants for feature reads
+  feature_rna_quant_ch = map_quant_feature.out
+    .map{[it[0]["library_id"]] + it } // add library_id from metadata as first element
+    .combine(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0) // combine by library_id 
+    .map{it.subList(1, it.size())} // remove library_id index
   // just print for now
-  // combine_meta = {ch1, ch2, meta_value -> 
-  //   ch1_indexed = ch1.map{[it[0][meta_value]] + it }
-  //   ch2_indexed = ch2.map{[it[0][meta_value]] + it }
-  //   ch1_indexed.combine(ch2_indexed, by: 0)
-  //     .map{it.subList(1, it.size())} // remove index
-  // }
-  // combine_meta(map_quant_feature.out, map_quant_rna.out, "library_id")
-  //   .view()
+  feature_rna_quant_ch.view()
 
 }

--- a/main.nf
+++ b/main.nf
@@ -47,10 +47,21 @@ workflow{
   run_all = run_ids[0] == "All"
   runs_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
+    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
+    .map{[
+      run_id: it.scpca_run_id,
+      library_id: it.scpca_library_id,
+      sample_id: it.scpca_sample_id,
+      technology: it.technology,
+      seq_unit: it.seq_unit,
+      feature_barcode_file: it.feature_barcode_file,
+      feature_barcode_geom: it.feature_barcode_geom,
+      s3_prefix: it.s3_prefix,
+    ]}
     // only technologies we know how to process
     .filter{it.technology in tech_list} 
     // use only the rows in the run_id list
-    .filter{run_all || (it.scpca_run_id in run_ids)}
+    .filter{run_all || (it.run_id in run_ids)}
   
   // **** Process RNA-seq data ****
   rna_ch = runs_ch.filter{it.technology in rna_techs}

--- a/main.nf
+++ b/main.nf
@@ -62,8 +62,13 @@ workflow{
   
   // combine feature & RNA quants for feature reads
   // just print for now
-  map_quant_feature.out
-    .combine(map_quant_rna.out, by: 0) // combine by the sample_id
-    .view()
+  // combine_meta = {ch1, ch2, meta_value -> 
+  //   ch1_indexed = ch1.map{[it[0][meta_value]] + it }
+  //   ch2_indexed = ch2.map{[it[0][meta_value]] + it }
+  //   ch1_indexed.combine(ch2_indexed, by: 0)
+  //     .map{it.subList(1, it.size())} // remove index
+  // }
+  // combine_meta(map_quant_feature.out, map_quant_rna.out, "library_id")
+  //   .view()
 
 }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -4,16 +4,16 @@
 process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
-  tag "${run_id}-rna"
+  tag "${meta.run_id}-rna"
   input:
-    tuple val(sample_id), val(run_id), val(tech), 
+    tuple val(meta), 
           path(read1), path(read2)
     path index
   output:
-    tuple val(sample_id), val(run_id), path(run_dir)
+    tuple val(meta), path(run_dir)
   script:
     // label the run-dir
-    run_dir = "${run_id}-rna"
+    run_dir = "${meta.run_id}-rna"
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
@@ -24,7 +24,7 @@ process alevin_rad{
     mkdir -p ${run_dir}
     salmon alevin \
       -l ISR \
-      ${tech_flag[tech]} \
+      ${tech_flag[meta.technology]} \
       -1 ${read1} \
       -2 ${read2} \
       -i ${index} \
@@ -39,14 +39,14 @@ process alevin_rad{
 process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
-  publishDir "${params.outdir}/rna"
+  publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
 
   input:
-    tuple val(sample_id), val(run_id), path(run_dir)
+    tuple val(meta), path(run_dir)
     path barcode_file
     path tx2gene_3col
   output:
-    tuple val(sample_id), val(run_id), path(run_dir)
+    tuple val(meta), path(run_dir)
   
   script: 
     """
@@ -82,12 +82,17 @@ workflow map_quant_rna {
     // create tuple of [run_id, sample_id, technology, [Read1 files], [Read2 files]]
     // for rnaseq runs
     rna_reads_ch = rna_channel
-      .map{row -> tuple(row.scpca_sample_id,
-                        row.scpca_run_id,
-                        row.technology,
-                        file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                        file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
-                        )}
+      .map{tuple([ // metadata map
+                   run_id: it.scpca_run_id,
+                   library_id: it.scpca_library_id,
+                   sample_id: it.scpca_sample_id,
+                   technology: it.technology,
+                   seq_unit: it.seq_unit,
+                   feature_barcode_geom: it.feature_barcode_geom,
+                 ],
+                 file("s3://${it.s3_prefix}/*_R1_*.fastq.gz"),
+                 file("s3://${it.s3_prefix}/*_R2_*.fastq.gz")
+                 )}
 
     rna_cellbarcodes_ch = rna_channel
       .map{file("${params.barcode_dir}/${params.cell_barcodes[it.technology]}")}


### PR DESCRIPTION
Closes #8

This PR add support for merging RNAseq and feature runs based on the new library_id. It also changes the output location (publishDir) to be nested by sample and library id, for an organization that will be closer to the final output we expect to want.

The other major change is how metadata is passed around within processes. Each process now expects a metadata map (dictionary) as the first element of the main channel input it receives. It then returns this as the first element of the output tuple in all cases. 

This should make it easier for us to add or remove metadata that might be used by processes and pass them along with less fuss. It did make joining by library a bit more involved, but I think the tradeoff is probably worth it. 

One nice extension (not currently implemented, but I'm pretty sure this is possible) is that a process could add to the metadata before returning. This would be done by adding a line like
```
meta.foo = "bar"
```
within any process `script:` block (before or after the shell script portion). Adding something like this would not affect any other script.

At the moment, I have not included in the metadata map the slide information for spatial data. Since we have not yet implemented processing those data, I thought that could wait until we needed it. Adding it should not affect any existing process!

