### PR TITLE
Sync moving metadata file and version number updates to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.6 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.2.7 -profile ccdl,batch --project SCPCP000000
 ```
 
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -29,12 +29,12 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config my_config.config \
   --run_metafile <path/to/metadata_file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.6` version, and run it based on the settings in the local configuration file `my_config.config`.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the local configuration file `my_config.config`.
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
@@ -105,7 +105,7 @@ By default, the workflow is set up to run in a local environment, and these para
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   --run_metafile <path/to/metadata_file> \
   --outdir <path/to/output>
 ```
@@ -128,7 +128,7 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config my_config.config 
 ```
 
@@ -146,7 +146,7 @@ In our example template file [user_template.config](https://github.com/AlexsLemo
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   -config user_template.config \
   -profile cluster
 ```
@@ -181,7 +181,7 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.6 \
+  -r v0.2.7 \
   --repeat_mapping
 ```
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -44,7 +44,7 @@ process spaceranger_publish{
   script:
     spatial_publish_dir = "${meta.library_id}_spatial"
     meta.cellranger_index = file(index).name
-    metadata_json = "${meta.library_id}_metadata.json" 
+    metadata_json = "${spatial_publish_dir}/${meta.library_id}_metadata.json" 
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     """
     # make a new directory to hold only the outs file we want to publish 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.2.6'
+  version = 'v0.2.7'
 }
 
 


### PR DESCRIPTION
This PR has the exact same changes that were filed in #164 but to the `main` branch in order to prepare `main` for a new release. Once these changes have been incorporated, we can close #160, as the updates to the spatial workflow will be present in both `main` and `development`. 