### PR TITLE
Add process to generate bulk metadata file for each project 

### DIFF
--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -1,0 +1,134 @@
+#!/usr/bin/env Rscript
+
+# This script generates the metadata.tsv file for bulk RNA-seq libraries.
+# It outputs one metadata file per project.
+
+# import libraries
+library(optparse)
+suppressPackageStartupMessages(library(SingleCellExperiment))
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("-p", "--project_id"),
+    type = "character",
+    help = "scpca project ID",
+  ),
+  make_option(
+    opt_str = c("-s", "--salmon_dirs"),
+    type = "character",
+    help = "Path to text file containing salmon output directories, one per line."
+  ),
+  make_option(
+    opt_str = c("--library_metadata_file"),
+    type = "character",
+    help = "path to metadata file containing scpca_library_id, scpca_sample_id and associated metadata"
+  ),
+  make_option(
+    opt_str = "--metadata_output",
+    default = "metadata.tsv",
+    type = "character",
+    help = "path to metadata tsv output file"
+  ),
+  make_option(
+    opt_str = "--genome_assembly",
+    type = "character",
+    default = NA,
+    help = "genome assembly used for mapping"
+  ),
+  make_option(
+    opt_str = "--workflow_url",
+    type = "character",
+    default = NA,
+    help = "workflow github url"
+  ),
+  make_option(
+    opt_str = "--workflow_version",
+    type = "character",
+    default = NA,
+    help = "workflow version identifier"
+  ),
+  make_option(
+    opt_str = "--workflow_commit",
+    type = "character",
+    default = NA,
+    help = "workflow commit hash"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# checks 
+
+# check for project id
+if(is.null(opt$project_id)){
+  stop("A `project_id` is required.")
+}
+
+
+# replace workflow url and commit if not provided
+if (is.null(opt$workflow_url)){
+  opt$workflow_url <- NA
+}
+if (is.null(opt$workflow_version)){
+  opt$workflow_version <- NA
+}
+if (is.null(opt$workflow_commit)){
+  opt$workflow_commit <- NA
+}
+
+# read in library metadata file 
+library_metadata <- readr::read_tsv(opt$library_metadata_file)
+
+# list of paths to salmon log files 
+library_ids <- readLines(opt$salmon_dirs)
+
+# subset library metadata to only contain libraries that are being processed 
+# only keep metadata columns of interest 
+bulk_metadata_df <- library_metadata |>
+  dplyr::filter(scpca_library_id %in% library_ids &
+                scpca_project_id %in% opt$project_id) |>
+  dplyr::select(scpca_sample_id, scpca_library_id, scpca_project_id,
+                technology, seq_unit) |> 
+  # rename column names to match format of metadata files from other modalities
+  dplyr::rename(
+    sample_id = scpca_sample_id,
+    library_id = scpca_library_id,
+    project_id = scpca_project_id
+  ) |>
+  # add columns with processing information and date processed (same for all libraries )
+  dplyr::mutate(date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
+                genome_assembly = opt$genome_assembly, 
+                workflow = opt$workflow_url,
+                workflow_version = opt$workflow_version,
+                workflow_commit = opt$workflow_commit)
+
+
+# add salmon version, index, total_reads, mapped_reads for each library 
+add_processing_info <- function(library_id) {
+  
+  # read in json files for that library containing individual process information
+  cmd_info_file <- file.path(library_id, "cmd_info.json")
+  meta_info_file <- file.path(library_id, "aux_info", "meta_info.json")
+  
+  cmd_info <- jsonlite::read_json(cmd_info_file)
+  meta_info <- jsonlite::read_json(meta_info_file)
+  
+  library_processing <- data.frame(
+    library_id = library_id,
+    salmon_version = cmd_info$salmon_version,
+    mapping_index = cmd_info$index,
+    total_reads = meta_info$num_processed,
+    mapped_reads = meta_info$num_mapped
+  )
+  
+}
+
+bulk_processing_metadata <- purrr::map(library_ids, add_processing_info) |>
+  dplyr::bind_rows()
+
+bulk_metadata_df <- bulk_metadata_df |>
+  dplyr::left_join(bulk_processing_metadata, by = c("library_id"))
+
+# write out file 
+readr::write_tsv(bulk_metadata_df, file = opt$metadata_output)

--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -58,8 +58,6 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list = option_list))
 
-# checks 
-
 # check for project id
 if(is.null(opt$project_id)){
   stop("A `project_id` is required.")

--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -95,15 +95,14 @@ bulk_metadata_df <- library_metadata |>
     project_id = scpca_project_id
   ) |>
   # add columns with processing information and date processed (same for all libraries )
-  dplyr::mutate(date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
-                genome_assembly = opt$genome_assembly, 
+  dplyr::mutate(genome_assembly = opt$genome_assembly, 
                 workflow = opt$workflow_url,
                 workflow_version = opt$workflow_version,
                 workflow_commit = opt$workflow_commit)
 
 
 # add salmon version, index, total_reads, mapped_reads for each library 
-add_processing_info <- function(library_id) {
+get_processing_info <- function(library_id) {
   
   # read in json files for that library containing individual process information
   cmd_info_file <- file.path(library_id, "cmd_info.json")
@@ -122,8 +121,7 @@ add_processing_info <- function(library_id) {
   
 }
 
-bulk_processing_metadata <- purrr::map(library_ids, add_processing_info) |>
-  dplyr::bind_rows()
+bulk_processing_metadata <- purrr::map_dfr(library_ids, add_processing_info) 
 
 bulk_metadata_df <- bulk_metadata_df |>
   dplyr::left_join(bulk_processing_metadata, by = c("library_id"))

--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -112,7 +112,7 @@ get_processing_info <- function(library_id) {
   meta_info <- jsonlite::read_json(meta_info_file)
   
   date_processed <- lubridate::as_datetime(meta_info$end_time, 
-                                           format = "%a %b %d %T %Y")
+                                           format = "%a %b %d %T %Y") // salmon date format: like "Mon Jan 03 15:13:14 2022"
   # if meta_info is not recorded or the format has changed, use the modification time of the file
   if (is.na(date_processed)){
     date_processed <- file.info(meta_info_file)$mtime

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -49,7 +49,7 @@ process salmon{
 
 }
 
-process group_output {
+process merge_bulk_quants {
     container params.SCPCATOOLS_CONTAINER
     publishDir "${params.outdir}/publish/${project_id}"
     input:
@@ -103,9 +103,8 @@ workflow bulk_quant_rna {
             .groupTuple(by: 0)
 
         // create tsv file and combined metadata for each project containing all libraries
-        group_output(grouped_salmon_ch, params.t2g_bulk_path, params.run_metafile)
+        merge_bulk_quants(grouped_salmon_ch, params.t2g_bulk_path, params.run_metafile)
 
     emit: 
-        bulk_counts = group_output.out.bulk_counts
-        bulk_metadata = group_output.out.bulk_metadata
+        merge_bulk_quants.out
 }


### PR DESCRIPTION
This PR adds a process to the bulk workflow to generate one metadata file containing information about each bulk library that has been processed in that project. This results in one `bulk_quant.tsv` and one matching `bulk_metadata.tsv` where the rows of `bulk_metadata.tsv` contain the library ID's that are present in the columns of `bulk_quant.tsv`. 

To do this, I used the same grouped salmon channel that we group by project ID after performing mapping with salmon. This contains the project ID and all associated directories to salmon outputs for that project. I also am inputting the metadata file that contains the metadata information for each library like seq unit and technology. 

Inside the process I am running an Rscript that reads in the library metadata file and list of salmon directories, subsets the library metadata file to only those library ids that have been processed and are part of this project and selects the metadata columns that we would like to retain in the output. I then followed a similar format to the other metadata files that we have for single-cell libraries and added columns containing the `date_processed`, `geneome_assembly`, `workflow`, `workflow_version`, and `workflow_commit`. 

Finally, for each salmon output directory, I am grabbing the processing information from the json files in that directory that contain the `salmon_version`, `index`, and then number of reads processed and mapped. 

I then write out the file as a `tsv` file as was discussed in our multi-team planning meeting. I have attached an example of what this file would look like. 
[SCPCP000001_bulk_metadata.tsv.zip](https://github.com/AlexsLemonade/scpca-nf/files/7995535/SCPCP000001_bulk_metadata.tsv.zip)

An alternative to this, would be creating individual `json` files for each library that is included in bulk, but was unsure we wanted to have that many individual metadata files when we only have one output file for bulk. 

 