### PR TITLE
Add process for building cellranger index to build-index.nf

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -83,8 +83,7 @@ process cellranger_index{
     gunzip -c ${gtf} > genome.gtf
     cellranger mkgtf \
       genome.gtf \
-      filtered.gtf \
-      --attribute=gene_biotype:protein_coding
+      filtered.gtf
     
     cellranger mkref \
       --genome=${cellranger_index} \
@@ -98,9 +97,9 @@ process cellranger_index{
 
 workflow {
   // generate splici and spliced cDNA reference fasta
-  generate_reference(params.gtf, params.fasta, params.assembly)
+  //generate_reference(params.gtf, params.fasta, params.assembly)
   // create index using reference fastas
-  salmon_index(generate_reference.out.fasta_files, params.fasta)
+  //salmon_index(generate_reference.out.fasta_files, params.fasta)
   // create cellranger index 
   cellranger_index(params.fasta, params.gtf, params.assembly)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -81,14 +81,11 @@ process cellranger_index{
     """
     gunzip -c ${fasta} > genome.fasta
     gunzip -c ${gtf} > genome.gtf
-    cellranger mkgtf \
-      genome.gtf \
-      filtered.gtf
     
     cellranger mkref \
       --genome=${cellranger_index} \
       --fasta=genome.fasta \
-      --genes=filtered.gtf \
+      --genes=genome.gtf \
       --nthreads=${task.cpus}
     """
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -94,9 +94,9 @@ process cellranger_index{
 
 workflow {
   // generate splici and spliced cDNA reference fasta
-  //generate_reference(params.gtf, params.fasta, params.assembly)
+  generate_reference(params.gtf, params.fasta, params.assembly)
   // create index using reference fastas
-  //salmon_index(generate_reference.out.fasta_files, params.fasta)
+  salmon_index(generate_reference.out.fasta_files, params.fasta)
   // create cellranger index 
   cellranger_index(params.fasta, params.gtf, params.assembly)
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -77,7 +77,7 @@ process cellranger_index{
   output:
     path(cellranger_index)
   script:
-    cellranger_index = "${assembly}_cdna_cellranger"
+    cellranger_index = "${assembly}_cellranger_full"
     """
     gunzip -c ${fasta} > genome.fasta
     gunzip -c ${gtf} > genome.gtf

--- a/build-index.nf
+++ b/build-index.nf
@@ -69,7 +69,7 @@ process salmon_index{
 process cellranger_index{
   container params.CELLRANGER_CONTAINER
   publishDir "${params.ref_dir}/cellranger_index", mode: 'copy'
-  label 'cpus_8'
+  label 'cpus_12'
   input:
     path(fasta)
     path(gtf)

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@ params{
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
   FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
   SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.1'
-
+  CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
 
   // Input data table
   run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,16 +18,17 @@ params{
 
   
   // Assembly, annotation, and index locations
-  assembly = 'Homo_sapiens.GRCh38.104'
-  ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-  fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-  gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-  index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  bulk_index    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
-  mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
-  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
-  t2g_bulk_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
-  barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+  assembly        = 'Homo_sapiens.GRCh38.104'
+  ref_dir         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+  fasta           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+  gtf             = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+  index_path      = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  cellranger_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full'
+  bulk_index      = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
+  mito_file       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
+  t2g_3col_path   = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+  t2g_bulk_path   = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
+  barcode_dir     = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial


### PR DESCRIPTION
Closes #65. This PR adds the `cellranger_index` process to the workflow for building the indices, `build-index.nf` ensuring that when we build all of our indices they will use the same assembly. I followed the same setup that was previously used in generating the cellranger index in [`alsf-scpca/workflows/rnaseq-ref-index/build-cellranger-index.nf`](https://github.com/AlexsLemonade/alsf-scpca/blob/544673eb008843548ac5c8663da65d4732d1f158/workflows/rnaseq-ref-index/build-cellranger-index.nf). 

This was pretty straight forward and I was able to test it and everything ran successfully, producing a new index with ensembl 104. The only question I had was about how we wanted to name this index. I included the assembly name that we use in the splici index and then appended `_cdna_cellranger`, but let me know if there is a different naming convention that would be preferred. 