### PR TITLE
Change index and barcodes paths to public reference bucket 

### DIFF
--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -1,6 +1,6 @@
 // reference params and files 
 assembly         = 'Homo_sapiens.GRCh38.104'
-ref_dir          = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+ref_dir          = 's3://scpca-references/homo_sapiens/ensembl-104'
 ref_fasta        = "$ref_dir/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz"
 ref_gtf          = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.gtf.gz"  
 
@@ -15,4 +15,4 @@ t2g_3col_path    = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.spliced_intron.t
 t2g_bulk_path    = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"  
 
 // barcode files
-barcode_dir      = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+barcode_dir      = 's3://scpca-references/barcodes/10X' 


### PR DESCRIPTION
Closes #79. Here I'm changing the directories for the `ref_dir` and the `barcode_dir` to be the public S3 bucket, `s3://scpca-references` that contain the necessary index and barcode files for the workflow. These two spots should be the only place that need to be changed, since I kept the remaining structure within the reference directory the same. All of the parameters for the indexes use the `ref_dir` as a variable in their path, so changing that one parameter changes all of them. 

I tested that this works and when running the workflow the updated index locations are shown in the configuration in tower and when looking at the command that was executed. Additionally there were no errors for missing index files and everything completed successfully.  