### PR TITLE
Use v0.1.0 of scpcaTools & memory/retry tweaks

### DIFF
--- a/modules/generate-rds.nf
+++ b/modules/generate-rds.nf
@@ -1,9 +1,9 @@
-
 // generate unfiltered and filtered RDS files using scpcaTools
 
 // RNA only libraries
 process make_unfiltered_sce{
     container params.SCPCATOOLS_CONTAINER
+    label 'mem_8'
     publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(alevin_dir)
@@ -26,6 +26,7 @@ process make_unfiltered_sce{
 
 // channels with RNA and feature data
 process make_merged_unfiltered_sce{
+    label 'mem_8'
     container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
@@ -55,6 +56,7 @@ process make_merged_unfiltered_sce{
 
 process filter_sce{
     container params.SCPCATOOLS_CONTAINER
+    label 'mem_8'
     publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -14,15 +14,15 @@ process sce_qc_report{
         workflow_url = workflow.repository ?: params.workflow_url
         """
         sce_qc_report.R \
-          --library_id ${meta.library_id} \
-          --sample_id ${meta.sample_id} \
+          --library_id "${meta.library_id}" \
+          --sample_id "${meta.sample_id}" \
           --unfiltered_sce ${unfiltered_rds} \
           --filtered_sce ${filtered_rds} \
           --qc_report_file ${qc_report} \
           --metadata_json ${metadata_json} \
-          --technology ${meta.technology} \
-          --seq_unit ${meta.seq_unit} \
-          --genome_assembly ${params.assembly} \
+          --technology "${meta.technology}" \
+          --seq_unit "${meta.seq_unit}" \
+          --genome_assembly "${params.assembly}" \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow.revision}" \
           --workflow_commit "${workflow.commitId}"

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,10 @@ profiles{
       maxRetries = 1
       maxErrors = '-1'
       memory = { 4.GB * task.attempt}
-
+      
+      withLabel: mem_8 {
+        memory = { 8.GB * task.attempt}
+      }
       withLabel: cpus_12 {
         cpus = 12
         memory = { 30.GB * task.attempt}

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,9 +54,10 @@ profiles{
       maxRetries = 1
       maxErrors = '-1'
       memory = { 4.GB * task.attempt}
-      
+
       withLabel: mem_8 {
         memory = { 8.GB * task.attempt}
+        errorStrategy = 'retry'
       }
       withLabel: cpus_12 {
         cpus = 12

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ params{
   // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
-  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.0'
 
 
   // Input data table

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,14 +50,13 @@ profiles{
       executor = 'awsbatch'
       queue = 'nextflow-batch-default-queue'
       // following options from nf-core
-      errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+      errorStrategy = { task.attempt < 2 ? 'retry' : 'finish' }
       maxRetries = 1
       maxErrors = '-1'
       memory = { 4.GB * task.attempt}
 
       withLabel: mem_8 {
         memory = { 8.GB * task.attempt}
-        errorStrategy = 'retry'
       }
       withLabel: cpus_12 {
         cpus = 12


### PR DESCRIPTION
Closes #47 

This updates the tag on the docker image to use v0.1.0 of scpcaTools, freezing that last image in place (for now).

In testing a separate step, I ran into some out of memory errors, so I added another process label with higher memory requirements (but still only one CPU, though I might later reconsider this to bump the CPU a bit too). I also tweaked the nextflow retry settings because those seemed to not be working as expected (i.e. I was clearly getting error 137 but the job was not being retried). With the modifications I made and the test sample I was working with, I still get an OOM error for one of the jobs (filtering), but this then correctly reruns with double the memory. 