### PR TITLE
Add description of output files to scpca-nf instructions

### DIFF
--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -172,3 +172,68 @@ Include information on all parameters that can be altered.
 ## Special considerations for using `scpca-nf` with spatial transcriptomics libraries 
 
 Instructions on creating your own spaceranger docker image
+
+## Output files 
+
+Upon completion of the `scpca-nf` workflow, the results will be published to the specified `outdir`. 
+Within the `outdir`, two folders will be present, `publish` and `internal`. 
+
+The `publish` folder will contain the final output files produced by the workflow and the files that are typically available for download on the ScPCA portal. 
+
+Within the `publish` folder, all files pertaining to a specific sample will be nested within a folder labeled with the sample ID.
+An `unfiltered.rds`, `filtered.rds`, `metadata.json`, and QC report (`qc.html`) will be present for each library. 
+The `unfiltered.rds` and `filtered.rds` files will contain the quantified gene expression data as a [`SingleCellExperiment` object](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html).
+For more information on the contents of these files, see the [ScPCA portal docs section on single cell gene expression file contents.](https://scpca.readthedocs.io/en/latest/sce_file_contents.html)
+
+Additionally, if bulk libraries are processed, a `bulk_quant.tsv` and `bulk_metadata.tsv` summarizing the counts data and metadata across all libraries will be present in the `publish` directory. 
+
+See below for the expected structure of the `publish` folder: 
+
+```
+├── SCPCP000001_bulk_metadata.tsv
+├── SCPCP000001_bulk_quant.tsv
+└── SCPCS000001
+    ├── SCPCL000001_filtered.rds
+    ├── SCPCL000001_metadata.json
+    ├── SCPCL000001_qc.html
+    └── SCPCL000001_unfiltered.rds
+```
+
+The `internal` folder will contain the intermediate files that are produced throughout the workflow. 
+The `af` folder contains the output from running [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html#alevin) with the `--rad` flag, while the `rad` folder contains the outputs from [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/index.html). 
+See below for the expected structure of the `internal` folder after running the single-cell/single-nuclei workflow: 
+
+```
+├── af
+│   └── SCPCL000001
+│       └── SCPCR000001-rna
+│           ├── alevin
+│           │   ├── alevin.log
+│           │   ├── quants_mat.mtx
+│           │   ├── quants_mat_cols.txt
+│           │   └── quants_mat_rows.txt
+│           ├── aux_info
+│           │   └── meta_info.json
+│           ├── cmd_info.json
+│           ├── collate.json
+│           ├── featureDump.txt
+│           ├── generate_permit_list.json
+│           ├── logs
+│           │   └── salmon_quant.log
+│           ├── permit_freq.tsv
+│           └── quant.json
+└── rad
+    └── SCPCL000001
+        └── SCPCR000001-rna
+            ├── alevin
+            │   └── alevin.log
+            ├── aux_info
+            │   └── meta_info.json
+            ├── cmd_info.json
+            ├── logs
+            │   └── salmon_quant.log
+            ├── map.rad
+            └── unmapped_bc_count.bin
+```
+
+If bulk libraries are processed, there will be an additional `salmon` folder that contains the output from running [`salmon`](https://salmon.readthedocs.io/en/latest/file_formats.html#fileformats) on each library processed. 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -185,19 +185,17 @@ An `unfiltered.rds`, `filtered.rds`, `metadata.json`, and QC report (`qc.html`) 
 The `unfiltered.rds` and `filtered.rds` files will contain the quantified gene expression data as a [`SingleCellExperiment` object](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html).
 For more information on the contents of these files, see the [ScPCA portal docs section on single cell gene expression file contents.](https://scpca.readthedocs.io/en/latest/sce_file_contents.html)
 
-Additionally, if bulk libraries are processed, a `bulk_quant.tsv` and `bulk_metadata.tsv` summarizing the counts data and metadata across all libraries will be present in the `publish` directory. 
-
 See below for the expected structure of the `publish` folder: 
 
 ```
-├── SCPCP000001_bulk_metadata.tsv
-├── SCPCP000001_bulk_quant.tsv
 └── SCPCS000001
     ├── SCPCL000001_filtered.rds
     ├── SCPCL000001_metadata.json
     ├── SCPCL000001_qc.html
     └── SCPCL000001_unfiltered.rds
 ```
+
+Additionally, if bulk libraries are processed, a `bulk_quant.tsv` and `bulk_metadata.tsv` summarizing the counts data and metadata across all libraries will be present in the `publish` directory. 
 
 The `internal` folder will contain the intermediate files that are produced throughout the workflow. 
 The `af` folder contains the output from running [`salmon alevin`](https://salmon.readthedocs.io/en/latest/alevin.html#alevin) with the `--rad` flag, while the `rad` folder contains the outputs from [`alevin-fry`](https://alevin-fry.readthedocs.io/en/latest/index.html). 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -2,13 +2,15 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Prepare the metadata file](#prepare-the-metadata-file)
-- [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
-  - [Configuration files](#configuration-files)
-  - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
-  - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
-- [Adjust optional parameters](#adjust-optional-parameters)
-- [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
+- [How to use `scpca-nf` as an external user](#how-to-use-scpca-nf-as-an-external-user)
+  - [Prepare the metadata file](#prepare-the-metadata-file)
+  - [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
+    - [Configuration files](#configuration-files)
+    - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
+    - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
+  - [Adjust optional parameters](#adjust-optional-parameters)
+  - [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
+  - [Output files](#output-files)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Closes #116. 

Here I added a section at the end of the instructions to describe the output files that should be expected after running the workflow. I noted that there should be two folders published to the `outdir`, the `internal` and the `publish` folder. I then explained the contents of each folder and showed the expected structure of each folder if running single-cell/single-nuclei samples. I also included a link to the docs to explain the contents of the files and focused here on the actual structure of the files. 

I added a note for each folder on if you were to run bulk samples, what the folders would look like. Would it be preferred to add this to the tree diagram rather than just adding a note? I was trying to avoid things getting really long with the `internal` folder specifically, but if we think it's important to have I can add it in. 

One thing to note is that I did not include the output structure for spatial yet as that is subject to change as part of #82. 

The main question I had was if we are okay with separating the structure into `publish` and `internal` or if it's preferred to put them all together and show one tree of the output directory? 
Additionally, should we show all of the intermediate files in the `internal` folder like I have it right now? Or is it better to just show the overall structure? 