### PR TITLE
revert to cr-like

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params{
   barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
-  af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
   seed = 2021   // random number seed for filtering (0 means use system seed)
 }


### PR DESCRIPTION
Unfortunately, we encountered an apparent bug in `alevin-fry` using `cr-like-em` which precludes its use by default here. See https://github.com/COMBINE-lab/alevin-fry/issues/28 When this is resolved, we may be able to try setting this back. 