### PR TITLE
Allow for skipping of `salmon alevin` process and proceed directly to alevin-fry quantification

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,13 +1,6 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-// run_ids are comma separated list to be parsed into 
-// a list of run ids, library ids, and or sample_ids
-// or "All" to process all samples in the metadata file
-params.run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
-// to run all samples in a project use that project's submitter name
-params.project = ""
-
 // 10X barcode files
 cell_barcodes = [
   '10Xv2': '737K-august-2016.txt',

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -31,7 +31,7 @@ process alevin_rad{
       -1 ${read1} \
       -2 ${read2} \
       -i ${index} \
-      -o ${run_dir} \
+      -o ${rad_dir} \
       -p ${task.cpus} \
       --dumpFeatures \
       --rad

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -113,7 +113,7 @@ workflow map_quant_rna {
 
     // combine ouput from running alevin step with channel containing libraries that skipped creating a RAD file 
     all_rad_ch = alevin_rad.out.mix(rna_rad_ch)
-      .map{it.toList() + it[0].barcode_file} // add barcode file to channel to use in fry_quant_rna process
+      .map{it.toList() << file(it[0].barcode_file)} // add barcode file to channel to use in fry_quant_rna process
 
     // quantify with alevin-fry
     fry_quant_rna(all_rad_ch, params.t2g_3col_path)

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,6 +9,13 @@ params {
   // Output base directory
   outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
+  // run_ids are comma separated list to be parsed into 
+  // a list of run ids, library ids, and or sample_ids
+  // or "All" to process all samples in the metadata file
+  params.run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
+  // to run all samples in a project use that project's submitter name
+  params.project = ""
+
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   seed = 2021   // random number seed for filtering (0 means use system seed)

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   seed = 2021   // random number seed for filtering (0 means use system seed)
+  rad_skip = true
 
   // Docker container images
   includeConfig 'config/containers.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,14 +12,14 @@ params {
   // run_ids are comma separated list to be parsed into 
   // a list of run ids, library ids, and or sample_ids
   // or "All" to process all samples in the metadata file
-  params.run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
+  run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
   // to run all samples in a project use that project's submitter name
-  params.project = ""
+  project = ""
 
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  rad_skip = true // if alevin mapping has already been performed and a rad file exists, use that.
   seed = 2021   // random number seed for filtering (0 means use system seed)
-  rad_skip = true
 
   // Docker container images
   includeConfig 'config/containers.config'


### PR DESCRIPTION
Closes #41. This PR, adds in flexibility to the workflow to skip the first step of running `salmon alevin` in cases where the RAD file already exists and a new parameter, `rad_skip` is set to true. 

Here we are specifically only skipping the first step in the `af-rna.nf` module as this is the step that is the most costly in both time and memory. This update will enable us to re-run samples that have already been processed and incorporate changes in the later parts of the workflow, such as the filtering steps, or future changes to the QC report, without having to re-run the mapping step. 

To do this, we first add the paths to the rad directory to the meta object. Then we create two channels within the `map_quant_rna` workflow. The first channel includes libraries that are missing the rad directory and then becomes the input to the `alevin_rad` process. The second channel contains libraries that already have a rad directory, and becomes the input to the next step, `fry_quant_rna`. We then combine these two channels, pull out the `barcode_file` to create a tuple of `[barcode_file, rad_dir, meta]` to be used as input to `fry_quant_rna`. 

A few things to note. The first is that in order to properly combine the output channel from `alevin_rad` with the `rna_rad_ch`, I had to rename the output of the process as `rad_dir` to match with how we had named it in the meta. I could rename everything here, `run_dir`, but I thought `rad_dir` was a better fit for everything related to looking for the rad files and then I am still using `run_dir` for the downstream `fry_quant_rna` process. 

I also am not quite sure why, but nextflow didn't like `.map{it + [it[0].barcode_file]}` to pull out the barcode file, but preferred `.map{[it[0].barcode_file] + it}`. So I changed it to have the barcode file as the first item in the tuple and it stopped complaining. 

I tested the workflow and everything worked as plan, skipping the RAD step and taking only 7 minutes to process a single RNA sample! 

We also added here the parameter, `rad_skip` which I set to true. By having this parameter here, we can force the rad step to still run and set it to false at the command line by using `--rad_skip false`. I tested this out and when set to false it no longer skips the `alevin_rad` step as planned. 
Also when adding in this parameter, I moved all of the other remaining parameters to the main configuration file rather than keeping some of them within `main.nf`. 