### PR TITLE
Increase memory for bulk workflow

### DIFF
--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -8,7 +8,7 @@ process{
   queue = 'nextflow-batch-default-queue'
   memory = { 4.GB * task.attempt }
   
-  errorStrategy = { task.attempt < 2 ? 'retry' : 'finish' }
+  errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 1
   maxErrors = '-1'
 

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -16,13 +16,13 @@ process{
     memory = { 8.GB * task.attempt }
   }
   withLabel: mem_16 {
-    memory = {16.GB * task.attempt }
+    memory = { 16.GB * task.attempt }
   }
   withLabel: mem_24 {
-    memory = {24.GB * task.attempt }
+    memory = { 24.GB * task.attempt }
   }
   withLabel: mem_32 {
-    memory = {32.GB * task.attempt }
+    memory = { 32.GB * task.attempt }
   }
   withLabel: cpus_2  { cpus = 2 }
   withLabel: cpus_4  { cpus = 4 }

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -16,13 +16,13 @@ process{
     memory = { 8.GB * task.attempt }
   }
   withLabel: mem_16 {
-    memory = {8.GB + 8.GB * task.attempt }
+    memory = {16.GB * task.attempt }
   }
   withLabel: mem_24 {
-    memory = {12.GB + 12.GB * task.attempt }
+    memory = {24.GB * task.attempt }
   }
   withLabel: mem_32 {
-    memory = {16.GB + 16.GB * task.attempt }
+    memory = {32.GB * task.attempt }
   }
   withLabel: cpus_2  { cpus = 2 }
   withLabel: cpus_4  { cpus = 4 }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -9,7 +9,7 @@ process fastp{
     input: 
         tuple val(meta), path(read1), path(read2)
     output: 
-        tuple val(meta), path(trimmed_reads), path(fastp_report)
+        tuple val(meta), path(trimmed_reads)
     script: 
         trimmed_reads = "${meta.library_id}_trimmed"
         fastp_report = "${meta.library_id}_fastp.html"
@@ -18,8 +18,7 @@ process fastp{
         fastp --in1 <(gunzip -c ${read1}) --out1 ${trimmed_reads}/${meta.library_id}_R1_trimmed.fastq.gz \
         ${meta.technology == 'paired_end' ? "--in2 <(gunzip -c ${read2}) --out2 ${trimmed_reads}/${meta.library_id}_R2_trimmed.fastq.gz" : ""} \
         --length_required 20 \
-        --thread ${task.cpus} \
-        --html ${fastp_report}
+        --thread ${task.cpus}
         """
 
 }
@@ -31,7 +30,7 @@ process salmon{
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 
-        tuple val(meta), path(read_dir), path(fastp_report)
+        tuple val(meta), path(read_dir)
         path (index)
     output: 
         tuple val(meta), path(salmon_results_dir)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -4,6 +4,7 @@ nextflow.enable.dsl=2
 process fastp{
     container params.FASTP_CONTAINER
     label 'cpus_8'
+    label 'mem_8'
     tag "${meta.library_id}-bulk"
     input: 
         tuple val(meta), path(read1), path(read2)
@@ -25,7 +26,7 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_12'
-    mem 64.GB
+    label 'mem_32'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -25,7 +25,7 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_12'
-    label 'mem_24'
+    label 'mem_32'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -9,7 +9,7 @@ process fastp{
     input: 
         tuple val(meta), path(read1), path(read2)
     output: 
-        tuple val(meta), path(trimmed_reads)
+        tuple val(meta), path(trimmed_reads), fastp_report
     script: 
         trimmed_reads = "${meta.library_id}_trimmed"
         fastp_report = "${meta.library_id}_fastp.html"
@@ -30,7 +30,7 @@ process salmon{
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 
-        tuple val(meta), path(read_dir)
+        tuple val(meta), path(read_dir), path(fastp_report)
         path (index)
     output: 
         tuple val(meta), path(salmon_results_dir)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -18,7 +18,8 @@ process fastp{
         fastp --in1 <(gunzip -c ${read1}) --out1 ${trimmed_reads}/${meta.library_id}_R1_trimmed.fastq.gz \
         ${meta.technology == 'paired_end' ? "--in2 <(gunzip -c ${read2}) --out2 ${trimmed_reads}/${meta.library_id}_R2_trimmed.fastq.gz" : ""} \
         --length_required 20 \
-        --thread ${task.cpus}
+        --thread ${task.cpus} \
+        --html ${fastp_report}
         """
 
 }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -25,7 +25,7 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_12'
-    label 'mem_32'
+    mem 64.GB
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -9,7 +9,7 @@ process fastp{
     input: 
         tuple val(meta), path(read1), path(read2)
     output: 
-        tuple val(meta), path(trimmed_reads), fastp_report
+        tuple val(meta), path(trimmed_reads), path(fastp_report)
     script: 
         trimmed_reads = "${meta.library_id}_trimmed"
         fastp_report = "${meta.library_id}_fastp.html"

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -26,7 +26,7 @@ process fastp{
 process salmon{
     container params.SALMON_CONTAINER
     label 'cpus_12'
-    label 'mem_32'
+    label 'mem_24'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
     input: 


### PR DESCRIPTION
In running the samples for the Murphy project, many of them are between 30-40 GB of FASTQ files for bulk samples (compared to previously accommodating for processing ~6 GB files). A few of the samples were failing the `fastp` process and retrying and taking multiple hours and I noticed an increase in their memory usage of 2-3GB up to 6-8 GB. Because `fastp` is normally a much faster process for most samples, I increased the memory to 8 GB for that process and it appears to be working better for all of the difficult samples I had found. 

I also was having issues where `salmon` was failing even after two tries using 32 GB. Without making too many drastic changes, I just increased the number of tries that were allowed from 2-3 and noticed that this also helped. I am running two more libraries right now that had previously had difficulties to make sure they can make it through before we tag a release and process the project as a whole, but wanted to get this up in a PR so @jashapiro could comment before he leaves. 