### PR TITLE
Move spatial metadata.json to be nested inside spatial folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.6 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.7 -profile ccdl,batch --project SCPCP000000
 ```
 
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -35,12 +35,12 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config my_config.config \
   --run_metafile <path/to/metadata_file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.6` version, and run it based on the settings in the local configuration file `my_config.config`.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the local configuration file `my_config.config`.
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
@@ -111,7 +111,7 @@ By default, the workflow is set up to run in a local environment, and these para
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   --run_metafile <path/to/metadata_file> \
   --outdir <path/to/output>
 ```
@@ -134,7 +134,7 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config my_config.config 
 ```
 
@@ -152,7 +152,7 @@ In our example template file [`user_template.config`](examples/user_template.con
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config user_template.config \
   -profile cluster
 ```
@@ -187,7 +187,7 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   --repeat_mapping
 ```
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -44,7 +44,7 @@ process spaceranger_publish{
   script:
     spatial_publish_dir = "${meta.library_id}_spatial"
     meta.cellranger_index = file(index).name
-    metadata_json = "${meta.library_id}_metadata.json" 
+    metadata_json = "${spatial_publish_dir}/${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """
     # make a new directory to hold only the outs file we want to publish 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.2.6'
+  version = 'v0.2.7'
 }
 
 


### PR DESCRIPTION
Closes #160. Here I updated the line in the spatial workflow that defines the path to the `metadata.json` file to now output the file to be inside the `SCPCL000000_spatial` directory as discussed in our design meeting. I tested this change and the output folder now looks as expected and the metadata file itself still contains the contents it should have. 

I'm also updating the relevant version numbers here as the next steps after filing this PR is to file a PR to `main` with the same exact changes that are included here and then create a new release so that we can process the spatial project again. 