### PR TITLE
Add back cr-like-em with update alevin-fry

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ params{
 
   // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
-  ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.1'
 
 
@@ -27,7 +27,7 @@ params{
   barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
-  af_resolution = 'cr-like' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   emptydrops_lower = 200 // emptydrops lower bound for cell UMI count
   seed = 2021   // random number seed for filtering (0 means use system seed)
 }


### PR DESCRIPTION
This PR adds back cr-like-em as the default resolution strategy after updating to version 0.4.2 of alevin-fry. I have tested that this works as expected, and it now seems to!