### PR TITLE
Add issue templates and contributing doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,18 +11,19 @@ assignees: ''
 A clear and concise description of what the bug is. 
 If you have an error message or report that you can include, please do!
 
-**To Reproduce**
+**To reproduce**
 If possible, please provide example code to reproduce the problem, including any information about the dataset where the problem occurred, if possible.
 
 What command did you use to invoke the `scpca-nf` workflow?
 
 What type of system are you using to run the workflow (local, slurm, AWS, etc.)?
+If you are using a custom profile or config file, please include the file and settings you used.
 
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Version Information**
+**Version information**
 What version of `scpca-nf` are you using, and what version of Nextflow?
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve scpca-nf
+title: "[BUG] Something is wrong"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is. 
+If you have an error message or report that you can include, please do!
+
+**To Reproduce**
+If possible, please provide example code to reproduce the problem, including any information about the dataset where the problem occurred, if possible.
+
+What command did you use to invoke the `scpca-nf` workflow?
+
+What type of system are you using to run the workflow (local, slurm, AWS, etc.)?
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Version Information**
+What version of `scpca-nf` are you using, and what version of Nextflow?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -12,14 +12,16 @@ assignees: ''
 ### Preparing for the release
 
 - [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
-- [ ] Update code and documentation with the latest version number:
+- [ ] Update code and documentation with the latest version number ind the `development` branch:
   - [ ] [nextflow.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config) 
   - [ ] [README.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/README.md)
   - [ ] [external-data-instructions.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-data-instructions.md)
+- [ ] Test that the workflow is in good working order with `nextflow run alexslemonade/scpca-nf -latest -r development`
+- [ ] File a PR from the `development` branch to the `main` branch. This should include all of the changes that will be associated with the next release.
 
 ### Creating a release
 - [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
 - [ ] In `Choose a tag`, type a new release number using semantic versioning (vX.X.X) (you did update the title of this issue to match, right?), then click `Create a new tag: vX.X.X on publish`.
-- [ ] Write a description of the major changes in this release. You may want to start with the Auto-generated release notes to save time.
-- [ ] Save a draft to return to later if testing isn't done yet, otherwise:
+- [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
+- [ ] Save a draft to return to later if not all issues have been addressed, otherwise:
 - [ ] Publish the release!

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,25 @@
+---
+name: Release checklist
+about: Prepare for a new release version of scpca-nf
+title: Prepare for scpca-nf release vX.X.X
+labels: release
+assignees: ''
+
+---
+
+## Steps for a new release of `scpca-nf`
+
+### Preparing for the release
+
+- [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
+- [ ] Update code and documentation with the latest version number:
+  - [ ] [nextflow.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config) 
+  - [ ] [README.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/README.md)
+  - [ ] [external-data-instructions.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-data-instructions.md)
+
+### Creating a release
+- [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
+- [ ] In `Choose a tag`, type a new release number using semantic versioning (vX.X.X) (you did update the title of this issue to match, right?), then click `Create a new tag: vX.X.X on publish`.
+- [ ] Write a description of the major changes in this release. You may want to start with the Auto-generated release notes to save time.
+- [ ] Save a draft to return to later if testing isn't done yet, otherwise:
+- [ ] Publish the release!

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -12,7 +12,7 @@ assignees: ''
 ### Preparing for the release
 
 - [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
-- [ ] Update code and documentation with the latest version number ind the `development` branch:
+- [ ] Update code and documentation with the latest version number in the `development` branch:
   - [ ] [nextflow.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config) 
   - [ ] [README.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/README.md)
   - [ ] [external-data-instructions.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-data-instructions.md)
@@ -23,5 +23,5 @@ assignees: ''
 - [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
 - [ ] In `Choose a tag`, type a new release number using semantic versioning (vX.X.X) (you did update the title of this issue to match, right?), then click `Create a new tag: vX.X.X on publish`.
 - [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
-- [ ] Save a draft to return to later if not all issues have been addressed, otherwise:
+- [ ] Optional: If not all issues have been addressed, save a draft to return to later.
 - [ ] Publish the release!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to `scpca-nf`
+
+We welcome contributions to the `scpca-nf` workflow, including usage reports and suggestions from users.
+
+## Issues
+
+Most updates to the `scpca-nf` workflow will begin with an issue that describes a change to be made and the reasoning behind that change.
+This provides an opportunity for discussion before implementation of any changes.
+
+## Pull requests and branch structure 
+
+The `main` branch holds the current release version of the `scpca-nf` workflow.
+
+New features and other workflow updates that are ready in advance of a new release are found in the `development` branch. 
+ 
+Contributions and updates to the `scpca-nf` repository operate on a pull request model. 
+Changes will typically be made in a new branch that is created from the `development` branch, followed by a pull request back to the `development` branch.
+All pull requests must be reviewed before merging to `development`. 
+To allow for efficeint reciew, please include in any pull request a concise and clear explanation of the changes you have made and the issues addressed. 
+
+When the changes in `development` merit a new release, a pull request will be filed to merge the current version of the `development` branch into `main`, followed by tagging a release on the `main` branch.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ New features and other workflow updates that are ready in advance of a new relea
 Contributions and updates to the `scpca-nf` repository operate on a pull request model. 
 Changes will typically be made in a new branch that is created from the `development` branch, followed by a pull request back to the `development` branch.
 All pull requests must be reviewed before merging to `development`. 
-To allow for efficeint reciew, please include in any pull request a concise and clear explanation of the changes you have made and the issues addressed. 
+To allow for efficient review, please include in any pull request a concise and clear explanation of the changes you have made and the issues addressed. 
 
 When the changes in `development` merit a new release, a pull request will be filed to merge the current version of the `development` branch into `main`, followed by tagging a release on the `main` branch.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nextflow run AlexsLemonade/scpca-nf -profile batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.3 -profile batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.4 -profile batch --project SCPCP000000
 ```
 
 Note that the default settings of the workflow is configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-## Running scpca-nf for the ScPCA portal 
+# scpca-nf
 
-This repo holds the scripts to run the nextflow workflow to process samples as part of the ScPCA project.
+This repository holds a [Nextflow](https://www.nextflow.io) workflow to process samples as part of the ScPCA project.
+
 Fastq files for single-cell and single-nuclei RNA-seq samples are processed using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).
 All samples are aligned, using selective alignment, to an index with transcripts corresponding to spliced cDNA and to intronic regions, denoted by alevin-fry as `splici`. 
 `scpca-nf` can also process CITE-seq, bulk RNA-seq, and spatial transcriptomics. 
 For more information on the processing of other modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
+
+
+## Running scpca-nf for the ScPCA portal 
 
 To run `scpca-nf` in its default configuration: 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ manifest{
   author = "Childhood Cancer Data Lab, Alex's Lemonade Stand Foundation"
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
-  defaultBranch = 'latest'
+  defaultBranch = 'main'
   version = 'v0.2.4'
 }
 


### PR DESCRIPTION
This PR adds a few issue templates to the repo, including feature requests and bug reports. Most importantly, it adds a checklist for releases that describes the expected process for creating a new release, following the discussion in #132.

I also changed the `manifest.defaultBranch` to `main` to parallel that change, and added a very brief `CONTRIBUTING.md` document to describe the organization of the repo. We may well want to expand that in the future, but I wanted to at least get a stub in there to describe the branches.  Of course, I am also open to suggestions of improvement now!

Closes #131 
Closes #132 