### PR TITLE
Restructure output files for spatial module

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -37,7 +37,7 @@ process spaceranger{
     mv ${outs_dir}/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
 
     # move over versions file temporarily to be passed to metadata.json
-    mv ${meta.run_id}/_versions ${outs_dir}/spaceranger_versions.json
+    mv ${meta.run_id}/_versions ${spatial_out}/spaceranger_versions.json
 
     """
 }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -14,7 +14,7 @@ process spaceranger{
     tuple val(meta), path(spatial_out)
   script:
     spatial_out = "${meta.library_id}"
-    outs_dir = "${meta.run_id}-spatial/outs"
+    out_id = "${meta.run_id}-spatial"
     """
     spaceranger count \
       --id=${meta.run_id}-spatial \
@@ -31,13 +31,13 @@ process spaceranger{
     mkdir ${spatial_out}
 
     # move over needed files to outs directory 
-    mv ${outs_dir}/filtered_feature_bc_matrix ${spatial_out}
-    mv ${outs_dir}/raw_feature_bc_matrix ${spatial_out}
-    mv ${outs_dir}/spatial ${spatial_out}
-    mv ${outs_dir}/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
+    mv ${out_id}/outs/filtered_feature_bc_matrix ${spatial_out}
+    mv ${out_id}/outs/raw_feature_bc_matrix ${spatial_out}
+    mv ${out_id}/outs/spatial ${spatial_out}
+    mv ${out_id}/outs/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
 
     # move over versions file temporarily to be passed to metadata.json
-    mv ${meta.run_id}-spatial/_versions ${spatial_out}/spaceranger_versions.json
+    mv ${out_id}/_versions ${spatial_out}/spaceranger_versions.json
 
     """
 }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -14,10 +14,10 @@ process spaceranger{
     tuple val(meta), path(spatial_out)
   script:
     spatial_out = "${meta.library_id}"
-    outs_dir = "${meta.run_id}/outs"
+    outs_dir = "${meta.run_id}-spatial/outs"
     """
     spaceranger count \
-      --id=${meta.run_id} \
+      --id=${meta.run_id}-spatial \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -17,7 +17,7 @@ process spaceranger{
     out_id = "${meta.run_id}-spatial"
     """
     spaceranger count \
-      --id=${meta.run_id}-spatial \
+      --id=${out_id} \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl=2
 
 process spaceranger{
   container params.SPACERANGER_CONTAINER
-  publishDir "${params.outdir}/internal/spaceranger/${meta.library_id}"
+  publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   tag "${meta.run_id}-spatial" 
   label 'cpus_12'
   label 'bigdisk'
@@ -11,12 +11,13 @@ process spaceranger{
     tuple val(meta), path(fastq_dir), file(image_file)
     path index
   output:
-    tuple val(meta), path(outs_dir)
+    tuple val(meta), path(spatial_out)
   script:
-    outs_dir = "${meta.run_id}-spatial/outs"
+    spatial_out = "${meta.library_id}"
+    outs_dir = "${meta.run_id}/outs"
     """
     spaceranger count \
-      --id=${meta.run_id}-spatial \
+      --id=${meta.run_id} \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \
@@ -24,13 +25,19 @@ process spaceranger{
       --localmem=${task.memory.toGiga()} \
       --image=${image_file} \
       --slide=${meta.slide_serial_number} \
-      --area=${meta.slide_section}
+      --area=${meta.slide_section} 
 
-    # remove bam files 
-    rm ${outs_dir}/*.bam && rm ${outs_dir}/*.bam.bai
+    # make a new directory to hold only the outs file we want to publish 
+    mkdir ${spatial_out}
 
-    # copy over needed files to outs directory 
-    mv ${meta.run_id}-spatial/_versions ${outs_dir}/spaceranger_versions.json
+    # move over needed files to outs directory 
+    mv ${outs_dir}/filtered_feature_barcode_bc_matrix ${spatial_out}
+    mv ${outs_dir}/raw_feature_bc_matrix ${spatial_out}
+    mv ${outs_dir}/spatial ${spatial_out}
+    mv ${outs_dir}/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
+
+    # move over versions file temporarily to be passed to metadata.json
+    mv ${meta.run_id}/_versions ${outs_dir}/spaceranger_versions.json
 
     """
 }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -37,7 +37,7 @@ process spaceranger{
     mv ${outs_dir}/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
 
     # move over versions file temporarily to be passed to metadata.json
-    mv ${meta.run_id}/_versions ${spatial_out}/spaceranger_versions.json
+    mv ${meta.run_id}-spatial/_versions ${spatial_out}/spaceranger_versions.json
 
     """
 }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -31,7 +31,7 @@ process spaceranger{
     mkdir ${spatial_out}
 
     # move over needed files to outs directory 
-    mv ${outs_dir}/filtered_feature_barcode_bc_matrix ${spatial_out}
+    mv ${outs_dir}/filtered_feature_bc_matrix ${spatial_out}
     mv ${outs_dir}/raw_feature_bc_matrix ${spatial_out}
     mv ${outs_dir}/spatial ${spatial_out}
     mv ${outs_dir}/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,16 +19,17 @@ params{
 
   
   // Assembly, annotation, and index locations
-  assembly = 'Homo_sapiens.GRCh38.104'
-  ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-  fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-  gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-  index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  bulk_index    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
-  mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
-  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
-  t2g_bulk_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
-  barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+  assembly         = 'Homo_sapiens.GRCh38.104'
+  ref_dir          = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+  fasta            = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+  gtf              = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+  index_path       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  bulk_index       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
+  cellranger_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full'
+  mito_file        = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
+  t2g_3col_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+  t2g_bulk_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
+  barcode_dir      = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial


### PR DESCRIPTION
Closes #71. Here I am modifying the workflow for quantifying spatial data to publish only the desired output files in the structure that was discussed in https://github.com/AlexsLemonade/scpca-nf/issues/68#issuecomment-998940420. 

Here, the approach that I took was to move the desired files from the output of spaceranger to a new folder that is named by the library ID and then publish only that folder and it's contents, rather than publishing the entirety of the spaceranger output folder. Right now the way I have it set up is to perform both `spaceranger count` and then the file moving within the same process before only publishing the desired files. An alternative approach would be to keep the spaceranger output folder intact (other than removing the bam files) and publishing it to the `internal` folder as we were doing previously and then create a separate process to copy over the desired files, but that seemed like over kill and I don't believe there's any reason to keep the other intermediate files. 

One thing to note is that I am keeping the `_versions` file and copying it over as `spaceranger_versions.json` for now as I believe we will want to add a secondary process that grabs the version information and adds the associated metadata to create a `metadata.json` file. In doing that we will need this versions file to be saved in our output. 

The last step that is still missing is the actual compression of the output files. I was unsure if we wanted to compress all files together or keep out the json and/or html files. Until we resolve that, and are sure about our output structure, I am keeping this in draft form. 

** I also noticed that in the last merge somehow the `cellranger_index` did not get merged in to the main config file so I am adding that in here as well as the workflow fails without it. 