### PR TITLE
Remove explicit dependence on S3

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -55,7 +55,7 @@ workflow {
       seq_unit: it.seq_unit,
       feature_barcode_file: it.feature_barcode_file,
       feature_barcode_geom: it.feature_barcode_geom,
-      s3_prefix: it.s3_prefix,
+      files_directory: it.files_directory,
       slide_serial_number: it.slide_serial_number,
       slide_section: it.slide_section,
       files: it.files

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -116,8 +116,8 @@ workflow map_quant_feature{
     feature_reads_ch = feature_channel
       .map{meta -> tuple(meta.feature_barcode_file,
                          meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz")
+                         file("${meta.files_directory}/*_R1_*.fastq.gz"),
+                         file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
       .combine(index_feature.out, by: 0) // combine by the feature_barcode_file
       .map{ it.subList(1, it.size())} // remove the first element (feature_barcode_file)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -107,7 +107,7 @@ workflow map_quant_feature{
     //get and map the feature barcode files
     feature_barcodes_ch = feature_channel
       .map{meta -> tuple(meta.feature_barcode_file,
-                         file("s3://${meta.feature_barcode_file}"))}
+                         file("${meta.feature_barcode_file}"))}
       .unique()
     index_feature(feature_barcodes_ch)
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -97,8 +97,8 @@ workflow map_quant_rna {
     // If We need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])   
     rna_reads_ch = rna_channel.make_rad
       .map{meta -> tuple(meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz")
+                         file("${meta.files_directory}/*_R1_*.fastq.gz"),
+                         file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
 
     // if the rad directory has been created and rad_skip is set to true

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -77,8 +77,8 @@ workflow bulk_quant_rna {
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
         bulk_reads_ch = bulk_channel
           .map{meta -> tuple(meta,
-                             file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                             file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+                             file("${meta.files_directory}/*_R1_*.fastq.gz"),
+                             file("${meta.files_directory}/*_R2_*.fastq.gz"))}
 
         fastp(bulk_reads_ch)
         salmon(fastp.out, params.bulk_index)

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -99,8 +99,8 @@ workflow spaceranger_quant{
           .map{it.cr_samples =  getCRsamples(it.files); it}
           // create tuple of [metadata, fastq dir, and path to image file]
           .map{meta -> tuple(meta,
-                            file("s3://${meta.s3_prefix}"),
-                            file("s3://${meta.s3_prefix}/*.jpg")
+                            file("${meta.files_directory}"),
+                            file("${meta.files_directory}/*.jpg")
                             )}
 
         // run spaceranger


### PR DESCRIPTION
This PR follows https://github.com/AlexsLemonade/ScPCA-admin/pull/299 to make the changes to the nf workflow to remove explicit dependence on s3.

Closes #78

I think I got everything, and I tested using the libarary info file from https://github.com/AlexsLemonade/ScPCA-admin/pull/299 to make sure there were not immediate errors, using samples from bulk, single cell and spatial to test all parts of the workflow. I did not wait for final success on some (looking at spaceranger), but all types started fine, so I believe that all paths were created as expected.