### PR TITLE
Add process to export metadata.json for spatial libraries

### DIFF
--- a/bin/generate_spaceranger_metadata.R
+++ b/bin/generate_spaceranger_metadata.R
@@ -99,7 +99,7 @@ if(is.null(opt$sample_id)){
 }
 
 # check that barcode files exist
-if(is.null(opt$unfiltered_barcodes_file) || !dir.exists(opt$unfiltered_barcodes_file)){
+if(is.null(opt$unfiltered_barcodes_file) || !file.exists(opt$unfiltered_barcodes_file)){
   stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
 }
 if(is.null(opt$filtered_barcodes_file) || !file.exists(opt$filtered_barcodes_file)){

--- a/bin/generate_spaceranger_metadata.R
+++ b/bin/generate_spaceranger_metadata.R
@@ -1,0 +1,161 @@
+#!/usr/bin/env Rscript
+
+# This script generates the metadata.json file for Spatial Transcriptomics libraries. 
+
+# import libraries
+library(optparse)
+suppressPackageStartupMessages(library(SingleCellExperiment))
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("-l", "--library_id"),
+    type = "character",
+    help = "Library identifier for report and metadata file"
+  ),
+  make_option(
+    opt_str = c("-s", "--sample_id"),
+    type = "character",
+    help = "Sample identifier for metadata file"
+  ),
+  make_option(
+    opt_str = c("-u", "--unfiltered_barcodes_file"),
+    type = "character",
+    help = "path to file containing list of all spot barcodes identified in library with no filtering"
+  ),
+  make_option(
+    opt_str = c("-f", "--filtered_barcodes_file"),
+    type = "character",
+    help = "path to file containing list of spot barcodes identified in library after filtering"
+  ),
+  make_option(
+    opt_str = c("--metrics_summary_file"),
+    type = "character",
+    help = "path to file containing summary of run metrics from spaceranger count, the metrics_summary.csv file output by spaceranger count"
+  ),
+  make_option(
+    opt_str = c("--spaceranger_versions_file"),
+    type = "character",
+    help = "path to json file containing spaceranger version information, the _versions file output by spaceranger count"
+  ),
+  make_option(
+    opt_str = "--metadata_json",
+    default = "metadata.json",
+    type = "character",
+    help = "path to metadata json output file"
+  ),
+  make_option(
+    opt_str = "--technology",
+    type = "character",
+    default = NA,
+    help = "sequencing technology"
+  ),
+  make_option(
+    opt_str = "--seq_unit",
+    type = "character",
+    default = NA,
+    help = "sequencing unit"
+  ),
+  make_option(
+    opt_str = "--genome_assembly",
+    type = "character",
+    default = NA,
+    help = "genome assembly used for mapping"
+  ),
+  make_option(
+    opt_str = "--index_path",
+    type = "character",
+    default = NA,
+    help = "path to index used for mapping"
+  ),
+  make_option(
+    opt_str = "--workflow_url",
+    type = "character",
+    default = NA,
+    help = "workflow github url"
+  ),
+  make_option(
+    opt_str = "--workflow_version",
+    type = "character",
+    default = NA,
+    help = "workflow version identifier"
+  ),
+  make_option(
+    opt_str = "--workflow_commit",
+    type = "character",
+    default = NA,
+    help = "workflow commit hash"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+if(is.null(opt$library_id)){
+  stop("A `library_id` is required.")
+}
+# check that barcode files exist
+if(is.null(opt$unfiltered_barcodes_file) || !dir.exists(opt$unfiltered_barcodes_file)){
+  stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
+}
+if(is.null(opt$filtered_barcodes_file) || !file.exists(opt$filtered_barcodes_file)){
+  stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
+}
+
+# check that metrics summary file exists 
+if(is.null(opt$metrics_summary_file) || !file.exists(opt$metrics_summary_file)){
+  stop("Metrics summary file missing or `metrics_summary_file` not specified.")
+}
+
+# check that version file exists
+if(is.null(opt$spaceranger_versions_file) || !file.exists(opt$spaceranger_versions_file)){
+  stop("Versions file missing or `spaceranger_versions_file` not specified.")
+}
+
+if (opt$workflow_url == "null"){
+  opt$workflow_url <- NA
+}
+if (opt$workflow_version == "null"){
+  opt$workflow_version <- NA
+}
+if (opt$workflow_commit == "null"){
+  opt$workflow_commit <- NA
+}
+
+# read in barcode files
+unfiltered_barcodes <- readr::read_tsv(opt$unfiltered_barcodes_file,
+                                       col_names = c("barcode"))
+filtered_barcodes <- readr::read_tsv(opt$filtered_barcodes_file,
+                                     col_names = c("barcode"))
+
+# read in metrics summary 
+metrics_summary <- readr::read_csv(opt$metrics_summary_file)
+
+# read in versions file 
+spaceranger_versions <- jsonlite::read_json(opt$spaceranger_versions_file)
+
+# obtain just the index name and drop the rest of the path 
+index_name <- basename(opt$index_path)
+
+# compile metadata list 
+metadata_list <- list(
+  library_id = opt$library_id,
+  sample_id = opt$sample_id,
+  technology = opt$technology,
+  seq_unit = opt$seq_unit,
+  filtered_spots = nrow(filtered_barcodes),
+  unfiltered_spots = nrow(unfiltered_barcodes),
+  total_reads = metrics_summary$`Number of Reads`,
+  mapped_reads = metrics_summary$`Reads Mapped Confidently to Genome`,
+  tissue_spots = metrics_summary$`Number of Spots Under Tissue`,
+  genome_assembly = opt$genome_assembly,
+  mapping_index = index_name,
+  date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
+  spaceranger_version = spaceranger_versions$pipelines,
+  workflow = opt$workflow_url,
+  workflow_version = opt$workflow_version,
+  workflow_commit = opt$workflow_commit
+) |>
+  purrr::map(~if(is.null(.)) NA else .) # convert any NULLS to NA
+
+# Output metadata as JSON
+jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
+

--- a/bin/generate_spaceranger_metadata.R
+++ b/bin/generate_spaceranger_metadata.R
@@ -63,10 +63,10 @@ option_list <- list(
     help = "genome assembly used for mapping"
   ),
   make_option(
-    opt_str = "--index_path",
+    opt_str = "--index_filename",
     type = "character",
     default = NA,
-    help = "path to index used for mapping"
+    help = "filename for index used for mapping"
   ),
   make_option(
     opt_str = "--workflow_url",
@@ -139,9 +139,6 @@ metrics_summary <- readr::read_csv(opt$metrics_summary_file)
 # read in versions file 
 spaceranger_versions <- jsonlite::read_json(opt$spaceranger_versions_file)
 
-# obtain just the index name and drop the rest of the path 
-index_name <- basename(opt$index_path)
-
 # compile metadata list 
 metadata_list <- list(
   library_id = opt$library_id,
@@ -154,7 +151,7 @@ metadata_list <- list(
   mapped_reads = metrics_summary$`Reads Mapped Confidently to Genome`,
   tissue_spots = metrics_summary$`Number of Spots Under Tissue`,
   genome_assembly = opt$genome_assembly,
-  mapping_index = index_name,
+  mapping_index = opt$index_filename,
   date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
   spaceranger_version = spaceranger_versions$pipelines,
   workflow = opt$workflow_url,

--- a/bin/generate_spaceranger_metadata.R
+++ b/bin/generate_spaceranger_metadata.R
@@ -89,15 +89,21 @@ option_list <- list(
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
+
+# check for sample and library id
 if(is.null(opt$library_id)){
   stop("A `library_id` is required.")
 }
+if(is.null(opt$sample_id)){
+  stop("A `sample_id` is required.")
+}
+
 # check that barcode files exist
 if(is.null(opt$unfiltered_barcodes_file) || !dir.exists(opt$unfiltered_barcodes_file)){
   stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
 }
 if(is.null(opt$filtered_barcodes_file) || !file.exists(opt$filtered_barcodes_file)){
-  stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
+  stop("Filtered barcodes file missing or `filtered_barcodes_file` not specified.")
 }
 
 # check that metrics summary file exists 
@@ -110,6 +116,7 @@ if(is.null(opt$spaceranger_versions_file) || !file.exists(opt$spaceranger_versio
   stop("Versions file missing or `spaceranger_versions_file` not specified.")
 }
 
+# replace workflow url and commit if not provided
 if (opt$workflow_url == "null"){
   opt$workflow_url <- NA
 }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -65,7 +65,7 @@ process spaceranger_metadata{
       --technology ${meta.technology} \
       --seq_unit ${meta.seq_unit} \
       --genome_assembly ${params.assembly} \
-      --index_path ${meta.cellranger_index} \
+      --index_filename ${meta.cellranger_index} \
       --workflow_url "${workflow_url}" \
       --workflow_version "${workflow.revision}" \
       --workflow_commit "${workflow.commitId}"

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -43,7 +43,7 @@ process spaceranger{
     """
 }
 
-process make_metadata{
+process spaceranger_metadata{
   container params.SCPCATOOLS_CONTAINER
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -44,7 +44,7 @@ process spaceranger{
 }
 
 process make_metadata{
-  container SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_CONTAINER
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -15,11 +15,11 @@ process spaceranger{
   script:
     spatial_out = "${meta.library_id}"
     outs_dir = "${meta.run_id}-spatial/outs"
-    meta.cellranger_index = "${index}"
+    meta.cellranger_index = index.fileName
     """
     spaceranger count \
       --id=${meta.run_id}-spatial \
-      --transcriptome=${meta.cellranger_index} \
+      --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \
       --localcores=${task.cpus} \

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -39,7 +39,9 @@ process spaceranger{
 
     # move over versions file temporarily to be passed to metadata.json
     mv ${out_id}/_versions ${spatial_out}/spaceranger_versions.json
-    mv ${outs_dir}/metrics_summary.csv ${spatial_out}/spaceranger_metrics_summary.csv
+    mv ${out_id}/outs/metrics_summary.csv ${spatial_out}/spaceranger_metrics_summary.csv
+    """
+}
 
 process spaceranger_metadata{
   container params.SCPCATOOLS_CONTAINER


### PR DESCRIPTION
Stacked on #72. 

This PR adds another process to the spatial workflow to create a `library_id_metadata.json` for spatial libraries, similar to the `json` file we create for single-cell/single-nuclei libraries. After quantifying the spatial libraries using Spaceranger, the metadata and directory containing the quantified output are passed to a process to generate a `metadata.json` file.  Inside that process, an Rscript to read in the specifics about each library and write them out in `json` format is run. 

In general, this follows a similar format to creating the other `metadata.json `which is done inside the `sce_qc_report.R` script. The main differences are as follows: 

- Here we do not have `RDS` files that contain the output, but only the direct output files from spaceranger. In order to get the number of filtered and unfiltered spots, I am reading in the `filtered_feature_bc_matrix/barcodes.tsv.gz` and `raw_feature_bc_matrix/barcodes.tsv.gz` and obtaining the number of rows, corresponding to the number of spot barcodes identified. 
- Previously, we had been storing metadata inside of the SCE object and grabbing some of the metadata from that object (like the number of reads), but here we do not have an SCE object. To get the number of reads, there is a `metrics_summary.csv` file that is output by spaceranger. I added that to be included in the spaceranger process and then am reading that in as part of the Rscript and grabbing the desired stats. [You can find the table of all metrics included in that summary on the 10X website](https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/gex-metrics). I included total reads and total reads mapped confidently to genome, are there any additional metrics that you think we should include here? 
- The name of the index with Alevin-fry was previously obtained from one of the log files output by Alevin-fry. It doesn't appear that can be identified from a log file here, so to get the index name I am reading in the entire path and then using the `basename()` function to grab just the index name. Let me know if you think there is a better approach to doing this.
- To obtain the version of spaceranger, I am grabbing that from the `_versions` file from spaceranger count (which we have renamed as `spaceranger_versions.json`. In that file there is also a martian version. Do we want to also include that here? 

The only other question I had for reviewers was if there were additional things that should be output as part of the `metadata.json` file or things you think are unnecessary and should be removed? 

This is currently being tested, which takes a long time, but will add any updates based on if things run successfully. 