### PR TITLE
Incorporate project info into channels and output

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -58,6 +58,7 @@ workflow {
       run_id: it.scpca_run_id,
       library_id: it.scpca_library_id,
       sample_id: it.scpca_sample_id,
+      project_id: it.scpca_project_id?: "SCPCP000000",
       submitter: it.submitter,
       technology: it.technology,
       seq_unit: it.seq_unit,
@@ -68,11 +69,13 @@ workflow {
     // only technologies we know how to process
     .filter{it.technology in tech_list} 
     // use only the rows in the run_id list (run, library, or sample can match)
+    // or run by project or submitter if the project parameter is set
     .filter{run_all 
              || (it.run_id in run_ids) 
              || (it.library_id in run_ids)
              || (it.sample_id in run_ids)
              || (it.submitter == params.project)
+             || (it.project_id == params.project)
             }
   
   // generate lists of library ids for feature libraries & RNA-only

--- a/main.nf
+++ b/main.nf
@@ -1,14 +1,6 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-// run parameters
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.outdir = "s3://nextflow-ccdl-results/scpca/processed"
-
-params.resolution = 'cr-like' //default resolution is cr-like, can also use full, cr-like-em, parsimony, and trivial
-params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
-
-
 // run_ids are comma separated list to be parsed into 
 // a list of run ids, library ids, and or sample_ids
 // or "All" to process all samples in the metadata file
@@ -58,7 +50,7 @@ workflow {
       run_id: it.scpca_run_id,
       library_id: it.scpca_library_id,
       sample_id: it.scpca_sample_id,
-      project_id: it.scpca_project_id?: "SCPCP000000",
+      project_id: it.scpca_project_id?: "no_project",
       submitter: it.submitter,
       technology: it.technology,
       seq_unit: it.seq_unit,

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -31,7 +31,7 @@ process alevin_feature{
           path(feature_index)
   output:
     tuple val(meta),
-          path(run_dir), path(feature_index)
+          path(run_dir)
   script:
     // label the run directory by id
     run_dir = "${meta.run_id}-features"
@@ -53,7 +53,9 @@ process alevin_feature{
       --umi-geometry ${umi_geom} \
       --rad \
       -o ${run_dir} \
-      -p ${task.cpus} 
+      -p ${task.cpus}
+
+    cp ${feature_index}/t2g.tsv ${run_dir}/t2g.tsv
     """
 }
 
@@ -65,7 +67,7 @@ process fry_quant_feature{
   publishDir "${params.outdir}/internal/${meta.library_id}"
   input:
     tuple val(meta),
-          path(run_dir), path(feature_index)
+          path(run_dir)
     path barcode_file
   output:
     tuple val(meta),
@@ -86,7 +88,7 @@ process fry_quant_feature{
     
     alevin-fry quant \
       --input-dir ${run_dir} \
-      --tg-map ${feature_index}/t2g.tsv \
+      --tg-map ${run_dir}/t2g.tsv \
       --resolution ${params.af_resolution} \
       -o ${run_dir} \
       --use-mtx \

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -87,7 +87,7 @@ process fry_quant_feature{
     alevin-fry quant \
       --input-dir ${run_dir} \
       --tg-map ${feature_index}/t2g.tsv \
-      --resolution ${params.resolution} \
+      --resolution ${params.af_resolution} \
       -o ${run_dir} \
       --use-mtx \
       -t ${task.cpus} \

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -24,6 +24,7 @@ process alevin_feature{
   container params.SALMON_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
+  publishDir "${params.outdir}/internal/${meta.library_id}"
   input:
     tuple val(meta), 
           path(read1), path(read2), 
@@ -61,7 +62,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
+  publishDir "${params.outdir}/internal/${meta.library_id}"
   input:
     tuple val(meta),
           path(run_dir), path(feature_index)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -24,7 +24,7 @@ process alevin_feature{
   container params.SALMON_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/internal/${meta.library_id}"
+  publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:
     tuple val(meta), 
           path(read1), path(read2), 
@@ -64,7 +64,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/internal/${meta.library_id}"
+  publishDir "${params.outdir}/internal/af/${meta.library_id}"
   input:
     tuple val(meta),
           path(run_dir)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -67,7 +67,7 @@ process fry_quant_rna{
     alevin-fry quant \
       --input-dir ${run_dir} \
       --tg-map ${tx2gene_3col} \
-      --resolution ${params.resolution} \
+      --resolution ${params.af_resolution} \
       -o ${run_dir} \
       --use-mtx \
       -t ${task.cpus} \

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -5,7 +5,7 @@ process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
   tag "${meta.run_id}-rna"
-  publishDir "${params.outdir}/internal/${meta.library_id}"
+  publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:
     tuple val(meta), 
           path(read1), path(read2)
@@ -42,7 +42,7 @@ process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.outdir}/internal/${meta.library_id}"
+  publishDir "${params.outdir}/internal/af/${meta.library_id}"
 
   input:
     tuple val(meta), path(run_dir)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -5,6 +5,7 @@ process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
   tag "${meta.run_id}-rna"
+  publishDir "${params.outdir}/internal/${meta.library_id}"
   input:
     tuple val(meta), 
           path(read1), path(read2)
@@ -41,7 +42,7 @@ process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.outdir}/${meta.sample_id}/${meta.library_id}"
+  publishDir "${params.outdir}/internal/${meta.library_id}"
 
   input:
     tuple val(meta), path(run_dir)

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -4,7 +4,7 @@
 // RNA only libraries
 process make_unfiltered_sce{
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(alevin_dir)
         path(mito)
@@ -26,7 +26,7 @@ process make_unfiltered_sce{
 // channels with RNA and feature data
 process make_merged_unfiltered_sce{
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(feature_meta), path(feature_alevin_dir), val (meta), path(alevin_dir)
         path(mito)
@@ -53,7 +53,7 @@ process make_merged_unfiltered_sce{
 
 process filter_sce{
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)
     output:

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -3,7 +3,7 @@
 
 process sce_qc_report{
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.outdir}/${meta.sample_id}"
+    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,14 @@ params{
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
+
+  // Input data table
+  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+
+  // Output base directory
+  outdir = "s3://nextflow-ccdl-results/scpca/processed"
+
+  
   // Assembly, annotation, and index locations
   assembly = 'Homo_sapiens.GRCh38.104'
   ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
@@ -13,9 +21,11 @@ params{
   index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
   mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+  barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
-  // Filtering constants
-  emptydrops_lower = 200
+  // Processing options
+  af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
 }
 
 


### PR DESCRIPTION
Here I am incorporating the `scpca_project_id` column into the `meta` passed along with each channel, and using that information to further subdivide the final output. 

In changing the output files, I also split outputs like alevin results & initial rad files (which we will now keep) into a separate `internal` prefix, with the elements that will go to the front end under the `publish` prefix. Some notes:
- This is slightly different from the approach in https://github.com/AlexsLemonade/scpca-nf/pull/28, which created separate `alevin_dir` and `final_output` parameters, and used those for output. 
- In doing this, I also decided to remove the `sample_id` prefix for the internal outputs, as it seemed like for internal things we might not need that level of nesting (which is usually redundant). 
- the internal saved files are separated into `rad` and `af` outputs; the former has the initial mapping results (in order to satisfy #40), and the latter the final alevin-fry folder, with the`.rad` files removed (after filter, collate and quant). 
  - For the `feature` processes, this resulted in a redundant `feature_index` folder being saved for every library due to the way we were passing those files around. It was small, but annoying, so I simplified things a bit by moving the only file we need in the next step to the alevin output directory. 
- I moved more parameters out to the config file, for consolidation, leaving only the choice of runs/projects in `main.nf`

**All of these decisions are open for debate!**

closes #17 
closes #26 
closes #40