### PR TITLE
Move addition of cellranger index name to `spaceranger_publish` process to avoid null value when spaceranger is skipped

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -37,12 +37,12 @@ process spaceranger_publish{
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)
-    path index
+    val index
   output:
     tuple val(meta), path(spatial_publish_dir), path(metadata_json)
   script:
     spatial_publish_dir = "${meta.library_id}_spatial"
-    meta.cellranger_index = index.fileName
+    meta.cellranger_index = file(index).fileName
     metadata_json = "${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -15,6 +15,7 @@ process spaceranger{
     tuple val(meta), path(out_id)
   script:
     out_id = "${meta.run_id}-spatial"
+    meta.cellranger_index = index.fileName
     """
     spaceranger count \
       --id=${out_id} \
@@ -37,12 +38,12 @@ process spaceranger_publish{
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)
-    val index
+    path index
   output:
     tuple val(meta), path(spatial_publish_dir), path(metadata_json)
   script:
     spatial_publish_dir = "${meta.library_id}_spatial"
-    meta.cellranger_index = file(index).fileName
+    meta.cellranger_index = index.fileName
     metadata_json = "${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -38,12 +38,12 @@ process spaceranger_publish{
   publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)
-    path index
+    val index
   output:
     tuple val(meta), path(spatial_publish_dir), path(metadata_json)
   script:
     spatial_publish_dir = "${meta.library_id}_spatial"
-    meta.cellranger_index = index.fileName
+    meta.cellranger_index = file(index).name
     metadata_json = "${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """


### PR DESCRIPTION
In processing the spatial libraries, I noticed that some of the `metadata.json` values had a null value in the slot for the `mapping_index`, which should correspond to the base filename of the index that was used for mapping. Interestingly, this was only a problem for libraries where the spaceranger process had completed successfully once and the process was being skipped upon re-running the entire project, but not on samples where they whole workflow was run from start to finish. This is because we were adding in the name of the index to the metadata in the spaceranger process, so when that process is skipped, it doesn't get added and then that value is null in the metadata. To accommodate for times when we skip spaceranger but still want to re-generate the metadata file, I moved the addition of the file name to the metadata to the `spaceranger_publish` process instead. I tested this and it does produce a metadata file that looks as expected when skipping the spaceranger process. 

I did think about also directly adding the filename to the metadata at the same time we are adding the publish directories, but I was getting some errors upon doing that so the method I implemented here seemed more straight forward. 

I made this PR to `main` here, as I plan on then creating a PR to `development` with the exact same changes. We would then need a new release in order to process the spatial project to hand over but want to make sure these changes get in before we incorporate any demultiplexing changes. 