### PR TITLE
Move ccdl-specific parameters to a profile

### DIFF
--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -14,7 +14,6 @@ on:
 jobs:
   nf-config-check:
     runs-on: ubuntu-20.04
-    container: nextflow/nextflow:21.10.6
     steps:
       - uses: actions/checkout@v2
       - name: Check nextflow params

--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -4,7 +4,7 @@ name: Check nextflow config
 on:
   push:
     branches:
-      - 'jashapiro/123-ccdl-params'
+      - jashapiro/123-ccdl-params
   pull_request:
     branches:
       - main

--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -2,9 +2,6 @@
 name: Check nextflow config
 
 on:
-  push:
-    branches:
-      - jashapiro/123-ccdl-params
   pull_request:
     branches:
       - main

--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -4,7 +4,7 @@ name: Check nextflow config
 on:
   push:
     branches:
-      - jashapiro/123-ccdl-params
+      - 'jashapiro/123-ccdl-params'
   pull_request:
     branches:
       - main
@@ -13,7 +13,8 @@ on:
 
 jobs:
   nf-config-check:
-    container: nextflow/nextflow
+    runs-on: ubuntu-20.04
+    container: nextflow/nextflow:21.10.6
     steps:
       - uses: actions/checkout@v2
       - name: Check nextflow params

--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -1,0 +1,21 @@
+
+name: Check nextflow config
+
+on:
+  push:
+    branches:
+      - jashapiro/123-ccdl-params
+  pull_request:
+    branches:
+      - main
+      - development
+
+
+jobs:
+  nf-config-check:
+    container: nextflow/nextflow
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check nextflow params
+        run: |
+          nextflow config

--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -18,5 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check nextflow params
-        run: |
-          nextflow config
+        uses: docker://nextflow/nextflow:21.10.6
+        with: 
+          args: nextflow config

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl
 ```
 Although running workflows locally can be done, we recommend using AWS batch for this workflow. 
 The first step in running the workflow is ensuring that your AWS credentials are configured. 
-()
 
 You can then run the same workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
 Note that you will still need the `ccdl` profile, and you can specify both with by separating them with a comma. 

--- a/README.md
+++ b/README.md
@@ -10,26 +10,30 @@ For more information on the processing of other modalities, please see the [ScPC
 
 ## Running scpca-nf for the ScPCA portal 
 
-To run `scpca-nf` in its default configuration: 
+The instructions below assume that you are a member of the CCDL with access to AWS.
+Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 
+To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md). 
+
+To run `scpca-nf` in its default configuration for the CCDL, you can use the following command: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf 
+nextflow run AlexsLemonade/scpca-nf -profile ccdl
 ```
-
 Although running workflows locally can be done, we recommend using AWS batch for this workflow. 
 The first step in running the workflow is ensuring that your AWS credentials are configured. 
+()
 
 You can then run the same workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
+Note that you will still need the `ccdl` profile, and you can specify both with by separating them with a comma. 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -profile batch
+nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 ```
 
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.4 -profile batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.5 -profile ccdl,batch --project SCPCP000000
 ```
 
-Note that the default settings of the workflow is configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 
-To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md).
+

--- a/config/containers.config
+++ b/config/containers.config
@@ -5,5 +5,6 @@ SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
 FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
 
-CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
-SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
+// 10X software containers not set by default
+CELLRANGER_CONTAINER = ''
+SPACERANGER_CONTAINER = ''

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -1,0 +1,14 @@
+// CCDL-specific settings to run samples for ScPCA with internal paths
+
+params{
+  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+  outdir = "s3://nextflow-ccdl-results/scpca/processed"
+
+  // a set of run_ids for testing
+  run_ids = "SCPCR000001,SCPCS000101"
+
+  //
+  CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
+  SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
+}
+

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -2,16 +2,15 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [How to use `scpca-nf` as an external user](#how-to-use-scpca-nf-as-an-external-user)
-  - [File organization](#file-organization)
-  - [Prepare the metadata file](#prepare-the-metadata-file)
-  - [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
-    - [Configuration files](#configuration-files)
-    - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
-    - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
-  - [Repeating mapping steps](#repeating-mapping-steps)
-  - [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
-  - [Output files](#output-files)
+- [File organization](#file-organization)
+- [Prepare the metadata file](#prepare-the-metadata-file)
+- [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
+  - [Configuration files](#configuration-files)
+  - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
+  - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
+- [Repeating mapping steps](#repeating-mapping-steps)
+- [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
+- [Output files](#output-files)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -30,12 +29,12 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config my_config.config \
   --run_metafile <path/to/metadata_file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.4` version, and run it based on the settings in the local configuration file `my_config.config`.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.5` version, and run it based on the settings in the local configuration file `my_config.config`.
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
@@ -96,16 +95,18 @@ We have provided an example metadata file for reference that can be found in [`e
 
 ## Configuring `scpca-nf` for your environment
 
-Two workflow parameters are *required* for running `scpca-nf` on your own data:
+Two workflow parameters are required for running `scpca-nf` on your own data:
 
-- `run_metafile`: the metadata file with sample information, prepared according to the directions above
-- `outdir`: the output directory where results will be stored
+- `run_metafile`: the metadata file with sample information, prepared according to the directions above. 
+  - This has a default value of `run_metadata.tsv`, but you will likely want to set your own file path.
+- `outdir`: the output directory where results will be stored.
+  - The default output is `scpca_output`, but again, you will likely want to customize this.
 
 By default, the workflow is set up to run in a local environment, and these parameters can be set at the command line as follows:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   --run_metafile <path/to/metadata_file> \
   --outdir <path/to/output>
 ```
@@ -128,7 +129,7 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config my_config.config 
 ```
 
@@ -146,7 +147,7 @@ In our example template file [user_template.config](https://github.com/AlexsLemo
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config user_template.config \
   -profile cluster
 ```
@@ -181,7 +182,7 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   --repeat_mapping
 ```
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -100,7 +100,7 @@ Two workflow parameters are required for running `scpca-nf` on your own data:
 - `run_metafile`: the metadata file with sample information, prepared according to the directions above. 
   - This has a default value of `run_metadata.tsv`, but you will likely want to set your own file path.
 - `outdir`: the output directory where results will be stored.
-  - The default output is `scpca_output`, but again, you will likely want to customize this.
+  - The default output is `scpca_out`, but again, you will likely want to customize this.
 
 By default, the workflow is set up to run in a local environment, and these parameters can be set at the command line as follows:
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
   mainScript = 'main.nf'
   defaultBranch = 'main'
   version = 'v0.2.4'
-}
+
 
 
 // global parameters for workflows

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,15 +12,15 @@ manifest{
 // global parameters for workflows
 params {
   // Input data table
-  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+  run_metafile = ""
 
   // Output base directory
-  outdir = "s3://nextflow-ccdl-results/scpca/processed"
+  outdir = "scpca_output"
 
   // run_ids are comma separated list to be parsed into 
   // a list of run ids, library ids, and or sample_ids
   // or "All" to process all samples in the metadata file
-  run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
+  run_ids = "All"
   // to run all samples in a project use that project's submitter name
   project = ""
 
@@ -49,5 +49,9 @@ profiles{
   // AWS batch profile
   batch {
     includeConfig 'config/profile_awsbatch.config'
+  }
+  // CCDL-specific settings
+  ccdl{
+    includeConfig 'config/profile_ccdl.config'
   }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.2.4'
+  version = 'v0.2.5'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest{
   mainScript = 'main.nf'
   defaultBranch = 'main'
   version = 'v0.2.4'
-
+}
 
 
 // global parameters for workflows

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ manifest{
 // global parameters for workflows
 params {
   // Input data table
-  run_metafile = ""
+  run_metafile = "run_metadata.tsv"
 
   // Output base directory
   outdir = "scpca_output"

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,7 +15,7 @@ params {
   run_metafile = "run_metadata.tsv"
 
   // Output base directory
-  outdir = "scpca_output"
+  outdir = "scpca_out"
 
   // run_ids are comma separated list to be parsed into 
   // a list of run ids, library ids, and or sample_ids


### PR DESCRIPTION
Closes #123

This PR pulls the CCDL-specific settings out to a profile that can be invoked with `nextflow run AlexsLemonade/scpca-nf -profile ccdl` (once this is all merged to main, that is). 

I added default settings for the metadata file and output directory, and updated the docs to reflect that, but I am not sure whether that is better than leaving them blank by default. I welcome feedback on that decision.

I did set the defaults for the 10X containers to be blank, so that we only invoke our containers with the `-profile ccdl` argument.

Are there any other settings that I should move to the `ccdl` profile?

Please also look at the the updates to the documentation that I made to be sure those are clear and understandable. One notable change was to move the warning about who the instructions are for to the top.

Finally, I added a github action that will run `nextflow config` to just check that the config files are well-formatted. The main reason for this is that we can use it later to enforce that branches are up to date before merging to `development` or `main`, which we have found can eliminate some accidental reversions.