### PR TITLE
No longer require list of files for spaceranger

### DIFF
--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -1,4 +1,4 @@
-scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	submitter	technology	seq_unit	library_method	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number	files_directory	files
-SCPCR999991	SCPCL999991	SCPCS999991	SCPCP999991	example	10Xv3.1	cell						example_fastqs/example1	example1_R1.fastq.gz;example1_R2.fastq.gz
-SCPCR999992	SCPCL999991	SCPCS999991	SCPCP999991	example	CITEseq_10Xv3	cell		example_barcode_files/cite_barcodes.tsv	2[1-15]			example_fastqs/example2	example2_R1.fastq.gz;example2_R2.fastq.gz
-SCPCR999993	SCPCL999993	SCPCS999992	SCPCP999992	example	visium_v1	spot				A1	VXXXX-XXX	example_fastqs/example3	example3_R1.fastq.gz;example3_R2.fastq.gz;example3.jpg
+scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	submitter	technology	seq_unit	library_method	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number	files_directory
+SCPCR999991	SCPCL999991	SCPCS999991	SCPCP999991	example	10Xv3.1	cell						example_fastqs/example1
+SCPCR999992	SCPCL999991	SCPCS999991	SCPCP999991	example	CITEseq_10Xv3	cell		example_barcode_files/cite_barcodes.tsv	2[1-15]			example_fastqs/example2
+SCPCR999993	SCPCL999993	SCPCS999992	SCPCP999992	example	visium_v1	spot				A1	VXXXX-XXX	example_fastqs/example3

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -89,7 +89,6 @@ The following columns may be necessary for running other data modalities (CITE-s
 | `feature_barcode_geom`| A salmon `--read-geometry` layout string/ See https://github.com/COMBINE-lab/salmon/releases for details (only required for CITE-seq) |
 | `slide_section`   | The slide section for spatial transcriptomics samples (only required for spatial transcriptomics) |
 | `slide_serial_number`| The slide serial number for spatial transcriptomics samples (only required for spatial transcriptomics)   |
-| `files`           | All sequencing files in the run folder, `;`-separated (only required for spatial transcriptomics)  |
 
 We have provided an example metadata file for reference that can be found in [`examples/example_metadata.tsv`](examples/example_metadata.tsv).
 
@@ -189,7 +188,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ## Special considerations for using `scpca-nf` with spatial transcriptomics libraries 
 
 To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated `.jpg` file must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file). 
-The metadata file must also contain columns with the `slide_section`, `slide_serial_number`, and list of all `files` inside the run directory, including the `.jpg` image. 
+The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
 
 You will also need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Space Ranger software from 10X Genomics](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest). 
 For licensing reasons, we cannot provide a Docker container with Space Ranger for you. 

--- a/main.nf
+++ b/main.nf
@@ -80,8 +80,7 @@ workflow {
       feature_barcode_geom: it.feature_barcode_geom,
       files_directory: it.files_directory,
       slide_serial_number: it.slide_serial_number,
-      slide_section: it.slide_section,
-      files: it.files
+      slide_section: it.slide_section
     ]}
 
  runs_ch = unfiltered_runs_ch 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -73,10 +73,10 @@ process spaceranger_publish{
 }
 
 def getCRsamples(files_dir){
-  // takes a string with semicolon separated file names
+  // takes the path to the directory holding the fastq files for each sample 
   // returns just the 'sample info' portion of the file names,
   // as spaceranger would interpret them, comma separated
-  fastq_files = file(files_dir).list().findAll{it.contains '.fastq.gz'}
+  fastq_files = file(files_dir).list().findAll{it.contains('.fastq.gz')}
   samples = []
   fastq_files.each{
     // append sample names to list, using regex to extract element before S001, etc.
@@ -93,23 +93,8 @@ workflow spaceranger_quant{
     take: spatial_channel 
     // a channel with a map of metadata for each spatial library to process 
     main: 
-        // create tuple of (metadata map, [])
-        //grouped_spatial_channel = spatial_channel
-          // add files, sample names and spatial output directory to metadata
-          //.map{meta -> tuple(meta,
-          /*                    meta.library_id,
-                             file("${meta.files_directory}/*_R*_*.fastq.gz")
-                             )}
-          // one fastq file per line 
-          .transpose()
-          // add new entry with 
-          .map{it.cr_samples = (it =~ /^(.+)_S.+_L.+_[R|I].+.fastq.gz$/)[0][1];
-               it}
-          .groupTuple(by:1) // group by library ID 
-          .map{[it[0], it[1], it[2]]} // remove files and put into one tuple  */
-
-          
         spatial_channel = spatial_channel
+        // add sample names and spatial output directory to metadata
           .map{it.cr_samples = getCRsamples(it.files_directory);
                it.spaceranger_publish_dir =  "${params.outdir}/internal/spaceranger/${it.library_id}";
                it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -72,11 +72,11 @@ process spaceranger_publish{
     """
 }
 
-def getCRsamples(filelist){
+def getCRsamples(files_dir){
   // takes a string with semicolon separated file names
   // returns just the 'sample info' portion of the file names,
   // as spaceranger would interpret them, comma separated
-  fastq_files = filelist.findAll{it.contains '.fastq.gz'}
+  fastq_files = file(files_dir).list().findAll{it.contains '.fastq.gz'}
   samples = []
   fastq_files.each{
     // append sample names to list, using regex to extract element before S001, etc.
@@ -94,10 +94,10 @@ workflow spaceranger_quant{
     // a channel with a map of metadata for each spatial library to process 
     main: 
         // create tuple of (metadata map, [])
-        grouped_spatial_channel = spatial_channel
+        //grouped_spatial_channel = spatial_channel
           // add files, sample names and spatial output directory to metadata
-          .map{meta -> tuple(meta,
-                             meta.library_id,
+          //.map{meta -> tuple(meta,
+          /*                    meta.library_id,
                              file("${meta.files_directory}/*_R*_*.fastq.gz")
                              )}
           // one fastq file per line 
@@ -106,21 +106,21 @@ workflow spaceranger_quant{
           .map{it.cr_samples = (it =~ /^(.+)_S.+_L.+_[R|I].+.fastq.gz$/)[0][1];
                it}
           .groupTuple(by:1) // group by library ID 
-          .map{[it[0], it[1], it[2]]} // remove files and put into one tuple 
+          .map{[it[0], it[1], it[2]]} // remove files and put into one tuple  */
 
           
-          branched_spatial_channel = grouped_spatial_channel
-            .map{
-              it.spaceranger_publish_dir =  "${params.outdir}/internal/spaceranger/${it.library_id}";
-              it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
-              it}
+        spatial_channel = spatial_channel
+          .map{it.cr_samples = getCRsamples(it.files_directory);
+               it.spaceranger_publish_dir =  "${params.outdir}/internal/spaceranger/${it.library_id}";
+               it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
+               it}
           .branch{
             has_spatial: !params.repeat_mapping & file(it.spaceranger_results_dir).exists()
             make_spatial: true
-          }
+           }
 
           // create tuple of [metadata, fastq dir, and path to image file]
-        spaceranger_reads = branched_spatial_channel.make_spatial
+        spaceranger_reads = spatial_channel.make_spatial
           .map{meta -> tuple(meta,
                             file("${meta.files_directory}"),
                             file("${meta.files_directory}/*.jpg")
@@ -130,7 +130,7 @@ workflow spaceranger_quant{
         spaceranger(spaceranger_reads, params.cellranger_index)
 
         // gather spaceranger output for completed libraries
-        spaceranger_quants_ch = branched_spatial_channel.has_spatial
+        spaceranger_quants_ch = spatial_channel.has_spatial
           .map{meta -> tuple(meta,
                              file("${meta.spaceranger_results_dir}")
                              )}


### PR DESCRIPTION
Closes #117. 

This PR removes the need to have a separate column in the metadata file with the list of files, specifically for external users using the spaceranger workflow. We had previously been grabbing the sample names needed to run spaceranger from the list of file names, but here we pass the directory through to the `getCRsamples` function, list all the files present in the directory and then grab the sample names that way. In addition, I removed the addition of files to the `unfiltered_runs_ch` in the main workflow, as we no longer need that column for any of the workflow to work. 

I also updated the example metadata to remove that column and updated the external instructions to remove any mention of a `files` column. I did not actually remove the `files` column from our metadata, as we use the list of files to perform data integrity checks in our internal workflows. I tested this with a spatial sample and it successfully populates the `--sample` option when running spaceranger with the names from the files as it was previously. 