### PR TITLE
Add generation of QC report to pipeline

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -4,7 +4,6 @@
 # filters it using emptyDrops, adding miQC metrics for probability compromised
 
 # import libraries
-library(magrittr)
 library(optparse)
 library(SingleCellExperiment)
 
@@ -44,7 +43,7 @@ filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
 rowData(filtered_sce) <- NULL
 
 # recalculate rowData and add to filtered sce
-filtered_sce <- filtered_sce %>%
+filtered_sce <- filtered_sce |>
   scater::addPerFeatureQC()
 
 # add prob_compromised to colData from miQC::mixtureModel

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -6,6 +6,7 @@
 # import libraries
 library(magrittr)
 library(optparse)
+library(SingleCellExperiment)
 
 # set up arguments
 option_list <- list(
@@ -55,10 +56,10 @@ alt_names <- altExpNames(filtered_sce)
 
 for (alt in alt_names) {
   # remove old row data from unfiltered
-  rowData(altExp(test, alt)) <- NULL
+  rowData(altExp(filtered_sce, alt)) <- NULL
 
   # add alt experiment features stats for filtered data
-  altExp(test, alt) <- scater::addPerFeatureQC(altExp(test, alt))
+  altExp(filtered_sce, alt) <- scater::addPerFeatureQC(altExp(filtered_sce, alt))
 }
 
 # write filtered sce to output

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
-# This script takes the output folder from alevin-fry as input and
-# returns the filtered counts matrices as a SingleCellExperiment stored in a .rds file
+# This script takes a SingleCellExperiment stored in a .rds file and
+# filters it using emptyDrops, adding miQC metrics for probability compromised
 
 # import libraries
 library(magrittr)
@@ -39,14 +39,14 @@ unfiltered_sce <- readr::read_rds(opt$unfiltered_file)
 # filter sce
 filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
 
-# need to remove old gene-level rowData first 
+# need to remove old gene-level rowData first
 rowData(filtered_sce) <- NULL
 
-# recalculate rowData and add to filtered sce 
+# recalculate rowData and add to filtered sce
 filtered_sce <- filtered_sce %>%
   scater::addPerFeatureQC()
-  
-# add prob_compromised to colData from miQC::mixtureModel 
+
+# add prob_compromised to colData from miQC::mixtureModel
 model <- miQC::mixtureModel(filtered_sce)
 filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, verbose = FALSE)
 
@@ -54,9 +54,9 @@ filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, ver
 alt_names <- altExpNames(filtered_sce)
 
 for (alt in alt_names) {
-  # remove old row data from unfiltered 
+  # remove old row data from unfiltered
   rowData(altExp(test, alt)) <- NULL
-  
+
   # add alt experiment features stats for filtered data
   altExp(test, alt) <- scater::addPerFeatureQC(altExp(test, alt))
 }

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -4,8 +4,8 @@
 # returns the unfiltered counts matrices as a SingleCellExperiment stored in a .rds file
 
 # import libraries
-library(magrittr)
 library(optparse)
+library(SingleCellExperiment)
 library(scpcaTools)
 
 # set up arguments
@@ -85,8 +85,8 @@ if (opt$feature_dir != ""){
 }
 
 # add per cell and per gene statistics to colData and rowData
-unfiltered_sce <- unfiltered_sce %>%
-  add_cell_mito_qc(mito = mito_genes) %>%
+unfiltered_sce <- unfiltered_sce |>
+  add_cell_mito_qc(mito = mito_genes) |>
   scater::addPerFeatureQC()
 
 # write to rds

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -1,0 +1,53 @@
+#!/usr/bin/env Rscript
+
+# This script generates a QC report using scpcaTools from a pair of filtered and unfiltered SCE objects
+
+# import libraries
+library(magrittr)
+library(optparse)
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("-u", "--unfiltered_sce"),
+    type = "character",
+    help = "path to rds file with unfiltered sce object"
+  ),
+  make_option(
+    opt_str = c("-f", "--filtered_sce"),
+    type = "character",
+    help = "path to rds file with filtered sce object"
+  ),
+  make_option(
+    opt_str = c("-s", "--sample_id"),
+    type = "character",
+    help = "Sample identifier for report"
+  ),
+  make_option(
+    opt_str = c("-o", "--output_file"),
+    default = "qc_report.html",
+    type = "character",
+    help = "path to output file"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# check that input files exists
+if(!file.exists(opt$unfiltered_file)){
+  stop("Missing unfiltered .rds file")
+}
+if(!file.exists(opt$filtered_file)){
+  stop("Missing filtered .rds file")
+}
+
+# read sce files
+unfiltered_sce <- readr::read_rds(opt$unfiltered_sce)
+filtered_sce <- readr::read_rds(opt$filtered_sce)
+
+scpcaTools::generate_qc_report(
+  sample_name = opt$sample_name,
+  unfiltered_sce = unfiltered_sce,
+  filtered_sce = filtered_sce,
+  output = opt$output_file
+)

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -34,10 +34,10 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check that input files exists
-if(!file.exists(opt$unfiltered_file)){
+if(!file.exists(opt$unfiltered_sce)){
   stop("Missing unfiltered .rds file")
 }
-if(!file.exists(opt$filtered_file)){
+if(!file.exists(opt$filtered_sce)){
   stop("Missing filtered .rds file")
 }
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -3,7 +3,6 @@
 # This script generates a QC report using scpcaTools from a pair of filtered and unfiltered SCE objects
 
 # import libraries
-library(magrittr)
 library(optparse)
 
 # set up arguments

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -32,14 +32,14 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list = option_list))
 if(is.null(opt$sample_id)){
-  stop("A sample id is required")
+  stop("A `sample_id` is required.")
 }
 # check that input files exists
-if(!file.exists(opt$unfiltered_sce)){
-  stop("Missing unfiltered .rds file")
+if(is.null(opt$unfiltered_sce) || !file.exists(opt$unfiltered_sce)){
+  stop("Unfiltered .rds file missing or `unfiltered_sce` not specified.")
 }
-if(!file.exists(opt$filtered_sce)){
-  stop("Missing filtered .rds file")
+if(is.null(opt$filtered_sce) || !file.exists(opt$filtered_sce)){
+  stop("Filtered .rds file missing or `filtered_sce` not specified.")
 }
 
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -31,7 +31,9 @@ option_list <- list(
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
-
+if(is.null(opt$sample_id)){
+  stop("A sample id is required")
+}
 # check that input files exists
 if(!file.exists(opt$unfiltered_sce)){
   stop("Missing unfiltered .rds file")
@@ -39,6 +41,7 @@ if(!file.exists(opt$unfiltered_sce)){
 if(!file.exists(opt$filtered_sce)){
   stop("Missing filtered .rds file")
 }
+
 
 # read sce files
 unfiltered_sce <- readr::read_rds(opt$unfiltered_sce)

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,7 @@ feature_techs = tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cel
 include { map_quant_rna } from './modules/af-rna.nf' addParams(cell_barcodes: cell_barcodes)
 include { map_quant_feature } from './modules/af-features.nf' addParams(cell_barcodes: cell_barcodes)
 include { generate_rds; generate_merged_rds } from './modules/generate-rds.nf'
+include { sce_qc_report } from './modules/qc-report.nf'
 
 workflow {
   // select runs to use
@@ -88,7 +89,8 @@ workflow {
   rna_quant_ch = map_quant_rna.out
     .filter{it[0]["library_id"] in rna_only_libs.getVal()}
   // make rds for rna only
-  generate_rds(rna_quant_ch)
+  rna_sce_ch = generate_sce(rna_quant_ch)
+
 
   // **** Process feature data ****
   feature_ch = runs_ch.filter{it.technology in feature_techs} 
@@ -100,9 +102,10 @@ workflow {
     .combine(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0) // combine by library_id 
     .map{it.subList(1, it.size())} // remove library_id index
   // make rds for merged RNA and feature quants
-  generate_merged_rds(feature_rna_quant_ch)
+  merged_sce_ch = generate_merged_sce(feature_rna_quant_ch)
 
-  // Make channel for all library rds files
-  library_rds_ch = generate_rds.out.mix(generate_merged_rds.out)
-  library_rds_ch.view()
+  // **** Generate QC reports ****
+  // Make channel for all library sce files & run QC report
+  library_sce_ch = rna_sce_ch.mix(merged_sce_ch)
+  sce_qc_report(library_sce_ch)
 }

--- a/main.nf
+++ b/main.nf
@@ -37,7 +37,7 @@ feature_techs = tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cel
 // include processes from modules
 include { map_quant_rna } from './modules/af-rna.nf' addParams(cell_barcodes: cell_barcodes)
 include { map_quant_feature } from './modules/af-features.nf' addParams(cell_barcodes: cell_barcodes)
-include { generate_rds; generate_merged_rds } from './modules/generate-rds.nf'
+include { generate_sce; generate_merged_sce } from './modules/generate-rds.nf'
 include { sce_qc_report } from './modules/qc-report.nf'
 
 workflow {

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -63,7 +63,7 @@ process filter_sce{
         """
 }
 
-workflow generate_rds {
+workflow generate_sce {
   // generate rds files for RNA-only samples
   take: quant_channel
   main:
@@ -74,7 +74,7 @@ workflow generate_rds {
   // a tuple of meta and the filtered and unfiltered rds files
 }
 
-workflow generate_merged_rds {
+workflow generate_merged_sce {
   // generate rds files for feature + quant samples
   // input is a channel with feature_meta, feature_quantdir, rna_meta, rna_quantdir
   take: feature_quant_channel

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -3,7 +3,7 @@
 
 // RNA only libraries
 process make_unfiltered_sce{
-    container params.SCPCATOOLS_CONTAINTER
+    container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(alevin_dir)
@@ -23,7 +23,7 @@ process make_unfiltered_sce{
 
 // channels with RNA and feature data
 process make_merged_unfiltered_sce{
-    container params.SCPCATOOLS_CONTAINTER
+    container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
@@ -48,7 +48,7 @@ process make_merged_unfiltered_sce{
 }
 
 process filter_sce{
-    container params.SCPCATOOLS_CONTAINTER
+    container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -42,7 +42,7 @@ process make_merged_unfiltered_sce{
           --alevin_dir ${alevin_dir} \
           --feature_dir ${feature_alevin_dir} \
           --feature_name ${meta.feature_type} \
-          --unfiltered_file ${unfiltered_rds} \j
+          --unfiltered_file ${unfiltered_rds} \
           --mito_file ${mito}
         """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -2,7 +2,7 @@
 // generate QC report from unfiltered and filtered SCE.rds files using scpcaTools
 
 process sce_qc_report{
-    container params.SCPCATOOLS_CONTAINTER
+    container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -1,0 +1,20 @@
+
+// generate QC report from unfiltered and filtered SCE.rds files using scpcaTools
+
+process sce_qc_report{
+    container params.SCPCATOOLS_CONTAINTER
+    publishDir "${params.outdir}/${meta.sample_id}"
+    input: 
+        tuple val(meta), path(unfiltered_rds), path(filtered_rds)
+    output:
+        tuple val(meta), path(qc_report)
+    script:
+        qc_report = "${meta.library_id}_qc.html"
+        """
+        sce_qc_report.R \
+          --sample_id {meta.library_id} \
+          --unfiltered_file ${unfiltered_rds} \
+          --filtered_file ${filtered_rds} \
+          --output_file ${qc_report}
+        """
+}

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -13,8 +13,8 @@ process sce_qc_report{
         """
         sce_qc_report.R \
           --sample_id {meta.library_id} \
-          --unfiltered_file ${unfiltered_rds} \
-          --filtered_file ${filtered_rds} \
+          --unfiltered_sce ${unfiltered_rds} \
+          --filtered_sce ${filtered_rds} \
           --output_file ${qc_report}
         """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,15 +1,17 @@
 // global parameters for workflows
 params{
-  // Docker container images in use
+  // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
-  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools'
+  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+
+  // Assembly, annotation, and index locations
   assembly = 'Homo_sapiens.GRCh38.104'
   ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
   fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
   gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
   index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  mito_file = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
+  mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 }
 


### PR DESCRIPTION
This PR adds a final step to the pipeline to run the QC generation function from [`scpcaTools`](https://github.com/AlexsLemonade/scpcatools). The process and pipeline are pretty simple, but there were a few changes I made along the way, some for clarity and some for bug fixes and some just because I was inspired and/or delusional

* In testing, I ran into a few outstanding bugs in the pipeline (mostly related to alt experiments) that should now be fixed. (In addition to the bugs in `scpcaTools` itself that were fixed in that repo).
* I altered the container we are using to track the `edge` release for now, so we will always be using the latest scpcaTools as we update things like the QC report. We will want to freeze this to a release when we start processing.
* In a fit of late night hubris, I realized that since we now have to use an R image with R4.1 we could use native pipes instead of `magrittr`, so I did that, just to see if I could. Still works as before, but I could change it back... Or we could change all of `scpcaTools` to use it!

Closes #1 
