### PR TITLE
Add technology to stored metadata

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -47,6 +47,11 @@ option_list <- list(
     opt_str = c("-g", "--gtf_file"),
     type = "character",
     help = "path to gtf file with gene annotations"
+  ),
+  make_option(
+    opt_str = c("-t", "--technology"),
+    type = "character",
+    help = "sequencing technology string to store in metadata"
   )
 )
 
@@ -85,7 +90,8 @@ which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
                               which_counts = which_counts,
-                              usa_mode = TRUE)
+                              usa_mode = TRUE,
+                              tech_version = opt$technology)
 
 
 # read and merge feature counts if present

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -19,7 +19,8 @@ process make_unfiltered_sce{
           --alevin_dir ${alevin_dir} \
           --unfiltered_file ${unfiltered_rds} \
           --mito_file ${mito} \
-          --gtf_file ${gtf}
+          --gtf_file ${gtf} \
+          --technology ${meta.technology}
         """
 }
 
@@ -47,7 +48,8 @@ process make_merged_unfiltered_sce{
           --feature_name ${meta.feature_type} \
           --unfiltered_file ${unfiltered_rds} \
           --mito_file ${mito} \
-          --gtf_file ${gtf}
+          --gtf_file ${gtf} \
+          --technology ${meta.technology}
         """
 }
 


### PR DESCRIPTION
While we added the ability to store metadata in the SCE objects a while back, we never implemented passing that data in via the workflow. This PR adds  the flags and arguments to do that.