### PR TITLE
Add gene_symbols to SCE objects

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -48,7 +48,7 @@ filtered_sce <- scpcaTools::filter_counts(unfiltered_sce,
 
 # need to remove old gene-level rowData statistics first
 drop_cols = colnames(rowData(filtered_sce)) %in% c('mean', 'detected')
-rowData(filtered_sce) <- rowData(filtered_sce)[, !drop_cols] 
+rowData(filtered_sce) <- rowData(filtered_sce)[!drop_cols] 
 
 # recalculate rowData and add to filtered sce
 filtered_sce <- filtered_sce |>
@@ -64,7 +64,7 @@ alt_names <- altExpNames(filtered_sce)
 for (alt in alt_names) {
   # remove old row data from unfiltered
   drop_cols = colnames(rowData(altExp(filtered_sce, alt))) %in% c('mean', 'detected')
-  rowData(altExp(filtered_sce, alt)) <- rowData(altExp(filtered_sce, alt))[, !drop_cols] 
+  rowData(altExp(filtered_sce, alt)) <- rowData(altExp(filtered_sce, alt))[!drop_cols] 
 
   # add alt experiment features stats for filtered data
   altExp(filtered_sce, alt) <- scuttle::addPerFeatureQCMetrics(altExp(filtered_sce, alt))

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -4,9 +4,10 @@
 # filters it using emptyDrops, adding miQC metrics for probability compromised
 
 # import libraries
-library(optparse)
-library(SingleCellExperiment)
-
+suppressPackageStartupMessages({
+  library(optparse)
+  library(SingleCellExperiment)
+})
 # set up arguments
 option_list <- list(
   make_option(

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -101,6 +101,7 @@ if (opt$feature_dir != ""){
 # add per cell and per gene statistics to colData and rowData
 unfiltered_sce <- unfiltered_sce |>
   add_cell_mito_qc(mito = mito_genes) |>
+ # add gene symbols to rowData
   add_gene_symbols(gene_info = gtf) |>
   scuttle::addPerFeatureQCMetrics()
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -76,7 +76,7 @@ if(!file.exists(opt$gtf_file)){
 mito_genes <- unique(scan(opt$mito_file, what = "character"))
 
 # read in gtf file (genes only for speed)
-gtf <- rtracklayer::import(opt$gtf_file, feature_type = "gene")
+gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 
 # convert seq_unit to spliced or unspliced to determine which types of transcripts to include in final counts matrix
 which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -4,10 +4,11 @@
 # returns the unfiltered counts matrices as a SingleCellExperiment stored in a .rds file
 
 # import libraries
-library(optparse)
-library(SingleCellExperiment)
-library(scpcaTools)
-
+suppressPackageStartupMessages({
+  library(optparse)
+  library(SingleCellExperiment)
+  library(scpcaTools)
+})
 # set up arguments
 option_list <- list(
   make_option(

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -42,6 +42,11 @@ option_list <- list(
     type = "character",
     help = "path to list of mitochondrial genes"
   )
+  make_option(
+    opt_str = c("-g", "--gtf_file"),
+    type = "character",
+    help = "path to gtf file with gene annotations"
+  )
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
@@ -61,8 +66,16 @@ if(!file.exists(opt$mito_file)){
   stop("Mitochondrial gene list file not found.")
 }
 
+# check that gtf file exists
+if(!file.exists(opt$gtf_file)){
+  stop("gtf file not found.")
+}
+
 # read in mitochondrial gene list
 mito_genes <- unique(scan(opt$mito_file, what = "character"))
+
+# read in gtf file (genes only for speed)
+gtf <- rtracklayer::import(opt$gtf_file, feature_type = "gene")
 
 # convert seq_unit to spliced or unspliced to determine which types of transcripts to include in final counts matrix
 which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",
@@ -81,13 +94,14 @@ if (opt$feature_dir != ""){
    
   unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name) 
   # add alt experiment features stats
-  altExp(unfiltered_sce, opt$feature_name) <- scater::addPerFeatureQC(altExp(unfiltered_sce, opt$feature_name))
+  altExp(unfiltered_sce, opt$feature_name) <- scuttle::addPerFeatureQCMetrics(altExp(unfiltered_sce, opt$feature_name))
 }
 
 # add per cell and per gene statistics to colData and rowData
 unfiltered_sce <- unfiltered_sce |>
   add_cell_mito_qc(mito = mito_genes) |>
-  scater::addPerFeatureQC()
+  add_gene_symbols(gene_info = gtf) |>
+  scuttle::addPerFeatureQCMetrics()
 
 # write to rds
 readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -42,7 +42,7 @@ option_list <- list(
     opt_str = c("-m", "--mito_file"),
     type = "character",
     help = "path to list of mitochondrial genes"
-  )
+  ),
   make_option(
     opt_str = c("-g", "--gtf_file"),
     type = "character",

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -8,6 +8,7 @@ process make_unfiltered_sce{
     input: 
         tuple val(meta), path(alevin_dir)
         path(mito)
+        path(gtf)
     output:
         tuple val(meta), path(unfiltered_rds)
     script:
@@ -17,7 +18,8 @@ process make_unfiltered_sce{
           --seq_unit ${meta.seq_unit} \
           --alevin_dir ${alevin_dir} \
           --unfiltered_file ${unfiltered_rds} \
-          --mito_file ${mito}
+          --mito_file ${mito} \
+          --gtf_file ${gtf}
         """
 }
 
@@ -28,6 +30,7 @@ process make_merged_unfiltered_sce{
     input: 
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
         path(mito)
+        path(gtf)
     output:
         tuple val(meta), path(unfiltered_rds)
     script:
@@ -43,7 +46,8 @@ process make_merged_unfiltered_sce{
           --feature_dir ${feature_alevin_dir} \
           --feature_name ${meta.feature_type} \
           --unfiltered_file ${unfiltered_rds} \
-          --mito_file ${mito}
+          --mito_file ${mito} \
+          --gtf_file ${gtf}
         """
 }
 
@@ -68,7 +72,7 @@ workflow generate_sce {
   // generate rds files for RNA-only samples
   take: quant_channel
   main:
-    make_unfiltered_sce(quant_channel, params.mito_file) \
+    make_unfiltered_sce(quant_channel, params.mito_file, params.gtf) \
       | filter_sce
 
   emit: filter_sce.out
@@ -80,7 +84,7 @@ workflow generate_merged_sce {
   // input is a channel with feature_meta, feature_quantdir, rna_meta, rna_quantdir
   take: feature_quant_channel
   main:
-    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file) \
+    make_merged_unfiltered_sce(feature_quant_channel, params.mito_file, params.gtf) \
       | filter_sce
 
   emit: filter_sce.out


### PR DESCRIPTION
Closes #38

This update to the workflow adds gene symbols to the row data of the single cell experiment objects that we generate. I do this first as part of the unfiltered_sce script, using the symbol information from the GTF file that is already a parameter defined in the workflow config file. I read the GTF with `rtracklayer::import()` which is pretty efficient once we restrict to reading only genes (not transcripts, cds, etc.).

The filtering script had to be modified a bit, because we no longer want to remove all row data before recalculating gene statistics. Instead, we are removing only the columns of the rowdata table that `addPerFeatureQCMetrics()`adds, then add them back recalculated. There is a bit of oddness here in that we select from the `DataFrame` as if it were a vector (brackets with no comma), as this allows us to keep the column names, which can otherwise be dropped if we are only keeping one column. (I made the same change for the `alt` experiment, even though it should not be affected).
