### PR TITLE
Increase the number of retries allowed to 2

### DIFF
--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -9,7 +9,7 @@ process{
   memory = { 4.GB * task.attempt }
   
   errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
-  maxRetries = 1
+  maxRetries = 2
   maxErrors = '-1'
 
   withLabel: mem_8 {


### PR DESCRIPTION
In #103, we changed the ternary operator to finish if the number of retries was less than 3 instead of the previous 2. However, we missed changing the number of `maxRetries` to be 2 rather than 1. This meant that it never actually made it to the third try. There were 3 samples that seemed to have slipped through that needed the the third try and were unable to complete successfully. 

I tested this change for the 3 remaining samples that had failed and with the 3 retries the workflow does complete. 