### PR TITLE
Add config file instructions and reorganize a bit

### DIFF
--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -5,7 +5,7 @@
 /*
 Global parameters for scpca-nf
 ------------------------------
-The values presented here are examples, and should be replaced in with 
+The values presented here are examples, and should be replaced with 
 the correct paths to any indicated files or other values that need to be set.
 */
 
@@ -32,7 +32,7 @@ Profile settings for the workflow execution environment
 Here we provide an example using slurm as the executor system. 
 For information about available process executors and their options, see https://www.nextflow.io/docs/latest/executor.html
 This profile should be adjusted based on the details of your system and can be invoked at runtime with 
-`--profile cluster` (or whatever name you have chosen)
+`-profile cluster` (or whatever name you have chosen)
 
 For more information on setting up profiles see https://www.nextflow.io/docs/latest/config.html#config-profiles
 */

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -31,7 +31,7 @@ params {
 // For more information on setting up profiles see https://www.nextflow.io/docs/latest/config.html#config-profiles
 
 profiles{
- slurm {
+ cluster {
     process {
       executor = 'slurm'
       // queue name for your cluster

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -1,34 +1,41 @@
-// To use this config file with the workflow use the following command:
-// `nextflow run AlexsLemonade/scpca-nf -c user_template.config -profile slurm`
-// Note that if you change the profile name you will have to use the name you chose in place of slurm.
+// user_template.config
+// An example template for use with the scpca-nf Nextflow workflow.
 
-// global parameters for workflows
-// parameters should be filled in with the correct paths to these files, here we provide examples
-params {
 
-  // Input data table
-  run_metafile = 'example_metadata.tsv'
+/*
+Global parameters for scpca-nf
+------------------------------
+The values presented here are examples, and should be replaced in with 
+the correct paths to any indicated files or other values that need to be set.
+*/
 
-  // Output base directory for results
-  outdir = "scpca_out"
+params.run_metafile = 'example_metadata.tsv' // Input data table
 
-  // which samples or libraries to process
-  // although the name of the parameter is `run_ids`, any ids found in `scpca_run_id`, `scpca_library_id`, or `scpca_sample_id` can be used as input
-  // by default this is set to all, but to change to a specific subset input a comma separated list e.g., "SCPCR000001,SCPCR000002"
-  // optionally, run_ids can be changed at the command line by using `--run_ids SCPCR000001`
-  run_ids = "All"
+params.outdir = "scpca_out" // Output base directory for results
 
-  // Spaceranger container, only required if using spatial transcriptomics workflow
-  SPACERANGER_CONTAINER = ''
+params.run_ids = "All"  // Which samples or libraries to process
+/*
+Note: Although the name of this parameter is `run_ids`, any ids found in 
+  `scpca_run_id`, `scpca_library_id`, or `scpca_sample_id` can be used.
+  By default this is set to "All", but to change to a specific subset,
+  use a comma separated list e.g., "SCPCR000001,SCPCR000002"
+  Optionally, `run_ids` can be set at the command line with `--run_ids SCPCR000003`
+*/
 
-}
+// Spaceranger container, only required if using spatial transcriptomics workflow
+params.SPACERANGER_CONTAINER = ''
 
-// profile settings for executing the workflow
-// Here we provide an example using slurm as the executor system. 
-// For information about available process executors,  and their options, see https://www.nextflow.io/docs/latest/executor.html
-// This profile should be adjusted based on the details of your system and can be invoked at runtime with 
-// `--profile slurm` (or whatever name you have chosen)
-// For more information on setting up profiles see https://www.nextflow.io/docs/latest/config.html#config-profiles
+
+/*
+Profile settings for the workflow execution environment
+-------------------------------------------------------
+Here we provide an example using slurm as the executor system. 
+For information about available process executors and their options, see https://www.nextflow.io/docs/latest/executor.html
+This profile should be adjusted based on the details of your system and can be invoked at runtime with 
+`--profile cluster` (or whatever name you have chosen)
+
+For more information on setting up profiles see https://www.nextflow.io/docs/latest/config.html#config-profiles
+*/
 
 profiles{
  cluster {

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -17,7 +17,7 @@
 In order to use `scpca-nf` to process your own data, you will need to make sure you have the following installed: 
 
 - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-- [Docker](https://docs.docker.com/get-started/#download-and-install-docker) (installed either locally or on an HPC)
+- [Docker](https://docs.docker.com/get-started/#download-and-install-docker) or [Singlularity](https://sylabs.io/docs) (installed either locally or on an HPC)
 
 You will also need to create a metadata file and a Nextflow configuration file (see below).
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
@@ -60,7 +60,9 @@ Note that *workflow* parameters such as `--run_metafile` and `--outdir` are deno
 
 ### Configuration files
 
-Workflow parameters can also be set in a configuration file by setting the values `params.run_metafile` and `params.outdir` as follows: 
+Workflow parameters can also be set in a [configuration file](https://www.nextflow.io/docs/latest/config.html#configuration-file) by setting the values `params.run_metafile` and `params.outdir` as follows.
+
+We could first create a file `my_config.config` (or a filename of your choice) with the following contents:  
 
 ```groovy
 // my_config.config
@@ -68,7 +70,7 @@ params.run_metafile = '<path/to/metadata_file>'
 params.outdir = '<path/to/output>'
 ```
 
-This is then used with the `-config` (or `-c`) argument at the command line:
+This file is then used with the `-config` (or `-c`) argument at the command line:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
@@ -76,14 +78,15 @@ nextflow run AlexsLemonade/scpca-nf \
   -config my_config.config 
 ```
 
-We provide an example template configuration file, [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), for reference, which includes some other workflow parameters that may be useful, as well as an example of profile configuration, discussed below. 
+For reference, we provide an example template configuration file, [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), which includes some other workflow parameters that may be useful, as well as an example of profile configuration, discussed below. 
 
 See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) and the below sections for more detail on creating your own configuration file.
 
 ### Setting up a profile in the configuration file
 
 Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
-To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine your system uses. 
+To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine (i.e. Docker or Singularity) your system uses.
+You will likely want to consult your HPC documentation and/or support staff to determine recommended settings.
 
 In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `cluster` which could be invoked with the following command:
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -84,13 +84,13 @@ See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html
 Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
 To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate Nextflow settings like the `process.executor` that will be used to run each process and associated details that may be required, such as queue names or the container engine your system uses.
 
-In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `user_cluster` which could be invoked with the following command:
+In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `cluster` which could be invoked with the following command:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
- -r v0.2.4 \
- -config user_template.config \
- -profile user_cluster
+  -r v0.2.4 \
+  -config user_template.config \
+  -profile cluster
 ```
 
 ### Using `scpca-nf` with AWS

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -83,7 +83,7 @@ See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html
 ### Setting up a profile in the configuration file
 
 Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
-To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate Nextflow settings like the `process.executor` that will be used to run each process and associated details that may be required, such as queue names or the container engine your system uses.
+To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine your system uses. 
 
 In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `cluster` which could be invoked with the following command:
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -24,8 +24,9 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
- -r v0.2.4 \
- -config my_config.config 
+  -r v0.2.4 \
+  -config my_config.config \
+  --run_metafile <path/to/metadata_file>
 ```
 
 This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.4` version, and run it based on the settings in the local configuration file `my_config.config`.
@@ -71,8 +72,8 @@ This is then used with the `-config` (or `-c`) argument at the command line:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
- -r v0.2.4 \
- -config my_config.config 
+  -r v0.2.4 \
+  -config my_config.config 
 ```
 
 We provide an example template configuration file, [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), for reference, which includes some other workflow parameters that may be useful, as well as an example of profile configuration, discussed below. 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -31,7 +31,7 @@ nextflow run AlexsLemonade/scpca-nf \
 
 This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.4` version, and run it based on the settings in the local configuration file `my_config.config`.
 
-**Note:** `spca-nf` is under active development.
+**Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -17,7 +17,7 @@
 In order to use `scpca-nf` to process your own data, you will need to make sure you have the following installed: 
 
 - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-- [Docker](https://docs.docker.com/get-started/#download-and-install-docker) or [Singlularity](https://sylabs.io/docs) (installed either locally or on an HPC)
+- [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singlularity](https://www.nextflow.io/docs/latest/singularity.html) (installed either locally or on an HPC)
 
 You will also need to create a metadata file and a Nextflow configuration file (see below).
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
@@ -85,7 +85,7 @@ See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html
 ### Setting up a profile in the configuration file
 
 Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
-To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine (i.e. Docker or Singularity) your system uses.
+To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine (i.e. [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singularity](https://www.nextflow.io/docs/latest/singularity.html)) your system uses.
 You will likely want to consult your HPC documentation and/or support staff to determine recommended settings.
 
 In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `cluster` which could be invoked with the following command:

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -2,70 +2,104 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [How to use `scpca-nf` as an external user](#how-to-use-scpca-nf-as-an-external-user)
-  - [Prepare the metadata file](#prepare-the-metadata-file)
-  - [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
-    - [Setting up a profile in the config file](#setting-up-a-profile-in-the-config-file)
-    - [Adding parameters to the config file](#adding-parameters-to-the-config-file)
-    - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
-  - [Adjust optional parameters](#adjust-optional-parameters)
-  - [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
+- [Prepare the metadata file](#prepare-the-metadata-file)
+- [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
+  - [Configuration files](#configuration-files)
+  - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
+  - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
+- [Adjust optional parameters](#adjust-optional-parameters)
+- [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## How to use `scpca-nf` as an external user 
+# How to use `scpca-nf` as an external user 
 
 In order to use `scpca-nf` to process your own data, you will need to make sure you have the following installed: 
 
 - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
 - [Docker](https://docs.docker.com/get-started/#download-and-install-docker) (installed either locally or on an HPC)
 
-You will also need to create a metadata file and a nextflow configuration file (see below).
+You will also need to create a metadata file and a Nextflow configuration file (see below).
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
 
-```
+```bash
 nextflow run AlexsLemonade/scpca-nf \
- -r 0.2.3 \
- -c my_config.config \
-  --run_metafile <path/to/metadata file> \
-  --outdir <path/to/output>
+ -r v0.2.4 \
+ -config my_config.config 
 ```
 
-### Prepare the metadata file 
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.4` version, and run it based on the settings in the local configuration file `my_config.config`.
+
+**Note:** `spca-nf` is under active development.
+We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
+Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
+
+## Prepare the metadata file 
 
 Using `scpca-nf` requires a metadata file where each library to be processed is a row and columns contain associated information about that library. 
 You will need the following columns to be present in your metadata file... 
 
-### Configuring `scpca-nf` for your environment
+## Configuring `scpca-nf` for your environment
 
-By default, the workflow is set up to run in a local environment. 
-If choosing to run the workflow locally, you will only need to provide the path to the metadata file and output directory where you would like the results to be stored. 
+Two workflow parameters are *required* for running `scpca-nf` on your own data:
 
-```
+- `run_metafile`: the metadata file with sample information, prepared according to the directions above
+- `outdir`: the output directory where results will be stored
+
+By default, the workflow is set up to run in a local environment, and these parameters can be set at the command line as follows:
+
+```sh
 nextflow run AlexsLemonade/scpca-nf \
- -r 0.2.3 \
-  --run_metafile <path/to/metadata file> \
+  -r v0.2.4 \
+  --run_metafile <path/to/metadata_file> \
   --outdir <path/to/output>
 ```
 
-However, if you need to run your workflow on an HPC, on AWS, or other workspace we encourage you to create your own config file.  
-The config file will allow you to define the system where you would like to execute nextflow, allocate resources, and define parameters for the workflow. 
-After creating a config file, `my_config.config`, that file can be used in conjunction with `scpca-nf` at the command line by using `-c my_config.config`. 
-See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) and the below sections for more detail on creating your own config file. 
+Note that *workflow* parameters such as `--run_metafile` and `--outdir` are denoted at the command line with double hyphen prefix, while options that affect Nextflow itself have only a single hyphen. 
 
-#### Setting up a profile in the config file
-Instructions on adding a new profile
+### Configuration files
 
-#### Adding parameters to the config file
-Adding parameters to the config file. 
+Workflow parameters can also be set in a configuration file by setting the values `params.run_metafile` and `params.outdir` as follows: 
 
-#### Using `scpca-nf` with AWS
+```groovy
+// my_config.config
+params.run_metafile = '<path/to/metadata_file>'
+params.outdir = '<path/to/output>'
+```
+
+This is then used with the `-config` (or `-c`) argument at the command line:
+
+```sh
+nextflow run AlexsLemonade/scpca-nf \
+ -r v0.2.4 \
+ -config my_config.config 
+```
+
+We provide an example template configuration file, [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), for reference, which includes some other workflow parameters that may be useful, as well as an example of profile configuration, discussed below. 
+
+See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) and the below sections for more detail on creating your own configuration file.
+
+### Setting up a profile in the configuration file
+
+Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
+To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate Nextflow settings like the `process.executor` that will be used to run each process and associated details that may be required, such as queue names or the container engine your system uses.
+
+In our example template file [user_template.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/user_template.config), we define a profile named `user_cluster` which could be invoked with the following command:
+
+```sh
+nextflow run AlexsLemonade/scpca-nf \
+ -r v0.2.4 \
+ -config user_template.config \
+ -profile user_cluster
+```
+
+### Using `scpca-nf` with AWS
 Instructions on setting up AWS
 
-### Adjust optional parameters
+## Adjust optional parameters
 
 Include information on all parameters that can be altered. 
 
-### Special considerations for using `scpca-nf` with spatial transcriptomics libraries 
+## Special considerations for using `scpca-nf` with spatial transcriptomics libraries 
 
 Instructions on creating your own spaceranger docker image


### PR DESCRIPTION
Closes #112 

This PR adds more detail about config files and profiles to the external user documentation. 

⚠️ As I was writing, I made some organizational changes to that section and the section about AWS, so this PR should be evaluated before we get too far into revisions, so that those organizational changes don't cause too many conflicts! ⚠️
(I retargeted #120 to this branch, as I think it makes sense to finish this one first.)

The organizational changes are mostly about hierarchy: I moved most everything up a level, but nested the "profile" discussion within the more general configuration discussion. It seemed like talking about workflow parameters in a config file was the easiest transition in, so I did that first, then moved on to the discussion of profiles.

I also moved the two required parameters up to the very top of the "Configuring `scpca-nf`" section, as I want to make sure that people don't miss those. (I had some thoughts about how to make it more clear that those are required at the command line, but I think that will be part of #105, and I will put those thoughts there.)

I didn't include too much detail about profiles as it seems like there were a number of ways one could go on that front, and most would not apply to most people. If you think there are places that I should expand a bit more though, I would be happy to do so!

