### PR TITLE
Add colData and rowData to unfiltered sce object

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -6,7 +6,6 @@
 # import libraries
 library(magrittr)
 library(optparse)
-library(SingleCellExperiment)
 library(scpcaTools)
 
 # set up arguments

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -74,10 +74,7 @@ which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
                               which_counts = which_counts,
-                              usa_mode = TRUE) %>%
-  # add per cell and per gene statistics to colData and rowData
-  add_cell_mito_qc(mito = mito_genes) %>%
-  scater::addPerFeatureQC()
+                              usa_mode = TRUE)
 
 
 # read and merge feature counts if present
@@ -89,6 +86,11 @@ if (opt$feature_dir != ""){
   # add alt experiment features stats
   altExp(unfiltered_sce, opt$feature_name) <- scater::addPerFeatureQC(altExp(unfiltered_sce, opt$feature_name))
 }
+
+# add per cell and per gene statistics to colData and rowData
+unfiltered_sce <- unfiltered_sce %>%
+  add_cell_mito_qc(mito = mito_genes) %>%
+  scater::addPerFeatureQC()
 
 # write to rds
 readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -40,7 +40,6 @@ option_list <- list(
   make_option(
     opt_str = c("-m", "--mito_file"),
     type = "character",
-    default = "",
     help = "path to list of mitochondrial genes"
   )
 )
@@ -59,13 +58,11 @@ if(!(stringr::str_ends(opt$unfiltered_file, ".rds"))){
 
 # check that mitochondrial gene list exists
 if(!file.exists(opt$mito_file)){
-  stop("Mitochondrial gene list is required using -m or --mito_file")
+  stop("Mitochondrial gene list file not found.")
 }
 
 # read in mitochondrial gene list
-mito_genes <- readr::read_tsv(opt$mito_file, col_names = "gene_id") %>%
-  dplyr::pull("gene_id") %>%
-  unique()
+mito_genes <- unique(scan(opt$mito_file, what = "character"))
 
 # convert seq_unit to spliced or unspliced to determine which types of transcripts to include in final counts matrix
 which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -37,11 +37,11 @@ option_list <- list(
     opt_str = c("-u", "--unfiltered_file"),
     type = "character",
     help = "path to output unfiltered rds file. Must end in .rds"
-  ), 
+  ),
   make_option(
     opt_str = c("-m", "--mito_file"),
-    type = "character", 
-    default = "", 
+    type = "character",
+    default = "",
     help = "path to list of mitochondrial genes"
   )
 )
@@ -63,7 +63,7 @@ if(!file.exists(opt$mito_file)){
   stop("Mitochondrial gene list is required using -m or --mito_file")
 }
 
-# read in mitochondrial gene list 
+# read in mitochondrial gene list
 mito_genes <- readr::read_tsv(opt$mito_file, col_names = "gene_id") %>%
   dplyr::pull("gene_id") %>%
   unique()
@@ -79,24 +79,20 @@ unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
   # add per cell and per gene statistics to colData and rowData
   add_cell_mito_qc(mito = mito_genes) %>%
   scater::addPerFeatureQC()
-  
+
 
 # read and merge feature counts if present
 if (opt$feature_dir != ""){
   feature_sce <- read_alevin(quant_dir = opt$feature_dir,
                              mtx_format = TRUE) %>%
-    # add per cell statistics to colData without mitochondrial reads 
+    # add per cell statistics to colData without mitochondrial reads
     scater::addPerCellQC() %>%
     # add per gene statistics to rowData
     scater::addPerFeatureQC()
-  
+
   unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name)
-  
-  # add colData and rowData from feature_sce to alternative experiment in unfiltered_sce
-  head(colData(altExp(unfiltered_sce, opt$feature_name)))
-  head(rowData(altExp(unfiltered_sce, opt$feature_name)))
-}                                
+}
 
 # write to rds
-#readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")
+readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -36,6 +36,12 @@ option_list <- list(
     opt_str = c("-u", "--unfiltered_file"),
     type = "character",
     help = "path to output unfiltered rds file. Must end in .rds"
+  ), 
+  make_option(
+    opt_str = c("-m", "--mito_file"),
+    type = "character", 
+    default = "", 
+    help = "path to list of mitochondrial genes"
   )
 )
 
@@ -49,6 +55,11 @@ if(!(opt$seq_unit %in% c("cell", "nucleus"))){
 # check that output file name ends in .rds
 if(!(stringr::str_ends(opt$unfiltered_file, ".rds"))){
   stop("unfiltered file name must end in .rds")
+}
+
+# check that mitochondrial gene list exists
+if(!file.exists(opt$mito_file)){
+  stop("Mitochondrial gene list is required using -m or --mito_file")
 }
 
 # convert seq_unit to spliced or unspliced to determine which types of transcripts to include in final counts matrix

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -83,13 +83,11 @@ unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
 # read and merge feature counts if present
 if (opt$feature_dir != ""){
   feature_sce <- read_alevin(quant_dir = opt$feature_dir,
-                             mtx_format = TRUE) %>%
-    # add per cell statistics to colData without mitochondrial reads
-    scater::addPerCellQC() %>%
-    # add per gene statistics to rowData
-    scater::addPerFeatureQC()
-
-  unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name)
+                             mtx_format = TRUE) 
+   
+  unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name) 
+  # add alt experiment features stats
+  altExp(unfiltered_sce, opt$feature_name) <- scater::addPerFeatureQC(altExp(unfiltered_sce, opt$feature_name))
 }
 
 # write to rds

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -67,8 +67,8 @@ workflow generate_rds {
   // generate rds files for RNA-only samples
   take: quant_channel
   main:
-    make_unfiltered_sce(quant_channel, params.mito_file)
-    filter_sce(make_unfiltered_sce.out)
+    make_unfiltered_sce(quant_channel, params.mito_file) \
+      | filter_sce
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files
@@ -79,8 +79,8 @@ workflow generate_merged_rds {
   // input is a channel with feature_meta, feature_quantdir, rna_meta, rna_quantdir
   take: feature_quant_channel
   main:
-    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file)
-    filter_sce(make_merged_unfiltered_sce.out)
+    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file) \
+      | filter_sce
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,8 @@ params{
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   SCPCATOOLS_CONTAINTER = 'ghcr.io/alexslemonade/scpca-tools'
+  mito_file = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
+  
 }
 
 


### PR DESCRIPTION
Closes #20. This PR adds the calculation of the `colData` and `rowData` statistics to the unfiltered output within the `generate_unfiltered_sce.R` script. To do this for the RNA counts I am using `add_cell_mito_qc()` within `scpcaTools` for the per cell statistics, to get total UMI count, number of genes detected per cell, and the mitochondrial content per cell. I then also used `scater::addPerFeatureQC()` to add in the number of counts for each gene in the `rowData`. Within the nextflow workflow, the only modification was the addition of the mitochondrial file as a paramter in the config file and then as an input to the process. 

I also made the choice to NOT use the `miQC` option here since I believe we only want that additional column on the filtered output. Additionally when playing around with it, I noticed that miQC doesn't handle empty drops well and threw a few errors with a sample that hadn't gone through filtering with `emptyDrops` filtering, another reason we probably only want to use it on samples post filtering with `emptyDrops`. 

Where I was not 100% sure about what to do was with the CITE-seq counts data. For those objects, I thought it could be useful to at least have total counts per cell and total number of counts per antibody. To do that I added in `colData` using `scater::addPerCellQC()` and `rowData` using `scater::addPerFeatureQC()` before merging the experiments within the `generate_unfiltered_sce.R` script. However, the merge does not keep the `colData` and `rowData` for the alternative experiment. I think we could either grab the specific statistics that we are interested in and add it in as metadata for the `altExp` or alter the `merge_altexp()` function to keep the data that we need (but the second option would be outside the scope of this PR). 

I did test these changes with sample `SCPCR000006` and everything looks as it should for a sample with just RNA counts. 