### PR TITLE
Split process settings from AWS profile

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,0 +1,24 @@
+process{
+  memory = { 4.GB * task.attempt }
+  
+  errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
+  maxRetries = 2
+  maxErrors = '-1'
+
+  withLabel: mem_8 {
+    memory = { 8.GB * task.attempt }
+  }
+  withLabel: mem_16 {
+    memory = { 16.GB * task.attempt }
+  }
+  withLabel: mem_24 {
+    memory = { 24.GB * task.attempt }
+  }
+  withLabel: mem_32 {
+    memory = { 32.GB * task.attempt }
+  }
+  withLabel: cpus_2  { cpus = 2 }
+  withLabel: cpus_4  { cpus = 4 }
+  withLabel: cpus_8  { cpus = 8 }
+  withLabel: cpus_12 { cpus = 12 }
+}

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -1,34 +1,13 @@
 bucketDir = 's3://nextflow-ccdl-data/work'
+
 aws{
   region = 'us-east-1'
   batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
 }
+
 process{
   executor = 'awsbatch'
   queue = 'nextflow-batch-default-queue'
-  memory = { 4.GB * task.attempt }
-  
-  errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
-  maxRetries = 2
-  maxErrors = '-1'
-
-  withLabel: mem_8 {
-    memory = { 8.GB * task.attempt }
-  }
-  withLabel: mem_16 {
-    memory = { 16.GB * task.attempt }
-  }
-  withLabel: mem_24 {
-    memory = { 24.GB * task.attempt }
-  }
-  withLabel: mem_32 {
-    memory = { 32.GB * task.attempt }
-  }
-  withLabel: cpus_2  { cpus = 2 }
-  withLabel: cpus_4  { cpus = 4 }
-  withLabel: cpus_8  { cpus = 8 }
-  withLabel: cpus_12 { cpus = 12 }
-
   withLabel: disk_big {
     queue = 'nextflow-batch-bigdisk-queue'
   }

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -1,4 +1,4 @@
-bucketDir = 's3://nextflow-ccdl-data/work'
+workDir = 's3://nextflow-ccdl-data/work'
 
 aws{
   region = 'us-east-1'

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -7,8 +7,10 @@ aws{
 
 process{
   executor = 'awsbatch'
-  queue = 'nextflow-batch-default-queue'
+  // default queue has 128GB local disks
+  queue = 'nextflow-batch-default-queue' 
   withLabel: disk_big {
+    // bigdisk queue has 1000GB local disks
     queue = 'nextflow-batch-bigdisk-queue'
   }
   withLabel: disk_dynamic {

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,11 +29,15 @@ params {
 
 }
 
+// Load base process config with labels
+includeConfig 'config/process_base.config'
+
 
 profiles{
   standard {
     process.executor = 'local'
     docker.enabled = true
+    docker.userEmulation = true
   }
   // AWS batch profile
   batch {


### PR DESCRIPTION
Here I am pulling the `process` directives, including settings for most of the labels we use, out to a separate file, and unnesting them from the `batch` profile.

This allows them to be reused if others add a separate profile (for slurm, say), without having to recreate all of the various levels of cpu and memory requirements. 

I left the disk labels in the AWS config (adding a bit of commentary), as those seem to be more specific to AWS, as what they do is set queues. Other systems may not require modifying disk sizes, and if they do they may specify it differently.

Also added a change from `bucketDir` to `workDir`, which is the only option in the docs. In the other direction, I added a `docker.userEmulation` option, copied from nfcore, for local running. This should solve potential problems with files getting set as owned by root when running locally).

closes #107 