### PR TITLE
Change publishDir to split alevin output and rds files 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,8 @@ nextflow.enable.dsl=2
 
 // run parameters
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.outdir = "s3://nextflow-ccdl-results/scpca/processed"
+params.alevin_outdir = 's3://nextflow-ccdl-results/scpca/alevin-fry-processed'
+params.final_outdir = 's3://nextflow-ccdl-results/scpca/processed-samples'
 
 params.resolution = 'cr-like' //default resolution is cr-like, can also use full, cr-like-em, parsimony, and trivial
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -61,7 +61,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
+  publishDir "${params.alevin_outdir}/${meta.sample_id}/${meta.library_id}"
   input:
     tuple val(meta),
           path(run_dir), path(feature_index)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -40,7 +40,7 @@ process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
+  publishDir "${params.alevin_outdir}/${meta.sample_id}/${meta.library_id}"
 
   input:
     tuple val(meta), path(run_dir)

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -4,7 +4,7 @@
 // RNA only libraries
 process make_unfiltered_sce{
     container params.SCPCATOOLS_CONTAINTER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.final_outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(alevin_dir)
     output:
@@ -22,7 +22,7 @@ process make_unfiltered_sce{
 // channels with RNA and feature data
 process make_merged_unfiltered_sce{
     container params.SCPCATOOLS_CONTAINTER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.final_outdir}/${meta.sample_id}"
     input: 
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
     output:
@@ -45,7 +45,7 @@ process make_merged_unfiltered_sce{
 
 process filter_sce{
     container params.SCPCATOOLS_CONTAINTER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.final_outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)
     output:


### PR DESCRIPTION
Closes #17. Here I am splitting up the `publishDir` for the modules that run alevin-fry to put the alevin output in a separate folder than the rds files. This gets us closer to our desired output structure. I'm leaving this in draft form right now because we anticipate there to be more structure changes with the addition of the unique project ID discussed in https://github.com/AlexsLemonade/ScPCA-admin/issues/213. At that point, we would want to further change the published output files to be nested by project and sample. Now all files are nested only by sample. 