### PR TITLE
Split up CPU and memory labels

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -6,7 +6,7 @@ process generate_reference{
   container params.SCPCATOOLS_CONTAINER
   // publish fasta and annotation files within reference directory 
   publishDir params.ref_dir
-  memory { 28.GB * task.attempt}
+  label 'mem_32'
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
   maxRetries 1
   input:
@@ -36,6 +36,7 @@ process salmon_index{
   container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
   publishDir "${params.ref_dir}/salmon_index", mode: 'copy'
   label 'cpus_8'
+  label 'mem_16'
   input:
     tuple path(splici_fasta), path(spliced_cdna_fasta)
     path(genome)
@@ -70,6 +71,7 @@ process cellranger_index{
   container params.CELLRANGER_CONTAINER
   publishDir "${params.ref_dir}/cellranger_index", mode: 'copy'
   label 'cpus_12'
+  label 'mem_24'
   input:
     path(fasta)
     path(gtf)

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -16,13 +16,13 @@ process{
     memory = { 8.GB * task.attempt }
   }
   withLabel: mem_16 {
-    memory = {16.GB + 8.GB * task.attempt }
+    memory = {8.GB + 8.GB * task.attempt }
   }
   withLabel: mem_24 {
-    memory = {24.GB + 12.GB * task.attempt }
+    memory = {12.GB + 12.GB * task.attempt }
   }
   withLabel: mem_32 {
-    memory = {32.GB + 16.GB * task.attempt }
+    memory = {16.GB + 16.GB * task.attempt }
   }
   withLabel: cpus_2  { cpus = 2 }
   withLabel: cpus_4  { cpus = 4 }

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -6,23 +6,29 @@ aws{
 process{
   executor = 'awsbatch'
   queue = 'nextflow-batch-default-queue'
-  // following options from nf-core
+  memory = { 4.GB * task.attempt }
+  
   errorStrategy = { task.attempt < 2 ? 'retry' : 'finish' }
   maxRetries = 1
   maxErrors = '-1'
-  memory = { 4.GB * task.attempt }
-  // batch parameters
+
   withLabel: mem_8 {
-    memory = { 8.GB * task.attempt}
+    memory = { 8.GB * task.attempt }
   }
-  withLabel: cpus_12 {
-    cpus = 12
-    memory = { 24.GB * task.attempt}
+  withLabel: mem_16 {
+    memory = {16.GB + 8.GB * task.attempt }
   }
-  withLabel: cpus_8 {
-    cpus = 8
-    memory = { 16.GB * task.attempt}
+  withLabel: mem_24 {
+    memory = {24.GB + 12.GB * task.attempt }
   }
+  withLabel: mem_32 {
+    memory = {32.GB + 16.GB * task.attempt }
+  }
+  withLabel: cpus_2  { cpus = 2 }
+  withLabel: cpus_4  { cpus = 4 }
+  withLabel: cpus_8  { cpus = 8 }
+  withLabel: cpus_12 { cpus = 12 }
+
   withLabel: disk_big {
     queue = 'nextflow-batch-bigdisk-queue'
   }

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -23,6 +23,7 @@ process index_feature{
 process alevin_feature{
   container params.SALMON_CONTAINER
   label 'cpus_8'
+  label 'mem_8'
   tag "${meta.run_id}-features"
   publishDir "${params.outdir}/internal/rad/${meta.library_id}"
   input:

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -4,6 +4,7 @@
 process alevin_rad{
   container params.SALMON_CONTAINER
   label 'cpus_12'
+  label 'mem_24'
   label 'disk_dynamic'
   tag "${meta.run_id}-rna"
   publishDir "${meta.rad_publish_dir}"
@@ -42,6 +43,7 @@ process alevin_rad{
 process fry_quant_rna{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
+  label 'mem_8'
   tag "${meta.run_id}-rna"
   publishDir "${params.outdir}/internal/af/${meta.library_id}"
 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -25,6 +25,7 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_12'
+    label 'mem_24'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -6,6 +6,7 @@ process spaceranger{
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   tag "${meta.run_id}-spatial" 
   label 'cpus_12'
+  label 'mem_24'
   label 'disk_big'
   input:
     tuple val(meta), path(fastq_dir), file(image_file)


### PR DESCRIPTION
In preparing #80, I needed to make some tweaks to memory requests, and decided that the easiest way to accomplish that was to split up some of the coupling that we had between cpu and memory in the process labels. This may allow us to make some processing more efficient as well (though we are still subject to whims of batch scheduling to a certain extent), as we can use much less RAM for some processes like alevin-fry quant that don't require much memory, while retaining multiprocessing.

So here I have split the CPU and memory requests, and added extra labels to processes as best I thought made sense. 

I also decreased the increments by which we expand memory requests on the logic that we probably don't need to double on failure, but adding 50% memory might make more sense.

**Important questions for review!**

Do  the memory choices I made look reasonable? I did my best to look through recent runs to see that I was covering the memory usage I saw, but I know that Ally has seen some things, so I expect she may have better insights for some of the larger data sets. If you let me know which ones were most problematic, I can also test those specifically.

I left `alevin_rad` with 24GB memory, but I can imagine we might be able to get away with less? Similarly, `fry_quant` might be able to do even less than 8GB, but I'm not sure.

I expect we can decrease the `alevin_feature` memory quite a bit, as I have never seen those use much memory (the index is tiny!), but I left it with 8GB for now.