### PR TITLE
Add random seed options

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -24,10 +24,18 @@ option_list <- list(
     opt_str = c("-l", "--lower"),
     type = "integer",
     help = "Value specifying the lower bound on total UMI count used in filtering with DropletUtils::emptyDrops."
- )
+ ),
+ make_option(
+   opt_str = c("-r", "--random_seed"),
+   type = "integer",
+   help = "A random seed for reproducibility."
+ ),
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
+
+# set seed
+set.seed(opt$random_seed)
 
 # check that unfiltered file file exists
 if(!file.exists(opt$unfiltered_file)){

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -29,7 +29,7 @@ option_list <- list(
    opt_str = c("-r", "--random_seed"),
    type = "integer",
    help = "A random seed for reproducibility."
- ),
+ )
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))

--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -66,7 +66,8 @@ process filter_sce{
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
           --filtered_file ${filtered_rds} \
-          --lower ${params.emptydrops_lower}
+          --lower ${params.emptydrops_lower} \
+          ${params.seed ? "--random_seed ${params.seed}" : ""}
         """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,7 @@ params{
   // Processing options
   af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
+  seed = false // random number seed for filtering (false means use system seed)
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params{
   // Processing options
   af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
-  seed = false // random number seed for filtering (false means use system seed)
+  seed = 0 // random number seed for filtering (0 means use system seed)
 }
 
 


### PR DESCRIPTION
This PR adds the option to set a random seed for the workflow, in particular the `filter_sce_rds.R` script. 

I set a default parameter value of `0` for the workflow, which will cause the workflow to skip the `random_seed` argument to the filter script, but any other value will be passed along to set the seed at the top of the script.

