### PR TITLE
Implement use of lower=200 during generation of filtered sce

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -18,7 +18,12 @@ option_list <- list(
     opt_str = c("-f", "--filtered_file"),
     type = "character",
     help = "path to output filtered rds file. Must end in .rds"
-  )
+  ),
+  make_option(
+    opt_str = c("-l", "--lower"),
+    type = "integer",
+    help = "Value specifying the lower bound on total UMI count used in filtering with DropletUtils::emptyDrops."
+ )
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
@@ -37,7 +42,8 @@ if(!(stringr::str_ends(opt$filtered_file, ".rds"))){
 unfiltered_sce <- readr::read_rds(opt$unfiltered_file)
 
 # filter sce
-filtered_sce <- scpcaTools::filter_counts(unfiltered_sce)
+filtered_sce <- scpcaTools::filter_counts(unfiltered_sce,
+                                          lower = opt$lower)
 
 # need to remove old gene-level rowData first
 rowData(filtered_sce) <- NULL

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -61,7 +61,7 @@ process filter_sce{
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
           --filtered_file ${filtered_rds} \
-          --lower ${lower}
+          --lower ${params.emptydrops_lower}
         """
 }
 

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -52,6 +52,7 @@ process filter_sce{
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)
+        val(lower)
     output:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     script:
@@ -59,7 +60,8 @@ process filter_sce{
         """
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
-          --filtered_file ${filtered_rds}
+          --filtered_file ${filtered_rds} \
+          --lower ${lower}
         """
 }
 
@@ -67,8 +69,8 @@ workflow generate_sce {
   // generate rds files for RNA-only samples
   take: quant_channel
   main:
-    make_unfiltered_sce(quant_channel, params.mito_file) \
-      | filter_sce
+    make_unfiltered_sce(quant_channel, params.mito_file)
+    filter_sce(make_unfiltered_sce.out, params.lower)
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files
@@ -79,8 +81,8 @@ workflow generate_merged_sce {
   // input is a channel with feature_meta, feature_quantdir, rna_meta, rna_quantdir
   take: feature_quant_channel
   main:
-    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file) \
-      | filter_sce
+    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file)
+    filter_sce(make_merged_unfiltered_sce.out, params.lower)
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -52,7 +52,6 @@ process filter_sce{
     publishDir "${params.outdir}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)
-        val(lower)
     output:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     script:
@@ -69,8 +68,8 @@ workflow generate_sce {
   // generate rds files for RNA-only samples
   take: quant_channel
   main:
-    make_unfiltered_sce(quant_channel, params.mito_file)
-    filter_sce(make_unfiltered_sce.out, params.lower)
+    make_unfiltered_sce(quant_channel, params.mito_file) \
+      | filter_sce(make_unfiltered_sce.out, params.lower)
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files
@@ -81,8 +80,8 @@ workflow generate_merged_sce {
   // input is a channel with feature_meta, feature_quantdir, rna_meta, rna_quantdir
   take: feature_quant_channel
   main:
-    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file)
-    filter_sce(make_merged_unfiltered_sce.out, params.lower)
+    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file) \
+      | filter_sce
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -69,7 +69,7 @@ workflow generate_sce {
   take: quant_channel
   main:
     make_unfiltered_sce(quant_channel, params.mito_file) \
-      | filter_sce(make_unfiltered_sce.out, params.lower)
+      | filter_sce
 
   emit: filter_sce.out
   // a tuple of meta and the filtered and unfiltered rds files

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,9 +11,11 @@ params{
   fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
   gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
   index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  lower         = 200
   mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+ 
+  // Filtering constants
+  emptydrops_lower = 200
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params{
   fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
   gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
   index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  lower         = 200
   mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 }


### PR DESCRIPTION
Closes #30. This PR adds the ability to pass through an option for the `lower` parameter as part of `DropletUtils::emptyDrops()` which we call inside the `scpcaTools::filter_counts()`. To do this, I chose to add a parameter for lower to our workflow in the config file and then pass that parameter through to the process `filter_sce` rather than hard code the use of `lower=200` within the Rscript that generates the filtered sce. By doing this, we can directly alter this parameter in the config file if we ever need to rather than going into the R script that is run by the workflow and changing it, making it a bit more transparent. 

In doing this, I also had to remove the pipe between the `make_unfiltered_sce` and `filter_sce` processes so that I could pass through both the `make_unfiltered_sce.out` and `params.lower`, but I am open to other suggestions on how to do this. 