### PR TITLE
Add workflow for building index to scpca-nf

### DIFF
--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -1,0 +1,154 @@
+#!/usr/bin/env Rscript
+
+# This script takes the input reference fasta of the genome and the 
+# corresponding gtf file, identifies the regions of interest corresponding
+# to spliced transcripts and introns, then subsets the genome and gtf for 
+# only those particular regions, and finally outputs a spliced_intron.txome.fa, 
+# spliced_intron.txome.gtf, and spliced_intron.txome.tx2gene.tsv all corresponding to the genomic 
+# regions with spliced transcripts and introns
+
+# This script is also used to generate the 3 column spliced_intron.tx2gene_3col.tsv needed for alevin-fry.
+
+# finally, a list of mitochondrial genes is output for QC
+
+# load needed packages
+library(Biostrings)
+library(BSgenome)
+library(eisaR)
+library(GenomicFeatures)
+library(magrittr)
+library(optparse)
+library(tidyverse)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-f", "--gtf"),
+    type = "character",
+    default = "annotation/Homo_sapiens.GRCh38.103.gtf.gz",
+    help = "File path for input gtf file",
+  ),
+  make_option(
+    opt_str = c("-g", "--genome"),
+    type = "character",
+    default = "fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
+    help = "File path for reference fasta file",
+  ), 
+  make_option(
+    opt_str = c("-a", "--annotation_output"),
+    type = "character",
+    default = "annotation",
+    help = "Directory to write output files",
+  ), 
+  make_option(
+    opt_str = c("-o", "--fasta_output"),
+    type = "character",
+    default = "fasta",
+    help = "Directory to write output files",
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Get base file name from input gtf file
+file_base <- stringr::str_replace(basename(opt$gtf), "\\.gtf(\\.gz)?$", "")
+
+## files with spliced + intron regions
+spliced_intron_fasta_file <- paste0(file_base, ".spliced_intron.txome.fa.gz")
+spliced_intron_gtf_file <- paste0(file_base, ".spliced_intron.txome.gtf")
+spliced_intron_tx2gene_file <- paste0(file_base, ".spliced_intron.tx2gene.tsv")
+spliced_intron_tx2gene_3col_file <- paste0(file_base, ".spliced_intron.tx2gene_3col.tsv")
+
+mito_file <- paste0(file_base, ".mitogenes.txt")
+
+# make final output file names needed
+
+spliced_intron_fasta <- file.path(opt$fasta_output, spliced_intron_fasta_file)
+spliced_intron_gtf <- file.path(opt$annotation_output, spliced_intron_gtf_file)
+spliced_intron_tx2gene <- file.path(opt$annotation_output, 
+                                    spliced_intron_tx2gene_file)
+
+spliced_intron_tx2gene_3col <- file.path(opt$annotation_output, 
+                                 spliced_intron_tx2gene_3col_file)
+
+mito_out <- file.path(opt$annotation_output, mito_file)
+
+# Check for output directory 
+if (!dir.exists(opt$fasta_output)) {
+  dir.create(opt$fasta_output)
+}
+
+if (!dir.exists(opt$annotation_output)) {
+  dir.create(opt$annotation_output)
+}
+
+
+# extract GRanges object containing genomic coordinates of each annotated transcript
+# both spliced transcripts and intronic regions
+grl <- eisaR::getFeatureRanges(
+  gtf = opt$gtf,
+  featureType = c("spliced", "intron"), 
+  flankLength = 86L,
+  joinOverlappingIntrons = FALSE,
+  verbose = TRUE
+)
+
+# load in primary genome
+genome <- Biostrings::readDNAStringSet(opt$genome)
+names(genome) <- stringr::word(names(genome), 1)
+
+
+# add the levels and lengths
+seqlevels(grl) <- seqlevels(genome)
+seqlengths(grl) <- seqlengths(genome)
+
+# trim grl used for splici
+splici_grl <- trim(grl)
+
+# extract seqs from trimmed grl for splici index
+splici_seqs <- GenomicFeatures::extractTranscriptSeqs(
+  x = genome, 
+  transcripts = splici_grl
+)
+
+# remove sequence duplicates
+splici_seqs <- unique(splici_seqs)
+splici_grl <- splici_grl[names(splici_seqs)]
+
+# write splici to fasta 
+Biostrings::writeXStringSet(
+  splici_seqs, filepath = spliced_intron_fasta, compress = TRUE
+)
+
+# write the associated annotations to gtf 
+eisaR::exportToGtf(
+  splici_grl, 
+  filepath = spliced_intron_gtf
+)
+
+# create text file mapping transcript and intron identifiers to corresponding gene identifiers
+# make 2 column Tx2Gene for all spliced and intron sequences
+splici_tx2gene_df <- eisaR::getTx2Gene(splici_grl)
+
+# write out 2 column Tx2 gene mapping
+readr::write_tsv(splici_tx2gene_df, spliced_intron_tx2gene, col_names = FALSE)
+
+# make 3 column Tx2 gene needed for alevin-fry USA mode
+splici_tx2gene_df_3col <- splici_tx2gene_df  %>%
+  # add status column
+  # remove extra -I* on gene ID
+  mutate(gene_id = stringr::word(gene_id,1,sep = '-'),
+         #if transcript_id contains an added -I*, then it is usnpliced
+         status = ifelse(stringr::str_detect(transcript_id, '-I'), 'U', 'S'))
+
+# write 3 column tx2gene
+readr::write_tsv(splici_tx2gene_df_3col, spliced_intron_tx2gene_3col, col_names = FALSE)
+
+
+# reimport gtf to get list of mito genes 
+gtf <- rtracklayer::import(spliced_intron_gtf)
+mitogenes <- gtf[seqnames(gtf) == 'MT']
+
+# write out mitochondrial gene list
+writeLines(mitogenes$gene_id, mito_out)

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -25,7 +25,7 @@ option_list <- list(
   make_option(
     opt_str = c("-f", "--gtf"),
     type = "character",
-    default = "annotation/Homo_sapiens.GRCh38.103.gtf.gz",
+    default = "annotation/Homo_sapiens.GRCh38.104.gtf.gz",
     help = "File path for input gtf file",
   ),
   make_option(

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -25,13 +25,11 @@ option_list <- list(
   make_option(
     opt_str = c("-f", "--gtf"),
     type = "character",
-    default = "annotation/Homo_sapiens.GRCh38.104.gtf.gz",
     help = "File path for input gtf file",
   ),
   make_option(
     opt_str = c("-g", "--genome"),
     type = "character",
-    default = "fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
     help = "File path for reference fasta file",
   ), 
   make_option(
@@ -49,7 +47,6 @@ option_list <- list(
   make_option(
     opt_str = c("-s", "--assembly"),
     type = "character",
-    default = "",
     help = "Prefix name containing organism and ensembl assembly version to be used for file naming"
   )
 )
@@ -92,7 +89,7 @@ if (!dir.exists(opt$annotation_output)) {
 grl <- eisaR::getFeatureRanges(
   gtf = opt$gtf,
   featureType = c("spliced", "intron"), 
-  flankLength = 86L,
+  flankLength = opts$flank_length,
   joinOverlappingIntrons = FALSE,
   verbose = TRUE
 )
@@ -154,4 +151,4 @@ gtf <- rtracklayer::import(spliced_intron_gtf)
 mitogenes <- gtf[seqnames(gtf) == 'MT']
 
 # write out mitochondrial gene list
-writeLines(mitogenes$gene_id, mito_out)
+writeLines(unique(mitogenes$gene_id), mito_out)

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -45,22 +45,25 @@ option_list <- list(
     type = "character",
     default = "fasta",
     help = "Directory to write output transcript fasta files",
+  ),
+  make_option(
+    opt_str = c("-s", "--assembly"),
+    type = "character",
+    default = ""
+    help = "Prefix name containing organism and ensembl assembly version to be used for file naming"
   )
 )
 
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
-# Get base file name from input gtf file
-file_base <- stringr::str_replace(basename(opt$gtf), "\\.gtf(\\.gz)?$", "")
-
 ## files with spliced + intron regions
-spliced_intron_fasta_file <- paste0(file_base, ".spliced_intron.txome.fa.gz")
-spliced_intron_gtf_file <- paste0(file_base, ".spliced_intron.txome.gtf")
-spliced_intron_tx2gene_file <- paste0(file_base, ".spliced_intron.tx2gene.tsv")
-spliced_intron_tx2gene_3col_file <- paste0(file_base, ".spliced_intron.tx2gene_3col.tsv")
+spliced_intron_fasta_file <- paste0(opt$assembly, ".spliced_intron.txome.fa.gz")
+spliced_intron_gtf_file <- paste0(opt$assembly, ".spliced_intron.txome.gtf")
+spliced_intron_tx2gene_file <- paste0(opt$assembly, ".spliced_intron.tx2gene.tsv")
+spliced_intron_tx2gene_3col_file <- paste0(opt$assembly, ".spliced_intron.tx2gene_3col.tsv")
 
-mito_file <- paste0(file_base, ".mitogenes.txt")
+mito_file <- paste0(opt$assembly, ".mitogenes.txt")
 
 # make final output file names needed
 

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -38,13 +38,13 @@ option_list <- list(
     opt_str = c("-a", "--annotation_output"),
     type = "character",
     default = "annotation",
-    help = "Directory to write output files",
+    help = "Directory to write output gtf, tx2gene, and mitochondrial gene list files",
   ), 
   make_option(
     opt_str = c("-o", "--fasta_output"),
     type = "character",
     default = "fasta",
-    help = "Directory to write output files",
+    help = "Directory to write output transcript fasta files",
   )
 )
 

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -48,6 +48,12 @@ option_list <- list(
     opt_str = c("-s", "--assembly"),
     type = "character",
     help = "Prefix name containing organism and ensembl assembly version to be used for file naming"
+  ),
+  make_option(
+    opt_str = c("-l","-flank_length"),
+    type = "integer",
+    default = 86,
+    help = "Length of sequence flanking introns to be included in index, recommended to use read length minus 5."
   )
 )
 

--- a/bin/make_splici_fasta.R
+++ b/bin/make_splici_fasta.R
@@ -49,7 +49,7 @@ option_list <- list(
   make_option(
     opt_str = c("-s", "--assembly"),
     type = "character",
-    default = ""
+    default = "",
     help = "Prefix name containing organism and ensembl assembly version to be used for file naming"
   )
 )

--- a/build-index.nf
+++ b/build-index.nf
@@ -16,7 +16,6 @@ fasta = "${params.ref_dir}/${params.fasta}"
 process generate_fastq{
   container 'ghcr.io/alexslemonade/scpca-r'
   publishDir params.ref_dir
-  memory 4 GB
   input:
     path(gtf)
     path(fasta)

--- a/build-index.nf
+++ b/build-index.nf
@@ -12,6 +12,7 @@ process generate_splici{
   input:
     path(gtf)
     path(fasta)
+    val(assembly)
   output: 
     tuple path(splici_fasta), path("annotation")
   script:
@@ -19,9 +20,10 @@ process generate_splici{
     """
     make_splici_fasta.R \
       --gtf ${gtf} \
-      --genome ${fasta}
-      --fasta_output fasta
-      --annotation_output annotation
+      --genome ${fasta} \
+      --fasta_output fasta \
+      --annotation_output annotation \
+      --assembly ${assembly}
     
     gzip annotation/*.gtf
     """
@@ -50,7 +52,7 @@ process salmon_index{
 
 workflow {
   // generate splici reference fasta
-  generate_fastq(params.gtf, params.fasta)
+  generate_fastq(params.gtf, params.fasta, params.assembly)
   // create index using splici reference fasta
   salmon_index(generate_fastq.out)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -1,12 +1,6 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-// basic parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-params.gtf = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-params.fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-params.assembly = 'Homo_sapiens.GRCh38.104'
-
 // generate fasta and annotation files with spliced cDNA + intronic reads 
 process generate_splici{
   container params.SCPCATOOLS_CONTAINER

--- a/build-index.nf
+++ b/build-index.nf
@@ -39,7 +39,7 @@ process salmon_index{
   output:
     path(index_dir)
   script:
-    index_dir = fasta.baseName.split("\\.(fasta|fa)")[0]
+    index_dir = "${fasta}".split("\\.(fasta|fa)")[0]
     """
     salmon index \
       -t ${fasta} \

--- a/build-index.nf
+++ b/build-index.nf
@@ -2,11 +2,11 @@
 nextflow.enable.dsl=2
 
 // basic parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
 params.gtf = 'annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-params.fasta = 
+params.fasta = 'fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
 params.assembly = 'Homo_sapiens.GRCh38.104'
-params.spliced_intron_txome = 'fasta/Homo_sapiens.GRCh38.103.spliced_intron.txome.fa.gz'
+params.spliced_intron_txome = 'fasta/Homo_sapiens.GRCh38.104.spliced_intron.txome.fa.gz'
 
 
 // generate fastq files with spliced cDNA + intronic reads 
@@ -28,16 +28,6 @@ process generate_fastq{
     
     gzip annotation/*.gtf
     """
-}
-
-
-// remove .gz if it exists
-def get_base(file){
-  if (file.extension == "gz"){
-    return file.baseName
-  }else{
-    return file.fileName
-  }
 }
 
 

--- a/build-index.nf
+++ b/build-index.nf
@@ -10,6 +10,7 @@ params.assembly = 'Homo_sapiens.GRCh38.104'
 // generate fastq files with spliced cDNA + intronic reads 
 process generate_fastq{
   container params.SCPCATOOLS_CONTAINTER
+  // publish fasta and annotation files within reference directory 
   publishDir params.ref_dir
   input:
     path(gtf)
@@ -51,6 +52,8 @@ process salmon_index{
 
 
 workflow {
+  // generate splici reference fasta
   generate_fastq(params.gtf, params.fasta)
+  // create index using splici reference fasta
   salmon_index(generate_fastq.out)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -16,7 +16,7 @@ process generate_splici{
   output: 
     tuple path(splici_fasta), path("annotation")
   script:
-    splici_fasta="fasta/${params.assembly}.spliced_intron.txome.fa.gz"
+    splici_fasta="fasta/${assembly}.spliced_intron.txome.fa.gz"
     """
     make_splici_fasta.R \
       --gtf ${gtf} \
@@ -52,7 +52,7 @@ process salmon_index{
 
 workflow {
   // generate splici reference fasta
-  generate_fastq(params.gtf, params.fasta, params.assembly)
+  generate_splici(params.gtf, params.fasta, params.assembly)
   // create index using splici reference fasta
-  salmon_index(generate_fastq.out)
+  salmon_index(generate_splici.out)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -6,7 +6,10 @@ params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
 params.gtf = 'annotation/Homo_sapiens.GRCh38.104.gtf.gz'
 params.fasta = 'fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
 params.assembly = 'Homo_sapiens.GRCh38.104'
-params.spliced_intron_txome = 'fasta/Homo_sapiens.GRCh38.104.spliced_intron.txome.fa.gz'
+
+// build paths
+gtf = "${params.ref_dir}/${params.gtf}"
+fasta = "${params.ref_dir}/${params.fasta}"
 
 
 // generate fastq files with spliced cDNA + intronic reads 
@@ -54,6 +57,6 @@ process salmon_index{
 
 
 workflow {
-  generate_fastq(params.gtf, params.fasta)
+  generate_fastq(gtf, fasta)
   salmon_index(generate_fastq.out)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -12,6 +12,9 @@ process generate_fastq{
   container params.SCPCATOOLS_CONTAINTER
   // publish fasta and annotation files within reference directory 
   publishDir params.ref_dir
+  memory { 28.GB * task.attempt}
+  errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+  maxRetries 1
   input:
     path(gtf)
     path(fasta)

--- a/build-index.nf
+++ b/build-index.nf
@@ -3,18 +3,13 @@ nextflow.enable.dsl=2
 
 // basic parameters
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-params.gtf = 'annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-params.fasta = 'fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+params.gtf = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+params.fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
 params.assembly = 'Homo_sapiens.GRCh38.104'
-
-// build paths
-gtf = "${params.ref_dir}/${params.gtf}"
-fasta = "${params.ref_dir}/${params.fasta}"
-
 
 // generate fastq files with spliced cDNA + intronic reads 
 process generate_fastq{
-  container 'ghcr.io/alexslemonade/scpca-r'
+  container params.SCPCATOOLS_CONTAINTER
   publishDir params.ref_dir
   input:
     path(gtf)
@@ -43,7 +38,7 @@ process salmon_index{
   input:
     path(splici_fasta)
   output:
-    path "${params.ref_dir}/fasta/${params.assembly}.spliced_intron.txome"
+    path(params.index_path)
   script:
     """
     salmon index \
@@ -56,6 +51,6 @@ process salmon_index{
 
 
 workflow {
-  generate_fastq(gtf, fasta)
+  generate_fastq(params.gtf, params.fasta)
   salmon_index(generate_fastq.out)
 }

--- a/main.nf
+++ b/main.nf
@@ -7,8 +7,6 @@ params.outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
 params.resolution = 'cr-like' //default resolution is cr-like, can also use full, cr-like-em, parsimony, and trivial
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
-params.index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103/salmon_index/spliced_intron_txome_k31'
-params.t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103/annotation/Homo_sapiens.GRCh38.103.spliced_intron.tx2gene_3col.tsv'
 
 
 // run_ids are comma separated list to be parsed into a list of run ids,

--- a/modules/build-index.nf
+++ b/modules/build-index.nf
@@ -1,0 +1,69 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// basic parameters
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
+params.gtf = 'annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+params.fasta = 
+params.assembly = 'Homo_sapiens.GRCh38.104'
+params.spliced_intron_txome = 'fasta/Homo_sapiens.GRCh38.103.spliced_intron.txome.fa.gz'
+
+
+// generate fastq files with spliced cDNA + intronic reads 
+process generate_fastq{
+  container 'ghcr.io/alexslemonade/scpca-r'
+  publishDir params.ref_dir
+  memory 4 GB
+  input:
+    path(gtf)
+    path(fasta)
+  output: 
+    path(splici_fasta)
+  script:
+    splici_fasta="${params.ref_dir}/fasta/${params.assembly}.spliced_intron.txome.fa.gz"
+    """
+    make_splici_fasta.R \
+      --gtf ${gtf} \
+      --genome ${fasta}
+    
+    gzip annotation/*.gtf
+    """
+}
+
+
+// remove .gz if it exists
+def get_base(file){
+  if (file.extension == "gz"){
+    return file.baseName
+  }else{
+    return file.fileName
+  }
+}
+
+
+process salmon_index{
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  publishDir "${params.ref_dir}/salmon_index", mode: 'copy'
+  memory { 28.GB * task.attempt}
+  cpus 8
+  errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+  maxRetries 1
+  input:
+    path(splici_fasta)
+  output:
+    path "${params.ref_dir}/fasta/${params.assembly}.spliced_intron.txome"
+  script:
+    """
+    salmon index \
+      -t ${splici_fasta} \
+      -i ${params.assembly}.spliced_intron.txome \
+      -k 31 \
+      -p ${task.cpus} \
+    """
+}
+
+
+workflow {
+  generate_fastq(params.gtf, params.fasta)
+  salmon_index(generate_fastq.out)
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,7 @@ params{
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   SCPCATOOLS_CONTAINTER = 'ghcr.io/alexslemonade/scpca-tools'
   index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,7 @@ params{
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   SCPCATOOLS_CONTAINTER = 'ghcr.io/alexslemonade/scpca-tools'
+  index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,7 +3,7 @@ params{
   // Docker container images in use
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
-  SCPCATOOLS_CONTAINTER = 'ghcr.io/alexslemonade/scpca-tools'
+  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools'
   index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,12 +4,12 @@ params{
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools'
-  index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
-  ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-  gtf = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-  fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
   assembly = 'Homo_sapiens.GRCh38.104'
+  ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+  fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+  gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+  index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,6 +6,10 @@ params{
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools'
   index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+  ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+  gtf = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+  fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+  assembly = 'Homo_sapiens.GRCh38.104'
 }
 
 


### PR DESCRIPTION
This PR closes #23 and #19. I moved the `build-index.nf` workflow over from `alsf-scpca/workflows` to the root directory of this repo and have streamlined the processes to only make the splici index using kmer=31. Here there are now only two processes, the first takes as input the ensembl gtf and primary assembly fasta file and uses the Rscript `make_splici_fasta.R` to grab only the spliced cDNA and intronic regions from the fasta. This script also outputs the needed tx2gene 3 column file and the corresponding mitochondrial gene list. 

The second process then takes as input the path to the splici fasta and creates the index. In this PR, I also moved the path to the splici index and the tx2gene file path as parameters in the config file and removed them from the `main.nf` file. 

In testing this I ran into an error part way through the R script, but after testing the Rscript locally with no issues and closer inspection it was exiting with command 137, which usually means a memory error. So I bumped up the memory and am re-running but in the meantime putting this up in draft form to elicit any feedback on the actual workflow. 

- Are there any parameters included here that we would want to move into the config file in addition to the splici index path? 
- Is the setup of the two processes logical, or are there any recommendations on a better way to do this? 

The input reference files used for this workflow are stored on s3 at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104`. 
