### PR TITLE
Add module for bulk RNA-seq to workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -22,8 +22,9 @@ cell_barcodes = [
   'cellhash_10Xv3.1': '3M-february-2018.txt'
   ]
 
-// supported single cell technologies
+// supported technologies
 tech_list = cell_barcodes.keySet()
+bulk_techs = ['single_end','paired_end']
 rna_techs = tech_list.findAll{it.startsWith('10Xv')}
 feature_techs = tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cellhash')}
 
@@ -75,6 +76,10 @@ workflow {
     .collect{it.library_id}
   rna_only_libs = runs_ch.filter{!(it.library_id in feature_libs.getVal())}
     .collect{it.library_id}
+
+  // **** Process Bulk RNA-seq data *** 
+  bulk_ch = runs_ch.filter{it.technology in bulk_techs}
+  bulk_quant_rna(bulk_ch)
 
   // **** Process RNA-seq data ****
   rna_ch = runs_ch.filter{it.technology in rna_techs}

--- a/main.nf
+++ b/main.nf
@@ -31,6 +31,7 @@ feature_techs = tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cel
 // include processes from modules
 include { map_quant_rna } from './modules/af-rna.nf' addParams(cell_barcodes: cell_barcodes)
 include { map_quant_feature } from './modules/af-features.nf' addParams(cell_barcodes: cell_barcodes)
+include { bulk_quant_rna } from './modules/bulk-salmon.nf'
 include { generate_sce; generate_merged_sce } from './modules/generate-rds.nf'
 include { sce_qc_report } from './modules/qc-report.nf'
 

--- a/main.nf
+++ b/main.nf
@@ -23,10 +23,12 @@ cell_barcodes = [
   ]
 
 // supported technologies
-tech_list = cell_barcodes.keySet()
-bulk_techs = ['single_end','paired_end']
-rna_techs = tech_list.findAll{it.startsWith('10Xv')}
-feature_techs = tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cellhash')}
+single_cell_tech_list = cell_barcodes.keySet()
+bulk_techs = ['single_end', 'paired_end']
+all_tech_list = single_cell_tech_list.plus(bulk_techs)
+rna_techs = single_cell_tech_list.findAll{it.startsWith('10Xv')}
+feature_techs = single_cell_tech_list.findAll{it.startsWith('CITEseq') || it.startsWith('cellhash')}
+
 
 // include processes from modules
 include { map_quant_rna } from './modules/af-rna.nf' addParams(cell_barcodes: cell_barcodes)
@@ -61,7 +63,7 @@ workflow {
       s3_prefix: it.s3_prefix,
     ]}
     // only technologies we know how to process
-    .filter{it.technology in tech_list} 
+    .filter{it.technology in all_tech_list} 
     // use only the rows in the run_id list (run, library, or sample can match)
     // or run by project or submitter if the project parameter is set
     .filter{run_all 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -1,0 +1,70 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process fastp{
+    container params.FASTP_CONTAINER
+    label 'cpus_8'
+    tag "${meta.run_id}-bulk"
+    publishDir "${params.outdir}/internal/fastp/${meta.library_id}"
+    input: 
+        tuple val(meta),path(read1),path(read2)
+    output: 
+        tuple val(meta),path(trimmed_read1),path(trimmed_read2)
+    script: 
+        trimmed_data = "${params.outdir}/data/trimmed"
+        fastp_reports = "${params.outdir}/reports/fastp"
+        """
+        mkdir -p data/trimmed
+        mkdir -p reports/fastp
+
+        fastp --in1 {input.r1} --in2 {input.r2} /
+        --out1 "${trimmed_data}/${id}_R1_001_fastq.gz" /
+        --out2 "${trimmed_data}/${id}_R2_001_fastq.gz" /
+        --html "${fastp_reports}/${id}_fastp.html" /
+        --json "${fastp_reports}/${id}_fastp.json" /
+        --trim_poly_g /
+        --report_title '${id} report'
+        """
+
+}
+
+process salmon{
+    container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+    label 'cpus_8'
+    tag "${id}-${index}"
+    publishDir "${params.outdir}"
+    input: 
+        tuple val(meta),path(trimmed_read1),path(trimmed_read2)
+    output: 
+        tuple val(meta),path()
+    script:
+        salmon_results = "${params.outdir}/salmon-quant"
+        """
+        salmon quant -i ${index} /
+        -l A /
+        -1 "${trimmed_data}/${id}_R1_001_fastq.gz" /
+        -2 "${trimmed_data}/${id}_R2_001_fastq.gz" /
+        -o ${salmon_results} /
+        --threads ${task.cpus}
+        """
+
+}
+
+workflow bulk_quant_rna {
+    take: bulk_channel 
+    // a channel with a map of metadata for each rna library to process
+    main: 
+    // create tuple of (metadata map, [Read 1 files], [Read 2 files])
+    single_bulk_reads_ch = bulk_channel
+      .filter{it.technology == "single_end"}
+      .map{meta -> tuple(meta,
+                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"))}
+
+    paired_bulk_reads_ch = bulk_channel
+      .filter{it.technology == "paired_end"}
+      .map{meta -> tuple(meta,
+                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
+                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+    
+    single_bulk
+}

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -4,22 +4,22 @@ nextflow.enable.dsl=2
 process fastp{
     container params.FASTP_CONTAINER
     label 'cpus_8'
-    tag "${meta.run_id}-bulk"
+    tag "${meta.library_id}-bulk"
     publishDir "${params.outdir}/internal/fastp/${meta.library_id}"
     input: 
         tuple val(meta),path(read1), path(read2)
     output: 
         tuple val(meta),path(trimmed_read1),path(trimmed_read2)
     script: 
-        trimmed_read1 = "${meta.run_id}-trimmed-R1.fastq.gz"
-        trimmed_read2 = "${meta.run_id}-trimmed-R2.fastq.gz"
+        trimmed_read1 = "${meta.library_id}-trimmed-R1.fastq.gz"
+        trimmed_read2 = "${meta.library_id}-trimmed-R2.fastq.gz"
         """
         fastp --in1 ${read1} \
-        ${meta.library == 'paired_end' ? "--in2 ${read2}":""} \
+        ${meta.technology == 'paired_end' ? "--in2 ${read2}":""} \
         --out1 "${trimmed_read1} \
-        ${meta.library == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
-        --html "${id}_fastp.html" \
-        --json "${id}_fastp.json" \
+        ${meta.technology == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
+        --html "${meta.library_id}_fastp.html" \
+        --json "${meta.library_id}_fastp.json" \
         --trim_poly_g \
         --report_title ${meta.library_id}
         """
@@ -29,19 +29,19 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_8'
-    tag "${meta.run_id}-bulk"
+    tag "${meta.library_id}-bulk"
     publishDir "${params.outdir}/internal/salmon/${meta.library_id}"
     input: 
         tuple val(meta),path(trimmed_read1),path(trimmed_read2)
     output: 
         tuple val(meta),path(salmon_results)
     script:
-        salmon_results = "${meta.run_id}-salmon"
+        salmon_results = "${meta.library_id}-salmon"
         """
         salmon quant -i ${index} /
         -l A /
         -1 ${trimmed_read1} /
-        ${meta.library == 'paired_end' ? "-2 ${trimmed_read2}":""} /
+        ${meta.technology == 'paired_end' ? "-2 ${trimmed_read2}":""} /
         -o ${salmon_results} /
         --threads ${task.cpus}
         """
@@ -53,13 +53,13 @@ workflow bulk_quant_rna {
     // a channel with a map of metadata for each rna library to process
     main: 
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
-    bulk_reads_ch = bulk_channel
-      .map{meta -> tuple(meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+        bulk_reads_ch = bulk_channel
+          .map{meta -> tuple(meta,
+                             file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
+                             file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
 
-    fastp(bulk_reads_ch) \
-      | salmon
+        fastp(bulk_reads_ch) \
+          | salmon
     
-    emit: salmon.out
+        emit: salmon.out
 }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -11,17 +11,15 @@ process fastp{
     output: 
         tuple val(meta),path(trimmed_read1),path(trimmed_read2)
     script: 
-        trimmed_read1 = "${params.outdir}/internal/fastp/${meta.library_id}/${meta.run_id}-trimmed-R1.fastq.gz"
-        trimmed_read2 = "${params.outdir}/internal/fastp/${meta.library_id}/${meta.run_id}-trimmed-R2.fastq.gz"
+        trimmed_read1 = "${meta.run_id}-trimmed-R1.fastq.gz"
+        trimmed_read2 = "${meta.run_id}-trimmed-R2.fastq.gz"
         """
-        mkdir -p ${params.outdir}/internal/fastp/${meta.library_id}
-
         fastp --in1 ${read1} \
         ${meta.library == 'paired_end' ? "--in2 ${read2}":""} \
         --out1 "${trimmed_read1} \
         ${meta.library == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
-        --html "${fastp_reports}/${id}_fastp.html" \
-        --json "${fastp_reports}/${id}_fastp.json" \
+        --html "${id}_fastp.html" \
+        --json "${id}_fastp.json" \
         --trim_poly_g \
         --report_title ${meta.library_id}
         """
@@ -32,13 +30,13 @@ process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_8'
     tag "${meta.run_id}-bulk"
-    publishDir "${params.outdir}/internal/${meta.project_id}/${meta.sample_id}"
+    publishDir "${params.outdir}/internal/salmon/${meta.library_id}"
     input: 
         tuple val(meta),path(trimmed_read1),path(trimmed_read2)
     output: 
         tuple val(meta),path(salmon_results)
     script:
-        salmon_results = "${meta.library_id}-salmon"
+        salmon_results = "${meta.run_id}-salmon"
         """
         salmon quant -i ${index} /
         -l A /

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -16,10 +16,10 @@ process fastp{
         """
         fastp --in1 ${read1} \
         ${meta.technology == 'paired_end' ? "--in2 ${read2}":""} \
-        --out1 "${trimmed_read1} \
+        --out1 ${trimmed_read1} \
         ${meta.technology == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
-        --html "${meta.library_id}_fastp.html" \
-        --json "${meta.library_id}_fastp.json" \
+        --html ${meta.library_id}_fastp.html \
+        --json ${meta.library_id}_fastp.json \
         --trim_poly_g \
         --report_title ${meta.library_id}
         """

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -39,7 +39,7 @@ process salmon{
         salmon_results = "${meta.library_id}-salmon"
         """
         salmon quant -i ${params.bulk_index} /
-        -l A /
+        -libType A /
         -1 ${trimmed_read1} /
         ${meta.technology == 'paired_end' ? "-2 ${trimmed_read2}":""} /
         -o ${salmon_results} /

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -18,9 +18,9 @@ process fastp{
         ${meta.technology == 'paired_end' ? "--in2 ${read2}":""} \
         --out1 ${trimmed_read1} \
         ${meta.technology == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
+        --length_required 20 \
         --html ${meta.library_id}_fastp.html \
         --json ${meta.library_id}_fastp.json \
-        --trim_poly_g \
         --report_title ${meta.library_id}
         """
 
@@ -38,11 +38,15 @@ process salmon{
     script:
         salmon_results = "${meta.library_id}-salmon"
         """
-        salmon quant -i ${index} /
+        salmon quant -i ${params.bulk_index} /
         -l A /
         -1 ${trimmed_read1} /
         ${meta.technology == 'paired_end' ? "-2 ${trimmed_read2}":""} /
         -o ${salmon_results} /
+        --validateMappings /
+        --rangeFactorizationBins 4 /
+        --gcBias /
+        --seqBias /
         --threads ${task.cpus}
         """
 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -40,7 +40,7 @@ process salmon{
         salmon_results = "${meta.library_id}-salmon"
         """
         salmon quant -i ${params.bulk_index} /
-        -libType A /
+        --libType A /
         -1 ${trimmed_reads}/${meta.library_id}-trimmed-R1.fastq.gz /
         ${meta.technology == 'paired_end' ? "-2 ${trimmed_reads}/${meta.library_id}-trimmed-R2.fastq.gz":""} /
         -o ${salmon_results} /

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -5,19 +5,20 @@ process fastp{
     container params.FASTP_CONTAINER
     label 'cpus_8'
     tag "${meta.library_id}-bulk"
-    publishDir "${params.outdir}/internal/fastp/${meta.library_id}"
+    publishDir "${params.outdir}/internal/fastp"
     input: 
         tuple val(meta),path(read1), path(read2)
     output: 
-        tuple val(meta),path(trimmed_read1),path(trimmed_read2)
+        tuple val(meta),path(trimmed_reads)
     script: 
-        trimmed_read1 = "${meta.library_id}-trimmed-R1.fastq.gz"
-        trimmed_read2 = "${meta.library_id}-trimmed-R2.fastq.gz"
+        trimmed_reads = "${meta.library_id}"
         """
+        mkdir -p ${meta.library_id}
+
         fastp --in1 ${read1} \
         ${meta.technology == 'paired_end' ? "--in2 ${read2}":""} \
-        --out1 ${trimmed_read1} \
-        ${meta.technology == 'paired_end' ? "--out2 ${trimmed_read2}":""} \
+        --out1 ${trimmed_reads}/${meta.library_id}-trimmed-R1.fastq.gz \
+        ${meta.technology == 'paired_end' ? "--out2 ${trimmed_reads}/${meta.library_id}-trimmed-R2.fastq.gz":""} \
         --length_required 20 \
         --html ${meta.library_id}_fastp.html \
         --json ${meta.library_id}_fastp.json \
@@ -32,7 +33,7 @@ process salmon{
     tag "${meta.library_id}-bulk"
     publishDir "${params.outdir}/internal/salmon/${meta.library_id}"
     input: 
-        tuple val(meta),path(trimmed_read1),path(trimmed_read2)
+        tuple val(meta),path(trimmed_reads)
     output: 
         tuple val(meta),path(salmon_results)
     script:
@@ -40,8 +41,8 @@ process salmon{
         """
         salmon quant -i ${params.bulk_index} /
         -libType A /
-        -1 ${trimmed_read1} /
-        ${meta.technology == 'paired_end' ? "-2 ${trimmed_read2}":""} /
+        -1 ${trimmed_reads}/${meta.library_id}-trimmed-R1.fastq.gz /
+        ${meta.technology == 'paired_end' ? "-2 ${trimmed_reads}/${meta.library_id}-trimmed-R2.fastq.gz":""} /
         -o ${salmon_results} /
         --validateMappings /
         --rangeFactorizationBins 4 /

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ params{
   // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
-  FASTP_CONTAINER = 'quay.io/biocontainers/fastp:v0.20.1_cv1'
+  FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.1'
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params{
   fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
   gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
   index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  bulk_index    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
   mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
   t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
   barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,6 +6,7 @@ params{
   // Docker container images
   SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  FASTP_CONTAINER = 'quay.io/biocontainers/fastp:v0.20.1_cv1'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.0'
 
 


### PR DESCRIPTION
In this PR, I started adding the ability to process bulk RNA sequencing samples to the main workflow. To do this, I first modified the list of allowed tech lists to include the bulk technologies, i.e. single_end and paired_end.

I then created a separate module for the bulk processing that includes running fastp and then salmon. It takes as input the same metadata map that the other modules use and will create a tuple of the metadata adn then the R1 and R2 files. That is then used as input to the fastp process which will output the paths to the trimmed fastq files as a tuple.

Then I am use the trimmed fastq files as input for salmon in a separate process. I was testing this and that's when I had the realization that I needed to use a different index for bulk samples then we are using for the single cell samples, since we don't want the splici index here. So I am filing this as a draft for now and will file the PR with the index as a separate PR stacked on this one.

If people do happen to look at this, the main question that I have is about the options that I chose to use for fastp and salmon and if those are what we would like?

Additionally, is there an alternative approach to dealing with processing both single_end and paired_end samples at the same time? Here, I am passing the path to the folder where the trimmed files live rather than the individual paths to the trimmed R1/R2 files so that it can work with either single-end or paired-end in the same process. I went back and forth on whether or not to separate them somehow, but thought that this would be a good way to approach it.