### PR TITLE
Adjust memory requirements for alevin rad process

### DIFF
--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -3,8 +3,7 @@
 // generates RAD file using alevin
 process alevin_rad{
   container params.SALMON_CONTAINER
-  label 'cpus_12'
-  label 'bigdisk'
+  label 'dynamic_disk'
   tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -4,7 +4,7 @@
 process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
-  label 'dynamic_disk'
+  label 'disk_dynamic'
   tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -3,6 +3,7 @@
 // generates RAD file using alevin
 process alevin_rad{
   container params.SALMON_CONTAINER
+  label 'cpus_12'
   label 'dynamic_disk'
   tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/internal/rad/${meta.library_id}"

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -4,6 +4,7 @@
 process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
+  label 'bigdisk'
   tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -6,7 +6,7 @@ process spaceranger{
   publishDir "${params.outdir}/internal/spaceranger/${meta.library_id}"
   tag "${meta.run_id}-spatial" 
   label 'cpus_12'
-  label 'bigdisk'
+  label 'disk_big'
   input:
     tuple val(meta), path(fastq_dir), file(image_file)
     path index

--- a/nextflow.config
+++ b/nextflow.config
@@ -75,8 +75,6 @@ profiles{
         queue = 'nextflow-batch-bigdisk-queue'
       }
       withLabel: dynamic_disk {
-        cpus = 12
-        memory = { 24.GB * task.attempt }
         queue = { task.attempt < 2 ? 'nextflow-batch-default-queue' : 'nextflow-batch-bigdisk-queue'}
       }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,10 +71,10 @@ profiles{
         cpus = 8
         memory = { 16.GB * task.attempt}
       }
-      withLabel: bigdisk {
+      withLabel: disk_big {
         queue = 'nextflow-batch-bigdisk-queue'
       }
-      withLabel: dynamic_disk {
+      withLabel: disk_dynamic {
         queue = { task.attempt < 2 ? 'nextflow-batch-default-queue' : 'nextflow-batch-bigdisk-queue'}
       }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,7 +64,7 @@ profiles{
       }
       withLabel: cpus_12 {
         cpus = 12
-        memory = { 24.GB * task.attempt}
+        memory = { 28.GB * task.attempt}
       }
       withLabel: cpus_8 {
         cpus = 8

--- a/nextflow.config
+++ b/nextflow.config
@@ -65,7 +65,7 @@ profiles{
       }
       withLabel: cpus_12 {
         cpus = 12
-        memory = { 28.GB * task.attempt}
+        memory = { 64.GB * task.attempt}
       }
       withLabel: cpus_8 {
         cpus = 8

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,16 +19,17 @@ params{
 
   
   // Assembly, annotation, and index locations
-  assembly = 'Homo_sapiens.GRCh38.104'
-  ref_dir       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
-  fasta         = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-  gtf           = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
-  index_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
-  bulk_index    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
-  mito_file     = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
-  t2g_3col_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
-  t2g_bulk_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
-  barcode_dir   = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+  assembly         = 'Homo_sapiens.GRCh38.104'
+  ref_dir          = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+  fasta            = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+  gtf              = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+  index_path       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome'
+  cellranger_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full'
+  bulk_index       = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome'
+  mito_file        = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
+  t2g_3col_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
+  t2g_bulk_path    = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv'
+  barcode_dir      = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
  
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial

--- a/nextflow.config
+++ b/nextflow.config
@@ -65,7 +65,7 @@ profiles{
       }
       withLabel: cpus_12 {
         cpus = 12
-        memory = { 64.GB * task.attempt}
+        memory = { 24.GB * task.attempt}
       }
       withLabel: cpus_8 {
         cpus = 8
@@ -73,6 +73,11 @@ profiles{
       }
       withLabel: bigdisk {
         queue = 'nextflow-batch-bigdisk-queue'
+      }
+      withLabel: dynamic_disk {
+        cpus = 12
+        memory = { 24.GB * task.attempt }
+        queue = { task.attempt < 2 ? 'nextflow-batch-default-queue' : 'nextflow-batch-bigdisk-queue'}
       }
     }
   }


### PR DESCRIPTION
In processing the Mullighan samples, there was one sample in particular with FASTQ files totaling 116 GB in size. Previously we had been using the default queue on batch which was not big enough to hold these files and the only way to successfully process this sample (or any other sample with FASTQ files this large) is to use the `bigdisk` queue. 

However, we do not want to use the `bigdisk` queue for all of the samples, so I have added a new label that uses the default queue on the first task attempt and then the `bigdisk` queue on the second task attempt. I have tested this and it works successfully for the Mullighan sample that had issues previously and switches to the `bigdisk` queue on the second attempt. 

Additionally, the `cellranger_index` was left out of the params previously and an error had been thrown so I added that in here so that the workflow would run successfully. 