### PR TITLE
Fix feature mapping

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -25,7 +25,7 @@ process index_feature{
 process alevin_feature{
   container params.SALMON_CONTAINER
   label 'cpus_8'
-  tag "${run_id}-features"
+  tag "${meta.run_id}-features"
   input:
     tuple val(meta), 
           path(read1), path(read2), 
@@ -62,8 +62,8 @@ process alevin_feature{
 process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
+  tag "${meta.run_id}-features"
   publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
-
   input:
     tuple val(meta),
           path(run_dir), path(feature_index)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -41,7 +41,7 @@ process alevin_feature{
                     '10Xv3': '1[17-28]',
                     '10Xv3.1': '1[17-28]']
     tech_version = meta.technology.split('_').last()
-    umi_geom = umi_geom_map[meta.tech_version]
+    umi_geom = umi_geom_map[tech_version]
     """
     mkdir -p ${run_dir}
     salmon alevin \
@@ -49,7 +49,7 @@ process alevin_feature{
       -1 ${read1} \
       -2 ${read2} \
       -i ${feature_index} \
-      --read-geometry ${meta.feature_geom} \
+      --read-geometry ${meta.feature_barcode_geom} \
       --bc-geometry 1[1-16] \
       --umi-geometry ${umi_geom} \
       --rad \

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -41,7 +41,7 @@ process alevin_feature{
                     '10Xv3': '1[17-28]',
                     '10Xv3.1': '1[17-28]']
     tech_version = meta.technology.split('_').last()
-    umi_geom = umi_geom_map[tech_version]
+    umi_geom = umi_geom_map[meta.tech_version]
     """
     mkdir -p ${run_dir}
     salmon alevin \

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -39,6 +39,7 @@ process alevin_rad{
 process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
+  tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
 
   input:


### PR DESCRIPTION
When converting to the standard `meta` value for processes, I missed a place where I needed to substitute that in, breaking the mapping of feature data. Now fixed, so feature mapping works again