### PR TITLE
Skip bulk mapping step

### DIFF
--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -111,8 +111,9 @@ get_processing_info <- function(library_id) {
   cmd_info <- jsonlite::read_json(cmd_info_file)
   meta_info <- jsonlite::read_json(meta_info_file)
   
+  # add date processed from salmon in the format: "Mon Jan 03 15:13:14 2022"
   date_processed <- lubridate::as_datetime(meta_info$end_time, 
-                                           format = "%a %b %d %T %Y") // salmon date format: like "Mon Jan 03 15:13:14 2022"
+                                           format = "%a %b %d %T %Y")
   # if meta_info is not recorded or the format has changed, use the modification time of the file
   if (is.na(date_processed)){
     date_processed <- file.info(meta_info_file)$mtime

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -88,9 +88,9 @@ workflow map_quant_rna {
            it.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna"; 
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}
-       // split based in whether rad_skip is true and a previous dir exists
+       // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
-          has_rad: params.rad_skip && file(it.rad_dir).exists()    
+          has_rad: !params.repeat_mapping && file(it.rad_dir).exists()    
           make_rad: true
        }     
     
@@ -101,7 +101,7 @@ workflow map_quant_rna {
                          file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
 
-    // if the rad directory has been created and rad_skip is set to true
+    // if the rad directory has been created and repeat_mapping is set to false
     // create tuple of (metdata map, rad_directory) to be used directly as input to alevin-fry quantification
     rna_rad_ch = rna_channel.has_rad
       .map{meta -> tuple(meta, 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -24,7 +24,7 @@ process fastp{
 
 process salmon{
     container params.SALMON_CONTAINER
-    label 'cpus_8'
+    label 'cpus_12'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 
@@ -110,8 +110,8 @@ workflow bulk_quant_rna {
         // create tuple of metadata map, salmon output directory to use as input to merge_bulk_quants
         quants_ch = bulk_channel.has_quants
           .map{meta -> tuple(meta,
-                       file(meta.salmon_results_dir)
-                       )}
+                             file(meta.salmon_results_dir)
+                             )}
 
         
         // run fastp and salmon for libraries that are not skipping salmon

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
 
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
-  rad_skip = true // if alevin mapping has already been performed and a rad file exists, use that.
+  repeat_mapping = false // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped, otherwise use `--repeat_mapping` to perform mapping again
   seed = 2021   // random number seed for filtering (0 means use system seed)
 
   // Docker container images


### PR DESCRIPTION
Closes #86. This PR adds the flexibility to skip the salmon mapping step in the bulk workflow, similar to skipping the `salmon alevin` mapping in the alevin-fry workflow. In doing this, I implemented the suggestion in #86 to use a parameter `--repeat_mapping` and set the default value to `false`, meaning that mapping will be skipped by default if the necessary salmon output files are present and will be repeated if using the `--repeat_mapping` flag at the command line. 

I followed a very similar structure to the steps we take to skip mapping in the fry workflow, adding the salmon directory to the metadata and then using `branch` to split the channel based on having or not having the expected output file from salmon. The branch that doesn't have the salmon files done yet are then run through the `fastp` and `salmon` processes, while the other branch skips those processes. The output from the `salmon` process is then mixed with the channel that skipped mapping before creating the final output files. 

The main difference here is that instead of simply looking for the salmon output directory to be created (like we do in the fry workflow), I am looking for the creation of the `quant.sf` file which is explicitly needed in the next steps. Do reviewers agree with this decision or prefer to just look for the output directory? 

Additionally, here I am only looking for completion of the salmon step and then if that step is completed skipping both `fastp` and `salmon`. I thought it was fairly safe to assume that if the `quant.sf` files existed, then both processes had been previously completed and we did not need a separate check for if trimming had completed but not salmon since trimming is not very time consuming. 

I tested that this works both with skipping and not skipping mapping and all looked good. I also tested the fry workflow since I had changed the use of the parameter there and that also worked as expected. 

