### PR TITLE
Update to scpcaTools:v0.1.4

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.4'
 
 SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'


### PR DESCRIPTION
Updates to use the latest `scpcaTools`, v0.1.4 which incorporates the new `emptyDrops` error handling. I tested this with the default run ID's and with the run ID that I know fails `emptyDropsCellRanger` and all worked as expected. 