### PR TITLE
Reduce memory requirements & change resolution strategy

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params{
   barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
-  af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
   seed = 2021   // random number seed for filtering (0 means use system seed)
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,11 +60,11 @@ profiles{
       }
       withLabel: cpus_12 {
         cpus = 12
-        memory = { 30.GB * task.attempt}
+        memory = { 24.GB * task.attempt}
       }
       withLabel: cpus_8 {
         cpus = 8
-        memory = { 24.GB * task.attempt}
+        memory = { 16.GB * task.attempt}
       }
     }
   }


### PR DESCRIPTION
In running the first set of samples, I noticed that we were using quite a bit less memory during mapping than we were requesting. So here I am making the memory request for those jobs smaller. Now that we have a working retry strategy, this should still work even in the rare event we exceed the lower limit. (This may also allow us to recover from some disk space limits we had run into, as the second run will probably require a larger portion of each instance, leaving more disk space available on shared instances.)

I also here am updating to use cr-like-em for processing, which we said we would do, but didn't actually implement.