### PR TITLE
Export cell statistics & other metadata

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -54,9 +54,10 @@ rowData(filtered_sce) <- rowData(filtered_sce)[!drop_cols]
 filtered_sce <- filtered_sce |>
   scuttle::addPerFeatureQCMetrics()
 
-# add prob_compromised to colData from miQC::mixtureModel
+# add prob_compromised to colData from miQC::mixtureModel and add model to metadata
 model <- miQC::mixtureModel(filtered_sce)
 filtered_sce <- miQC::filterCells(filtered_sce, model, posterior_cutoff = 1, verbose = FALSE)
+metadata(filtered_sce)$miQC_model <- model
 
 # grab names of altExp, if any
 alt_names <- altExpNames(filtered_sce)

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -137,7 +137,7 @@ metadata_list <- list(
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
   
 scpcaTools::generate_qc_report(
-  sample_id = metadata_list$library_id,
+  sample_name = metadata_list$library_id,
   unfiltered_sce = unfiltered_sce,
   filtered_sce = filtered_sce,
   output = opt$qc_report_file

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -117,6 +117,8 @@ metadata_list <- list(
   genome_assembly = opt$genome_assembly,
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
+  salmon_version = sce_meta$salmon_version,
+  alevin_fry_version = sce_meta$alevinfry_version,
   has_citeseq = has_citeseq,
   workflow = opt$workflow_url,
   workflow_version = opt$workflow_version,

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -131,7 +131,7 @@ metadata_list <- list(
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
-  purrr::map(~if(is.null(.)) NA else .)) # convert any NULLS to NA
+  purrr::map(~if(is.null(.)) NA else .) # convert any NULLS to NA
 
 # Output metadata as JSON
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -109,7 +109,7 @@ has_citeseq <- "CITEseq" %in% alt_expts
 metadata_list <- list(
   library_id = opt$library_id,
   sample_id = opt$sample_id,
-  date_processed = lubridate::now(),
+  date_processed = lubridate::now(tzone = "UTC"),
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
   total_reads = sce_meta$total_reads,

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -63,7 +63,14 @@ option_list <- list(
     type = "character",
     default = NA,
     help = "workflow version identifier"
+  ),
+  make_option(
+    opt_str = "--workflow_commit",
+    type = "character",
+    default = NA,
+    help = "workflow commit hash"
   )
+
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
@@ -83,6 +90,9 @@ if (opt$workflow_url == "null"){
 }
 if (opt$workflow_version == "null"){
   opt$workflow_version <- NA
+}
+if (opt$workflow_commit == "null"){
+  opt$workflow_commit <- NA
 }
 
 # read sce files
@@ -110,7 +120,8 @@ metadata_list <- list(
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
   workflow = opt$workflow_url,
-  workflow_version = opt$workflow_version
+  workflow_version = opt$workflow_version,
+  workflow_commit = opt$workflow_commit
 ) |>
   purrr::map(~ifelse(is.null(.), NA, .)) # convert any NULLS to NA
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -99,13 +99,6 @@ if (opt$workflow_commit == "null"){
 unfiltered_sce <- readr::read_rds(opt$unfiltered_sce)
 filtered_sce <- readr::read_rds(opt$filtered_sce)
 
-scpcaTools::generate_qc_report(
-  sample_name = opt$sample_id,
-  unfiltered_sce = unfiltered_sce,
-  filtered_sce = filtered_sce,
-  output = opt$qc_report_file
-)
-
 # Compile metadata for output files
 sce_meta <- metadata(unfiltered_sce)
 
@@ -116,6 +109,7 @@ has_citeseq <- "CITEseq" %in% alt_expts
 metadata_list <- list(
   library_id = opt$library_id,
   sample_id = opt$sample_id,
+  date_processed = lubridate::now(),
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
   total_reads = sce_meta$total_reads,
@@ -134,4 +128,10 @@ metadata_list <- list(
 readr::write_csv(as.data.frame(metadata_list), file = opt$metadata_csv)
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
   
+scpcaTools::generate_qc_report(
+  sample_id = metadata_list$sample_id,
+  unfiltered_sce = unfiltered_sce,
+  filtered_sce = filtered_sce,
+  output = opt$qc_report_file
+)
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -21,7 +21,7 @@ option_list <- list(
   make_option(
     opt_str = c("-l", "--library_id"),
     type = "character",
-    help = "Library identifier for report"
+    help = "Library identifier for report and metadata file"
   ),
   make_option(
     opt_str = c("-s", "--sample_id"),
@@ -76,7 +76,6 @@ option_list <- list(
     default = NA,
     help = "workflow commit hash"
   )
-
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
@@ -115,17 +114,17 @@ has_citeseq <- "CITEseq" %in% alt_expts
 metadata_list <- list(
   library_id = opt$library_id,
   sample_id = opt$sample_id,
-  date_processed = lubridate::now(tzone = "UTC"),
-  filtered_cells = ncol(filtered_sce),
-  unfiltered_cells = ncol(unfiltered_sce),
   technology = opt$technology,
   seq_unit = opt$seq_unit,
   has_citeseq = has_citeseq,
+  filtered_cells = ncol(filtered_sce),
+  unfiltered_cells = ncol(unfiltered_sce),
   total_reads = sce_meta$total_reads,
   mapped_reads = sce_meta$mapped_reads,
   genome_assembly = opt$genome_assembly,
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
+  date_processed = lubridate::now(tzone = "UTC"),
   salmon_version = sce_meta$salmon_version,
   alevin_fry_version = sce_meta$alevinfry_version,
   workflow = opt$workflow_url,
@@ -138,7 +137,7 @@ metadata_list <- list(
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
   
 scpcaTools::generate_qc_report(
-  sample_id = metadata_list$sample_id,
+  sample_id = metadata_list$library_id,
   unfiltered_sce = unfiltered_sce,
   filtered_sce = filtered_sce,
   output = opt$qc_report_file

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -35,22 +35,28 @@ option_list <- list(
     help = "path to QC report output file"
   ),
   make_option(
-    opt_str = "--metadata_csv",
-    default = "metadata.csv",
-    type = "character",
-    help = "path to metadata csv output file"
-  ),
-  make_option(
     opt_str = "--metadata_json",
     default = "metadata.json",
     type = "character",
     help = "path to metadata json output file"
   ),
   make_option(
+    opt_str = "--technology",
+    type = "character",
+    default = NA,
+    help = "sequencing technology"
+  ),
+  make_option(
+    opt_str = "--seq_unit",
+    type = "character",
+    default = NA,
+    help = "sequencing unit"
+  ),
+  make_option(
     opt_str = "--genome_assembly",
     type = "character",
     default = NA,
-    help = "workflow github url"
+    help = "genome assembly used for mapping"
   ),
   make_option(
     opt_str = "--workflow_url",
@@ -112,6 +118,9 @@ metadata_list <- list(
   date_processed = lubridate::now(tzone = "UTC"),
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
+  technology = opt$technology,
+  seq_unit = opt$seq_unit,
+  has_citeseq = has_citeseq,
   total_reads = sce_meta$total_reads,
   mapped_reads = sce_meta$mapped_reads,
   genome_assembly = opt$genome_assembly,
@@ -119,15 +128,13 @@ metadata_list <- list(
   transcript_type = sce_meta$transcript_type,
   salmon_version = sce_meta$salmon_version,
   alevin_fry_version = sce_meta$alevinfry_version,
-  has_citeseq = has_citeseq,
   workflow = opt$workflow_url,
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
   purrr::map(~ifelse(is.null(.), NA, .)) # convert any NULLS to NA
 
-# Output metadata
-readr::write_csv(as.data.frame(metadata_list), file = opt$metadata_csv)
+# Output metadata as JSON
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
   
 scpcaTools::generate_qc_report(

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -109,6 +109,10 @@ scpcaTools::generate_qc_report(
 # Compile metadata for output files
 sce_meta <- metadata(unfiltered_sce)
 
+# check for alt experiments (CITE-seq, etc)
+alt_expts <- altExpNames(unfiltered_sce)
+has_citeseq <- "CITEseq" %in% alt_expts
+
 metadata_list <- list(
   library_id = opt$library_id,
   sample_id = opt$sample_id,
@@ -119,6 +123,7 @@ metadata_list <- list(
   genome_assembly = opt$genome_assembly,
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
+  has_citeseq = has_citeseq,
   workflow = opt$workflow_url,
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -78,6 +78,12 @@ if(is.null(opt$filtered_sce) || !file.exists(opt$filtered_sce)){
   stop("Filtered .rds file missing or `filtered_sce` not specified.")
 }
 
+if (opt$workflow_url == "null"){
+  opt$workflow_url <- NA
+}
+if (opt$workflow_version == "null"){
+  opt$workflow_version <- NA
+}
 
 # read sce files
 unfiltered_sce <- readr::read_rds(opt$unfiltered_sce)
@@ -110,6 +116,6 @@ metadata_list <- list(
 
 # Output metadata
 readr::write_csv(as.data.frame(metadata_list), file = opt$metadata_csv)
-jsonlite::write_json(metadata_list, path = opt$metadata_json)
+jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
   
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -124,14 +124,14 @@ metadata_list <- list(
   genome_assembly = opt$genome_assembly,
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
-  date_processed = lubridate::now(tzone = "UTC"),
+  date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
   salmon_version = sce_meta$salmon_version,
   alevin_fry_version = sce_meta$alevinfry_version,
   workflow = opt$workflow_url,
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
-  purrr::map(~ifelse(is.null(.), NA, .)) # convert any NULLS to NA
+  purrr::map(~if(is.null(.)) NA else .)) # convert any NULLS to NA
 
 # Output metadata as JSON
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -12,7 +12,7 @@ process sce_qc_report{
         qc_report = "${meta.library_id}_qc.html"
         metadata_csv = "${meta.library_id}_metadata.csv"
         metadata_json = "${meta.library_id}_metadata.json"
-        workflow_version = workflow.revision ? workflow.revision : workflow.commitId
+        workflow_url = workflow.repository? workflow.repository : params.workflow_url
         """
         sce_qc_report.R \
           --library_id ${meta.library_id} \
@@ -23,7 +23,7 @@ process sce_qc_report{
           --genome_assembly ${params.assembly} \
           --metadata_csv ${metadata_csv} \
           --metadata_json ${metadata_json} \
-          --workflow_url "${workflow.repository}" \
-          --workflow_version "${workflow_version}" 
+          --workflow_url "${workflow_url}" \
+          --workflow_version "${workflow.revision}" 
         """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -24,6 +24,7 @@ process sce_qc_report{
           --metadata_csv ${metadata_csv} \
           --metadata_json ${metadata_json} \
           --workflow_url "${workflow_url}" \
-          --workflow_version "${workflow.revision}" 
+          --workflow_version "${workflow.revision}" \
+          --workflow_commit "${workflow.commit}"
         """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -25,6 +25,6 @@ process sce_qc_report{
           --metadata_json ${metadata_json} \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow.revision}" \
-          --workflow_commit "${workflow.commit}"
+          --workflow_commit "${workflow.commitId}"
         """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -19,10 +19,10 @@ process sce_qc_report{
           --unfiltered_sce ${unfiltered_rds} \
           --filtered_sce ${filtered_rds} \
           --qc_report_file ${qc_report} \
-          --genome_assembly ${params.assembly} \
           --metadata_json ${metadata_json} \
           --technology ${meta.technology} \
           --seq_unit ${meta.seq_unit} \
+          --genome_assembly ${params.assembly} \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow.revision}" \
           --workflow_commit "${workflow.commitId}"

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -7,10 +7,9 @@ process sce_qc_report{
     input: 
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:
-        tuple val(meta), path(qc_report), path(metadata_csv), path(metadata_json)
+        tuple val(meta), path(qc_report), path(metadata_json)
     script:
         qc_report = "${meta.library_id}_qc.html"
-        metadata_csv = "${meta.library_id}_metadata.csv"
         metadata_json = "${meta.library_id}_metadata.json"
         workflow_url = workflow.repository? workflow.repository : params.workflow_url
         """
@@ -21,8 +20,9 @@ process sce_qc_report{
           --filtered_sce ${filtered_rds} \
           --qc_report_file ${qc_report} \
           --genome_assembly ${params.assembly} \
-          --metadata_csv ${metadata_csv} \
           --metadata_json ${metadata_json} \
+          --technology ${meta.technology} \
+          --seq_unit ${meta.seq_unit} \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow.revision}" \
           --workflow_commit "${workflow.commitId}"

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -11,7 +11,7 @@ process sce_qc_report{
     script:
         qc_report = "${meta.library_id}_qc.html"
         metadata_json = "${meta.library_id}_metadata.json"
-        workflow_url = workflow.repository? workflow.repository : params.workflow_url
+        workflow_url = workflow.repository ?: params.workflow_url
         """
         sce_qc_report.R \
           --library_id ${meta.library_id} \

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -7,14 +7,23 @@ process sce_qc_report{
     input: 
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:
-        tuple val(meta), path(qc_report)
+        tuple val(meta), path(qc_report), path(metadata_csv), path(metadata_json)
     script:
         qc_report = "${meta.library_id}_qc.html"
+        metadata_csv = "${meta.library_id}_metadata.csv"
+        metadata_json = "${meta.library_id}_metadata.json"
+        workflow_version = workflow.revision ? workflow.revision : workflow.commitId
         """
         sce_qc_report.R \
-          --sample_id {meta.library_id} \
+          --library_id ${meta.library_id} \
+          --sample_id ${meta.sample_id} \
           --unfiltered_sce ${unfiltered_rds} \
           --filtered_sce ${filtered_rds} \
-          --output_file ${qc_report}
+          --qc_report_file ${qc_report} \
+          --genome_assembly ${params.assembly} \
+          --metadata_csv ${metadata_csv} \
+          --metadata_json ${metadata_json} \
+          --workflow_url "${workflow.repository}" \
+          --workflow_version "${workflow_version}" 
         """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,8 @@
 // global parameters for workflows
 params{
+  // Workflow metadata
+  workflow_url = 'https://github.com/AlexsLemonade/scpca-nf'
+
   // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'


### PR DESCRIPTION
In this PR I am adding to the QC process/script to output information at the library level, including some basic statistics that we were thinking might go into the portal front end. 

Closes #34 
Also addresses https://github.com/AlexsLemonade/ScPCA-admin/issues/210

I am attaching here an example of the output csv file, [SCPCL000001_metadata.csv](https://github.com/AlexsLemonade/scpca-nf/files/7228171/SCPCL000001_metadata.csv).
The equivalent json (which is also exported, but gh won't let me attach), appears below.
```
{
  "library_id": "SCPCL000001",
  "sample_id": "SCPCS000001",
  "filtered_cells": 1642,
  "unfiltered_cells": 61980,
  "total_reads": 121894873,
  "mapped_reads": 90729577,
  "genome_assembly": "Homo_sapiens.GRCh38.104",
  "mapping_index": "Homo_sapiens.GRCh38.104.spliced_intron.txome",
  "transcript_type": "spliced",
  "has_citeseq": false,
  "workflow": "https://github.com/AlexsLemonade/scpca-nf",
  "workflow_version": "jashapiro/34-export-cell-stats",
  "workflow_commit": "839d5412b47064eb2953f841745e3074f4839d08"
}
```

Are there other statistics and information that we should include in these files? (Do we want both formats?) I'm thinking only the filtered cells are likely to really make it to the front end, but getting the other stats wasn't hard. I could add a processing date?

Worth noting: you only get the workflow version & commit if you start the workflow with:
```
nextflow run AlexsLemonade/scpca-nf -r <branch/tag/commit> 
```
If running from a local file, you will still get the workflow url, because I hard coded that as a fallback.
(I anticipate in production runs we would use a release tag for the version, so it would look like `"v1.0"`, but branches work, so that is what I have in the example here.)

