### PR TITLE
Add colData and rowData to filtered sce object

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -39,26 +39,26 @@ unfiltered_sce <- readr::read_rds(opt$unfiltered_file)
 # filter sce
 filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
 
-# need to remove old rowData first 
+# need to remove old gene-level rowData first 
 rowData(filtered_sce) <- NULL
-
-# add prob_compromised to colData from miQC::mixtureModel 
-model <- miQC::mixtureModel(filtered_sce)
-filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, verbose = FALSE)
 
 # recalculate rowData and add to filtered sce 
 filtered_sce <- filtered_sce %>%
   scater::addPerFeatureQC()
+  
+# add prob_compromised to colData from miQC::mixtureModel 
+model <- miQC::mixtureModel(filtered_sce)
+filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, verbose = FALSE)
 
 # grab names of altExp, if any
-feature_names <- altExpNames(filtered_sce)
+alt_names <- altExpNames(filtered_sce)
 
-for (feature in feature_names) {
+for (alt in alt_names) {
   # remove old row data from unfiltered 
-  rowData(altExp(test, feature)) <- NULL
+  rowData(altExp(test, alt)) <- NULL
   
   # add alt experiment features stats for filtered data
-  altExp(test, feature) <- scater::addPerFeatureQC(altExp(test, feature))
+  altExp(test, alt) <- scater::addPerFeatureQC(altExp(test, alt))
 }
 
 # write filtered sce to output

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -18,6 +18,18 @@ option_list <- list(
     opt_str = c("-f", "--filtered_file"),
     type = "character",
     help = "path to output filtered rds file. Must end in .rds"
+  ),
+  make_option(
+    opt_str = c("-m", "--mito_file"),
+    type = "character",
+    default = "",
+    help = "path to list of mitochondrial genes"
+  ), 
+  make_option(
+    opt_str = c("-n", "--feature_name"),
+    type = "character",
+    default = "ALT",
+    help = "Feature type"
   )
 )
 
@@ -38,6 +50,24 @@ unfiltered_sce <- readr::read_rds(opt$unfiltered_file)
 
 # filter sce
 filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
+
+# need to remove old colData and rowData first 
+colData(filtered_sce) <- NULL
+rowData(filtered_sce) <- NULL
+
+# add colData and rowData to filtered sce 
+filtered_sce <- filtered_sce %>%
+  scpcaTools::add_cell_mito_qc(mito = mito_genes, miQC = TRUE) %>%
+  scater::addPerFeatureQC()
+
+# if altExp is present, add feature data
+if (opt$feature_name != "") {
+  # remove old row data from unfiltered 
+  rowData(altExp(filtered_sce, opt$feature_name)) <- NULL
+  
+  # add alt experiment features stats for filtered data
+  altExp(filtered_sce, opt$feature_name) <- scater::addPerFeatureQC(altExp(filtered_sce, opt$feature_name))
+}
 
 # write filtered sce to output
 readr::write_rds(filtered_sce, opt$filtered_file, compress = "gz")

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -18,18 +18,6 @@ option_list <- list(
     opt_str = c("-f", "--filtered_file"),
     type = "character",
     help = "path to output filtered rds file. Must end in .rds"
-  ),
-  make_option(
-    opt_str = c("-m", "--mito_file"),
-    type = "character",
-    default = "",
-    help = "path to list of mitochondrial genes"
-  ), 
-  make_option(
-    opt_str = c("-n", "--feature_name"),
-    type = "character",
-    default = "ALT",
-    help = "Feature type"
   )
 )
 
@@ -51,22 +39,26 @@ unfiltered_sce <- readr::read_rds(opt$unfiltered_file)
 # filter sce
 filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
 
-# need to remove old colData and rowData first 
-colData(filtered_sce) <- NULL
+# need to remove old rowData first 
 rowData(filtered_sce) <- NULL
 
-# add colData and rowData to filtered sce 
+# add prob_compromised to colData from miQC::mixtureModel 
+model <- miQC::mixtureModel(filtered_sce)
+filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, verbose = FALSE)
+
+# recalculate rowData and add to filtered sce 
 filtered_sce <- filtered_sce %>%
-  scpcaTools::add_cell_mito_qc(mito = mito_genes, miQC = TRUE) %>%
   scater::addPerFeatureQC()
 
-# if altExp is present, add feature data
-if (opt$feature_name != "") {
+# grab names of altExp, if any
+feature_names <- altExpNames(filtered_sce)
+
+for (feature in feature_names) {
   # remove old row data from unfiltered 
-  rowData(altExp(filtered_sce, opt$feature_name)) <- NULL
+  rowData(altExp(test, feature)) <- NULL
   
   # add alt experiment features stats for filtered data
-  altExp(filtered_sce, opt$feature_name) <- scater::addPerFeatureQC(altExp(filtered_sce, opt$feature_name))
+  altExp(test, feature) <- scater::addPerFeatureQC(altExp(test, feature))
 }
 
 # write filtered sce to output

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -9,7 +9,7 @@ process make_unfiltered_sce{
         tuple val(meta), path(alevin_dir)
         path(mito)
     output:
-        tuple val(meta), path(unfiltered_rds), path(mito)
+        tuple val(meta), path(unfiltered_rds)
     script:
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         """
@@ -29,7 +29,7 @@ process make_merged_unfiltered_sce{
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
         path(mito)
     output:
-        tuple val(meta), path(unfiltered_rds), path(mito)
+        tuple val(meta), path(unfiltered_rds)
     script:
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         // add feature metadata as an element of the main meta object
@@ -51,7 +51,7 @@ process filter_sce{
     container params.SCPCATOOLS_CONTAINTER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
-        tuple val(meta), path(unfiltered_rds), path(mito)
+        tuple val(meta), path(unfiltered_rds)
     output:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     script:
@@ -59,9 +59,7 @@ process filter_sce{
         """
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
-          --filtered_file ${filtered_rds} \
-          --mito_file ${mito} \
-          --feature_name ${meta.feature_type}
+          --filtered_file ${filtered_rds}
         """
 }
 

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -9,7 +9,7 @@ process make_unfiltered_sce{
         tuple val(meta), path(alevin_dir)
         path(mito)
     output:
-        tuple val(meta), path(unfiltered_rds)
+        tuple val(meta), path(unfiltered_rds), path(mito)
     script:
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         """
@@ -29,7 +29,7 @@ process make_merged_unfiltered_sce{
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
         path(mito)
     output:
-        tuple val(meta), path(unfiltered_rds)
+        tuple val(meta), path(unfiltered_rds), path(mito)
     script:
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         // add feature metadata as an element of the main meta object
@@ -51,7 +51,7 @@ process filter_sce{
     container params.SCPCATOOLS_CONTAINTER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
-        tuple val(meta), path(unfiltered_rds)
+        tuple val(meta), path(unfiltered_rds), path(mito)
     output:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     script:
@@ -59,7 +59,9 @@ process filter_sce{
         """
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
-          --filtered_file ${filtered_rds}
+          --filtered_file ${filtered_rds} \
+          --mito_file ${mito} \
+          --feature_name ${meta.feature_type}
         """
 }
 


### PR DESCRIPTION
Closes #18. This PR adds in the `colData` and `rowData` to the filtered sce object. This includes adding any per cell and per feature data for alternative experiments, if present in the filtered data. To do this, I first removed the previous `rowData` that is attached to the unfiltered data since we will want to recalculate the per gene metrics using only the cells that are present in the filtered matrix. 

We don't need to recalculate the per cell metrics here, but we did want to add in a column containing the posterior probability of each cell being compromised as calculated by `miQC`. Because we want to do this after performing filtering with `emptyDrops`, I added in a step here to calculate the model then using `miQC::filterCells()` with a `posterior_cutoff=1` add in the `prob_compromised` column, just like we have in `scpcaTools::add_cell_mito_qc()`. After discussion with @jashapiro we chose to do it manually here rather than removing the old `colData` and recalculating using scpcaTools. We are anticipating adding additional steps here to add in the `ccdl_suggests` column in the future. 

Finally, to calculate the `rowData` for any alternative experiments if present, I'm grabbing the names of the altExp and then looping through those names to remove any previous `rowData` and then recalculate it using the filtered cells. After a code pairing session with @jashapiro, we came to the conclusion that use of the `for` loop was ultimately the best way to handle this for now. 
