### PR TITLE
Remove zero genes from filtered sce

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -61,6 +61,12 @@ for (alt in alt_names) {
   altExp(filtered_sce, alt) <- scater::addPerFeatureQC(altExp(filtered_sce, alt))
 }
 
+# remove any genes with zero counts 
+detected_genes <- rowData(filtered_sce)$mean > 0 & 
+  rowData(filtered_sce)$detected > 0
+
+filtered_sce <- filtered_sce[detected_genes,]
+
 # write filtered sce to output
 readr::write_rds(filtered_sce, opt$filtered_file, compress = "gz")
 


### PR DESCRIPTION
This PR closes AlexsLemonade/scpcaTools#36. Here, I added in a step during the generation of the filtered sce objects to remove any genes that are not detected prior to writing out the final `filtered.rds` file. I chose to do that here rather than within the `filter_counts()` function within scpcaTools for transparency purposes, rather than having it performed within the function. It seemed like it was an additional filtering step that we were choosing to add, rather than something that we wanted nested within another function, but I'm open to other opinions on this. 

In terms of implementation, I just added an additional step to remove zero count genes as the last step before writing out the file. I chose to not remove any zero counts from the alternative experiments that could be present as I think knowing that an antibody wasn't detected in CITE-seq actually could be useful information for someone and didn't want to remove that from the object.  