### PR TITLE
Merge v0.2.5 release changes into main

### DIFF
--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -1,0 +1,19 @@
+
+name: Check nextflow config
+
+on:
+  pull_request:
+    branches:
+      - main
+      - development
+
+
+jobs:
+  nf-config-check:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check nextflow params
+        uses: docker://nextflow/nextflow:21.10.6
+        with: 
+          args: nextflow config

--- a/README.md
+++ b/README.md
@@ -10,26 +10,29 @@ For more information on the processing of other modalities, please see the [ScPC
 
 ## Running scpca-nf for the ScPCA portal 
 
-To run `scpca-nf` in its default configuration: 
+The instructions below assume that you are a member of the CCDL with access to AWS.
+Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 
+To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md). 
+
+To run `scpca-nf` in its default configuration for the CCDL, you can use the following command: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf 
+nextflow run AlexsLemonade/scpca-nf -profile ccdl
 ```
-
 Although running workflows locally can be done, we recommend using AWS batch for this workflow. 
 The first step in running the workflow is ensuring that your AWS credentials are configured. 
 
 You can then run the same workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
+Note that you will still need the `ccdl` profile, and you can specify both with by separating them with a comma. 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -profile batch
+nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 ```
 
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.5 -profile batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.5 -profile ccdl,batch --project SCPCP000000
 ```
 
-Note that the default settings of the workflow is configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 
-To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md).
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nextflow run AlexsLemonade/scpca-nf -profile batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.4 -profile batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.5 -profile batch --project SCPCP000000
 ```
 
 Note that the default settings of the workflow is configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 

--- a/config/containers.config
+++ b/config/containers.config
@@ -5,5 +5,6 @@ SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
 FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
 
-CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
-SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
+// 10X software containers not set by default
+CELLRANGER_CONTAINER = ''
+SPACERANGER_CONTAINER = ''

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -1,0 +1,14 @@
+// CCDL-specific settings to run samples for ScPCA with internal paths
+
+params{
+  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+  outdir = "s3://nextflow-ccdl-results/scpca/processed"
+
+  // a set of run_ids for testing
+  run_ids = "SCPCR000001,SCPCS000101"
+
+  //
+  CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
+  SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
+}
+

--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -1,4 +1,4 @@
-scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	submitter	technology	seq_unit	library_method	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number	files_directory	files
-SCPCR999991	SCPCL999991	SCPCS999991	SCPCP999991	example	10Xv3.1	cell						example_fastqs/example1	example1_R1.fastq.gz;example1_R2.fastq.gz
-SCPCR999992	SCPCL999991	SCPCS999991	SCPCP999991	example	CITEseq_10Xv3	cell		example_barcode_files/cite_barcodes.tsv	2[1-15]			example_fastqs/example2	example2_R1.fastq.gz;example2_R2.fastq.gz
-SCPCR999993	SCPCL999993	SCPCS999992	SCPCP999992	example	visium_v1	spot				A1	VXXXX-XXX	example_fastqs/example3	example3_R1.fastq.gz;example3_R2.fastq.gz;example3.jpg
+scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	submitter	technology	seq_unit	library_method	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number	files_directory
+SCPCR999991	SCPCL999991	SCPCS999991	SCPCP999991	example	10Xv3.1	cell						example_fastqs/example1
+SCPCR999992	SCPCL999991	SCPCS999991	SCPCP999991	example	CITEseq_10Xv3	cell		example_barcode_files/cite_barcodes.tsv	2[1-15]			example_fastqs/example2
+SCPCR999993	SCPCL999993	SCPCS999992	SCPCP999992	example	visium_v1	spot				A1	VXXXX-XXX	example_fastqs/example3

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -75,7 +75,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_run_id`    | A unique run ID                                              |
 | `scpca_library_id`| A unique library ID for each unique set of cells             |
 | `scpca_sample_id` | A unique sample ID for each tissue or unique source          |
-| `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use either `visium_v1` or `visium_v2`      |
+| `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use either `visium` or `spatial`      |
 | `seq_unit`        | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`)|
 | `files_directory` | path/uri to directory containing fastq files (unique per run) |
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -75,7 +75,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_run_id`    | A unique run ID                                              |
 | `scpca_library_id`| A unique library ID for each unique set of cells             |
 | `scpca_sample_id` | A unique sample ID for each tissue or unique source          |
-| `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use either `visium` or `spatial`      |
+| `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use `visium`      |
 | `seq_unit`        | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`)|
 | `files_directory` | path/uri to directory containing fastq files (unique per run) |
 
@@ -195,6 +195,7 @@ For licensing reasons, we cannot provide a Docker container with Space Ranger fo
 As an example, the Dockerfile that we used to build Space Ranger can be found [here](https://github.com/AlexsLemonade/alsf-scpca/tree/main/images/spaceranger). 
 
 After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.SPACERANGER_CONTAINER` to the registry location and image id in the `user_template.config` file. 
+*Note: The workflow is currently set up to work with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods.*
 
 ## Output files 
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -2,16 +2,15 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [How to use `scpca-nf` as an external user](#how-to-use-scpca-nf-as-an-external-user)
-  - [File organization](#file-organization)
-  - [Prepare the metadata file](#prepare-the-metadata-file)
-  - [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
-    - [Configuration files](#configuration-files)
-    - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
-    - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
-  - [Repeating mapping steps](#repeating-mapping-steps)
-  - [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
-  - [Output files](#output-files)
+- [File organization](#file-organization)
+- [Prepare the metadata file](#prepare-the-metadata-file)
+- [Configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment)
+  - [Configuration files](#configuration-files)
+  - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
+  - [Using `scpca-nf` with AWS](#using-scpca-nf-with-aws)
+- [Repeating mapping steps](#repeating-mapping-steps)
+- [Special considerations for using `scpca-nf` with spatial transcriptomics libraries](#special-considerations-for-using-scpca-nf-with-spatial-transcriptomics-libraries)
+- [Output files](#output-files)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -95,10 +94,12 @@ We have provided an example metadata file for reference that can be found in [`e
 
 ## Configuring `scpca-nf` for your environment
 
-Two workflow parameters are *required* for running `scpca-nf` on your own data:
+Two workflow parameters are required for running `scpca-nf` on your own data:
 
-- `run_metafile`: the metadata file with sample information, prepared according to the directions above
-- `outdir`: the output directory where results will be stored
+- `run_metafile`: the metadata file with sample information, prepared according to the directions above. 
+  - This has a default value of `run_metadata.tsv`, but you will likely want to set your own file path.
+- `outdir`: the output directory where results will be stored.
+  - The default output is `scpca_out`, but again, you will likely want to customize this.
 
 By default, the workflow is set up to run in a local environment, and these parameters can be set at the command line as follows:
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -30,12 +30,12 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config my_config.config \
   --run_metafile <path/to/metadata_file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.4` version, and run it based on the settings in the local configuration file `my_config.config`.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.5` version, and run it based on the settings in the local configuration file `my_config.config`.
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
@@ -104,7 +104,7 @@ By default, the workflow is set up to run in a local environment, and these para
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   --run_metafile <path/to/metadata_file> \
   --outdir <path/to/output>
 ```
@@ -127,7 +127,7 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config my_config.config 
 ```
 
@@ -145,7 +145,7 @@ In our example template file [user_template.config](https://github.com/AlexsLemo
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   -config user_template.config \
   -profile cluster
 ```
@@ -180,7 +180,7 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.4 \
+  -r v0.2.5 \
   --repeat_mapping
 ```
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -90,7 +90,6 @@ The following columns may be necessary for running other data modalities (CITE-s
 | `feature_barcode_geom`| A salmon `--read-geometry` layout string/ See https://github.com/COMBINE-lab/salmon/releases for details (only required for CITE-seq) |
 | `slide_section`   | The slide section for spatial transcriptomics samples (only required for spatial transcriptomics) |
 | `slide_serial_number`| The slide serial number for spatial transcriptomics samples (only required for spatial transcriptomics)   |
-| `files`           | All sequencing files in the run folder, `;`-separated (only required for spatial transcriptomics)  |
 
 We have provided an example metadata file for reference that can be found in [`examples/example_metadata.tsv`](examples/example_metadata.tsv).
 
@@ -188,7 +187,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ## Special considerations for using `scpca-nf` with spatial transcriptomics libraries 
 
 To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated `.jpg` file must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file). 
-The metadata file must also contain columns with the `slide_section`, `slide_serial_number`, and list of all `files` inside the run directory, including the `.jpg` image. 
+The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
 
 You will also need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Space Ranger software from 10X Genomics](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest). 
 For licensing reasons, we cannot provide a Docker container with Space Ranger for you. 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -195,7 +195,7 @@ For licensing reasons, we cannot provide a Docker container with Space Ranger fo
 As an example, the Dockerfile that we used to build Space Ranger can be found [here](https://github.com/AlexsLemonade/alsf-scpca/tree/main/images/spaceranger). 
 
 After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.SPACERANGER_CONTAINER` to the registry location and image id in the `user_template.config` file. 
-*Note: The workflow is currently set up to work with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods.*
+*Note: The workflow is currently set up to work only with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods.*
 
 ## Output files 
 

--- a/main.nf
+++ b/main.nf
@@ -18,7 +18,7 @@ cell_barcodes = [
 // supported technologies
 single_cell_techs = cell_barcodes.keySet()
 bulk_techs = ['single_end', 'paired_end']
-spatial_techs = ["spatial", "visium_v1", "visium_v2"]
+spatial_techs = ['spatial', 'visium']
 all_techs = single_cell_techs + bulk_techs + spatial_techs
 rna_techs = single_cell_techs.findAll{it.startsWith('10Xv')}
 feature_techs = single_cell_techs.findAll{it.startsWith('CITEseq') || it.startsWith('cellhash')}

--- a/main.nf
+++ b/main.nf
@@ -79,8 +79,7 @@ workflow {
       feature_barcode_geom: it.feature_barcode_geom,
       files_directory: it.files_directory,
       slide_serial_number: it.slide_serial_number,
-      slide_section: it.slide_section,
-      files: it.files
+      slide_section: it.slide_section
     ]}
     // only technologies we know how to process
     .filter{it.technology in all_techs} 

--- a/main.nf
+++ b/main.nf
@@ -18,7 +18,7 @@ cell_barcodes = [
 // supported technologies
 single_cell_techs = cell_barcodes.keySet()
 bulk_techs = ['single_end', 'paired_end']
-spatial_techs = ['spatial', 'visium']
+spatial_techs = 'visium'
 all_techs = single_cell_techs + bulk_techs + spatial_techs
 rna_techs = single_cell_techs.findAll{it.startsWith('10Xv')}
 feature_techs = single_cell_techs.findAll{it.startsWith('CITEseq') || it.startsWith('cellhash')}

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl=2
 
 process spaceranger{
   container params.SPACERANGER_CONTAINER
-  publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+  publishDir "${meta.spaceranger_publish_dir}"
   tag "${meta.run_id}-spatial" 
   label 'cpus_12'
   label 'mem_24'
@@ -12,9 +12,8 @@ process spaceranger{
     tuple val(meta), path(fastq_dir), file(image_file)
     path index
   output:
-    tuple val(meta), path(spatial_out)
+    tuple val(meta), path(out_id)
   script:
-    spatial_out = "${meta.library_id}"
     out_id = "${meta.run_id}-spatial"
     meta.cellranger_index = index.fileName
     """
@@ -29,39 +28,39 @@ process spaceranger{
       --slide=${meta.slide_serial_number} \
       --area=${meta.slide_section} 
 
-    # make a new directory to hold only the outs file we want to publish 
-    mkdir ${spatial_out}
-
-    # move over needed files to outs directory 
-    mv ${out_id}/outs/filtered_feature_bc_matrix ${spatial_out}
-    mv ${out_id}/outs/raw_feature_bc_matrix ${spatial_out}
-    mv ${out_id}/outs/spatial ${spatial_out}
-    mv ${out_id}/outs/web_summary.html ${spatial_out}/${meta.library_id}_spaceranger_summary.html
-
-    # move over versions file temporarily to be passed to metadata.json
-    mv ${out_id}/_versions ${spatial_out}/spaceranger_versions.json
-    mv ${out_id}/outs/metrics_summary.csv ${spatial_out}/spaceranger_metrics_summary.csv
+    # remove bam and bai files
+    rm ${out_id}/outs/*.bam*
     """
 }
 
-process spaceranger_metadata{
+process spaceranger_publish{
   container params.SCPCATOOLS_CONTAINER
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)
   output:
-    tuple val(meta), path(metadata_json)
+    tuple val(meta), path(spatial_publish_dir), path(metadata_json)
   script:
+    spatial_publish_dir = "${meta.library_id}_spatial"
     metadata_json = "${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """
+    # make a new directory to hold only the outs file we want to publish 
+    mkdir ${spatial_publish_dir}
+
+    # move over needed files to outs directory 
+    mv ${spatial_out}/outs/filtered_feature_bc_matrix ${spatial_publish_dir}
+    mv ${spatial_out}/outs/raw_feature_bc_matrix ${spatial_publish_dir}
+    mv ${spatial_out}/outs/spatial ${spatial_publish_dir}
+    mv ${spatial_out}/outs/web_summary.html ${spatial_publish_dir}/${meta.library_id}_spaceranger_summary.html
+
     generate_spaceranger_metadata.R \
       --library_id ${meta.library_id} \
       --sample_id ${meta.sample_id} \
-      --unfiltered_barcodes_file "${spatial_out}/raw_feature_bc_matrix/barcodes.tsv.gz" \
-      --filtered_barcodes_file "${spatial_out}/filtered_feature_bc_matrix/barcodes.tsv.gz" \
-      --metrics_summary_file "${spatial_out}/spaceranger_metrics_summary.csv" \
-      --spaceranger_versions_file "${spatial_out}/spaceranger_versions.json" \
+      --unfiltered_barcodes_file "${spatial_publish_dir}/raw_feature_bc_matrix/barcodes.tsv.gz" \
+      --filtered_barcodes_file "${spatial_publish_dir}/filtered_feature_bc_matrix/barcodes.tsv.gz" \
+      --metrics_summary_file "${spatial_out}/outs/metrics_summary.csv" \
+      --spaceranger_versions_file "${spatial_out}/_versions" \
       --metadata_json ${metadata_json} \
       --technology ${meta.technology} \
       --seq_unit ${meta.seq_unit} \
@@ -95,21 +94,39 @@ workflow spaceranger_quant{
     // a channel with a map of metadata for each spatial library to process 
     main: 
         // create tuple of (metadata map, [])
-        spaceranger_reads = spatial_channel
-          // add sample names to metadata
-          .map{it.cr_samples =  getCRsamples(it.files); it}
+        spatial_channel = spatial_channel
+          // add sample names and spatial output directory to metadata
+          .map{it.cr_samples =  getCRsamples(it.files);
+               it.spaceranger_publish_dir =  "${params.outdir}/internal/spaceranger/${it.library_id}";
+               it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
+               it}
+          .branch{
+            has_spatial: !params.repeat_mapping & file(it.spaceranger_results_dir).exists()
+            make_spatial: true
+          }
+
           // create tuple of [metadata, fastq dir, and path to image file]
+        spaceranger_reads = spatial_channel.make_spatial
           .map{meta -> tuple(meta,
                             file("${meta.files_directory}"),
                             file("${meta.files_directory}/*.jpg")
                             )}
 
         // run spaceranger
-        spaceranger(spaceranger_reads, params.cellranger_index) \
-          // generate metadata.json
-          | spaceranger_metadata
+        spaceranger(spaceranger_reads, params.cellranger_index)
 
-    // tuple of metadata and path to spaceranger output directory
-    emit: spaceranger.out
+        // gather spaceranger output for completed libraries
+        spaceranger_quants_ch = spatial_channel.has_spatial
+          .map{meta -> tuple(meta,
+                             file("${meta.spaceranger_results_dir}")
+                             )}
+
+        grouped_spaceranger_ch = spaceranger.out.mix(spaceranger_quants_ch)
+
+          // generate metadata.json
+        spaceranger_publish(grouped_spaceranger_ch)
+
+    // tuple of metadata, path to spaceranger output directory, and path to metadata json file
+    emit: spaceranger_publish.out
   
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.2.4'
+  version = 'v0.2.5'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,15 +12,15 @@ manifest{
 // global parameters for workflows
 params {
   // Input data table
-  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+  run_metafile = "run_metadata.tsv"
 
   // Output base directory
-  outdir = "s3://nextflow-ccdl-results/scpca/processed"
+  outdir = "scpca_out"
 
   // run_ids are comma separated list to be parsed into 
   // a list of run ids, library ids, and or sample_ids
   // or "All" to process all samples in the metadata file
-  run_ids = "SCPCR000001,SCPCS000101,SCPCR000050,SCPCR000084"
+  run_ids = "All"
   // to run all samples in a project use that project's submitter name
   project = ""
 
@@ -49,5 +49,9 @@ profiles{
   // AWS batch profile
   batch {
     includeConfig 'config/profile_awsbatch.config'
+  }
+  // CCDL-specific settings
+  ccdl{
+    includeConfig 'config/profile_ccdl.config'
   }
 }


### PR DESCRIPTION
This PR incorporates the changes needed for the release v0.2.5 as mentioned in #141. Here, we are not including any changes related to genetic demultiplexing and we will wait until those changes are complete and documentation has been added before merging into main and incorporating into a release. 

This includes changes that were merged in #134 and #139 to complete the spaceranger workflow. 
I also added the changes from #136 to add in the ccdl specific profile as well (Let me know if I should remove these changes for any reason, but there were no conflicts when merging these). 
I then updated all the release numbers from `0.2.4` to `0.2.5`. 

I did make one minor change in the workflow in `main.nf` related to  https://github.com/AlexsLemonade/ScPCA-admin/issues/341 and that is to remove `visium_v1` and `visium_v2` from the list of technologies and allow for `visium` to be an accepted technology in anticipation of changing all libraries to this tech. I also updated the line in the external instructions that lists the options for tech to reflect this change and added a note at the end of the spatial section that states that only visium libraries have been tested with the workflow and no other spatial transcriptomics methods have been used. I wasn't sure if this was completely necessary, but it seemed like something important to have if we are using `visium` as the technology listed. 