### PR TITLE
Reorganize main readme file to include section for external users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This repository holds a [Nextflow](https://www.nextflow.io) workflow to process 
 Fastq files for single-cell and single-nuclei RNA-seq samples are processed using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).
 All samples are aligned, using selective alignment, to an index with transcripts corresponding to spliced cDNA and to intronic regions, denoted by alevin-fry as `splici`. 
 `scpca-nf` can also process CITE-seq, bulk RNA-seq, and spatial transcriptomics. 
-For more information on the processing of all types of modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
+For more information on the processing of all modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
 
-## Using scpca-nf to process samples in your HPC
+## Using scpca-nf to process your samples
 
-The `scpca-nf` workflow is currently set up to process samples as part of the ScPCA portal and requires access to AWS through the CCDL.  
+The `scpca-nf` workflow is currently set up to process samples as part of [the ScPCA portal](https://scpca.alexslemonade.org/) and requires access to AWS through the Data Lab.  
 For all other users, `scpca-nf` can be set up to process your samples in your computing environment by following the [instructions for using `scpca-nf` with external data](external-data-instructions.md). 
 
-:warning: Please note that processing single-cell and single-nuclei RNA-seq samples, requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus. 
+:warning: Please note that processing single-cell and single-nuclei RNA-seq samples, requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 CPUs. 
 
 To run `scpca-nf` on your own samples, you will need to complete the following steps: 
 
@@ -22,7 +22,7 @@ To run `scpca-nf` on your own samples, you will need to complete the following s
 
 If you would like, after you created your configuration file, you may also [test your set up using example data](examples/README.md). 
 
-## Running scpca-nf for the Data Lab staff 
+## Running scpca-nf as a Data Lab staff member
 
 The instructions below assume that you are a member of the CCDL with access to AWS.
 Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ All samples are aligned, using selective alignment, to an index with transcripts
 `scpca-nf` can also process CITE-seq, bulk RNA-seq, and spatial transcriptomics. 
 For more information on the processing of all types of modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
 
-## Using scpca-nf to process samples in your computing environment
+## Using scpca-nf to process samples in your HPC
+
 The `scpca-nf` workflow is currently set up to process samples as part of the ScPCA portal and requires access to AWS through the CCDL.  
 For all other users, `scpca-nf` can be set up to process your samples in your computing environment by following the [instructions for using `scpca-nf` with external data](external-data-instructions.md). 
 
-:warning: As a warning, processing single-cell and single-nuclei RNA-seq samples, requires access to a high power computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus. 
+:warning: Please note that processing single-cell and single-nuclei RNA-seq samples, requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus. 
 
 To run `scpca-nf` on your own samples, you will need to complete the following steps: 
 
 1. [Organize your files](./external-data-instructions.md#file-organization) so that each folder contains fastq files relevant to a single sequencing run. 
-2. [Prepare a metadata file](./external-data-instructions.md#prepare-the-metadata-file) with all associated metadata about the samples you would like to process. 
+2. [Prepare a metadata file](./external-data-instructions.md#prepare-the-metadata-file) with one row per library containing all information needed to process your samples.
 3. Set up a [configuration file](./external-data-instructions.md#configuration-files), including the [definition of a profile](./external-data-instructions.md#setting-up-a-profile-in-the-configuration-file), dictating where nextflow should execute the workflow. 
 
-If you would like, after you created a configuration file, you may also [test your set up using example data](examples/README.md). 
+If you would like, after you created your configuration file, you may also [test your set up using example data](examples/README.md). 
 
 ## Running scpca-nf for the Data Lab staff 
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,23 @@ This repository holds a [Nextflow](https://www.nextflow.io) workflow to process 
 Fastq files for single-cell and single-nuclei RNA-seq samples are processed using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).
 All samples are aligned, using selective alignment, to an index with transcripts corresponding to spliced cDNA and to intronic regions, denoted by alevin-fry as `splici`. 
 `scpca-nf` can also process CITE-seq, bulk RNA-seq, and spatial transcriptomics. 
-For more information on the processing of other modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
+For more information on the processing of all types of modalities, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/). 
 
+## Using scpca-nf to process samples in your computing environment
+The `scpca-nf` workflow is currently set up to process samples as part of the ScPCA portal and requires access to AWS through the CCDL.  
+For all other users, `scpca-nf` can be set up to process your samples in your computing environment by following the [instructions for using `scpca-nf` with external data](external-data-instructions.md). 
 
-## Running scpca-nf for the ScPCA portal 
+:warning: As a warning, processing single-cell and single-nuclei RNA-seq samples, requires access to a high power computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus. 
+
+To run `scpca-nf` on your own samples, you will need to complete the following steps: 
+
+1. [Organize your files](./external-data-instructions.md#file-organization) so that each folder contains fastq files relevant to a single sequencing run. 
+2. [Prepare a metadata file](./external-data-instructions.md#prepare-the-metadata-file) with all associated metadata about the samples you would like to process. 
+3. Set up a [configuration file](./external-data-instructions.md#configuration-files), including the [definition of a profile](./external-data-instructions.md#setting-up-a-profile-in-the-configuration-file), dictating where nextflow should execute the workflow. 
+
+If you would like, after you created a configuration file, you may also [test your set up using example data](examples/README.md). 
+
+## Running scpca-nf for the Data Lab staff 
 
 The instructions below assume that you are a member of the CCDL with access to AWS.
 Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scpca-nf
 
-This repository holds a [Nextflow](https://www.nextflow.io) workflow to process samples as part of the ScPCA project.
+This repository holds a [Nextflow](https://www.nextflow.io) workflow to process samples as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).
 
 Fastq files for single-cell and single-nuclei RNA-seq samples are processed using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).
 All samples are aligned, using selective alignment, to an index with transcripts corresponding to spliced cDNA and to intronic regions, denoted by alevin-fry as `splici`. 
@@ -20,7 +20,7 @@ To run `scpca-nf` on your own samples, you will need to complete the following s
 2. [Prepare a metadata file](./external-data-instructions.md#prepare-the-metadata-file) with one row per library containing all information needed to process your samples.
 3. Set up a [configuration file](./external-data-instructions.md#configuration-files), including the [definition of a profile](./external-data-instructions.md#setting-up-a-profile-in-the-configuration-file), dictating where nextflow should execute the workflow. 
 
-If you would like, after you created your configuration file, you may also [test your set up using example data](examples/README.md). 
+You may also [test your configuration file using example data](examples/README.md).
 
 ## Running scpca-nf as a Data Lab staff member
 


### PR DESCRIPTION
Closes #156. 

Here I reorganized the main `README.md` file so that we have included a section geared towards outside users looking to process their samples with `scpca-nf`. Following the description in #156 and some feed back in the pilot sessions, I kept the beginning intro section unchanged but had the next header be specific to running outside samples for those outside of CCDL. I then changed the next header to make it clear that that section is specifically for CCDL staff. 

In the section for other users, I added the link to the external instructions and also included a brief outline of the steps that they will need to take with links to the sections that have each of the relevant information. I was back and forth on how much information is too much vs. how much information is helpful to get an idea of what you will need to setup. 

I didn't put the command to actually run here, because I want people to actually go to the link and read about how to set up the files. I also anticipate we will do some further reorganization of the external data instructions so that we might have a more detailed intro at the beginning of that (based on #157) where I think commands would be appropriate. 

The other thing I added here was a note about needed specific resources as to begin to address #153. We will also need to make changes throughout to remove the reference to running locally and also will want to put these resource requirements in the main external instructions which is a separate PR, but I thought it would be helpful to have here on the front page as well. 