### PR TITLE
Add support for 5' libraries 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -19,6 +19,7 @@ params.project = ""
 // 10X barcode files
 cell_barcodes = [
   '10Xv2': '737K-august-2016.txt',
+  '10Xv2_5prime': '737K-august-2016.txt',
   '10Xv3': '3M-february-2018.txt',
   '10Xv3.1': '3M-february-2018.txt',
   'CITEseq_10Xv2': '737K-august-2016.txt',

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -16,6 +16,7 @@ process alevin_rad{
     run_dir = "${meta.run_id}-rna"
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
+                 '10Xv2_5prime': '--chromium',
                  '10Xv3': '--chromiumV3',
                  '10Xv3.1': '--chromiumV3']
     // run alevin like normal with the --rad flag 
@@ -53,7 +54,7 @@ process fry_quant_rna{
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
-      --expected-ori fw \
+      --expected-ori ${meta.technology == '10Xv2_5prime' ? 'rc' : 'fw'} \
       -o ${run_dir} \
       --unfiltered-pl ${barcode_file}
 


### PR DESCRIPTION
Closes #39. Here I'm adding in support for 5' libraries into the workflow and took the same approach that we used and tested in the [alevin-fry workflow in alsf-scpca.](https://github.com/AlexsLemonade/alsf-scpca/blob/main/workflows/alevin-quant/run-alevin-fry.nf)

I believe these changes should be pretty straight forward, but please let me know if there is a better way to approach making the proposed changes in this workflow. 