### PR TITLE
Add option to skip spaceranger quantification

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -29,7 +29,7 @@ process spaceranger{
       --area=${meta.slide_section} 
 
     # remove bam files
-    rm ${out_id}/*.bam*
+    rm ${out_id}/outs/*.bam*
     """
 }
 


### PR DESCRIPTION
Here, I added in the option to skip the spaceranger quantification, if the spaceranger output folder already exists. This was pretty similar to the previous steps that we skipped where as long as the `--repeat_mapping` flag is set to false and the output directory exists, then it will be included in a separate branch on the spatial channel that will not go through the `spaceranger` process. 

As part of this PR, I also addressed the reorganization of the output files, removing the `spaceranger_versions.json` and `spaceranger_metrics_summary.csv` files from the final output. However, we need those files to create the `metadata.json` file that we create in the `spaceranger_metadata` process. 

So here, what I did was break out the file reorganization that was originally in the `spaceranger` process and put it in the `spaceranger_metadata` process. This means that we now are going to store the outs folder from cellranger as is (with removal of the large bam files) in the `internal/spaceranger` folder, and then actually include the files we would like to include on the portal in the `publish` directory. I'm torn on this because we don't really need to have all of these smaller files, but it seemed like the clean way to do it. This way we have the original folder that remains untouched and if it exists we skip spaceranger. Then we output the final files in a separate output folder in the file structure we would like without disturbing the original files. 

Lastly, to finish addressing the reorganization, I appended the `_spatial` flag to the library folder that gets published as described in #82. 

I tested these changes and the spaceranger process is successfully skipped and the output files look as expected. 

Closes #81.
Closes #82. 