### PR TITLE
Restructure introduction to external instructions to include an overview of all steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information on the processing of all modalities, please see the [ScPCA 
 The `scpca-nf` workflow is currently set up to process samples as part of [the ScPCA portal](https://scpca.alexslemonade.org/) and requires access to AWS through the Data Lab.  
 For all other users, `scpca-nf` can be set up to process your samples in your computing environment by following the [instructions for using `scpca-nf` with external data](external-data-instructions.md). 
 
-:warning: Please note that processing single-cell and single-nuclei RNA-seq samples, requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 CPUs. 
+:warning: Please note that processing single-cell and single-nuclei RNA-seq samples, requires access to a high performance computing (HPC) environment that can accomodate up to 24 GB of RAM and 12 CPUs. 
 
 To run `scpca-nf` on your own samples, you will need to complete the following steps: 
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -26,20 +26,20 @@ Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data 
 After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process. 
 Here we provide an overview of the steps you will need to complete: 
 
-1. Install the necessary dependencies. 
+1. **Install the necessary dependencies.** 
 You will need to make sure you have the following software installed on your HPC where you plan to execute the workflow: 
     - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
     - [Docker](https://docs.docker.com/get-docker/) or [Singularity](https://sylabs.io/guides/3.0/user-guide/installation.html#installation)
 
-2. Organize your files. 
+2. **Organize your files.** 
 You will need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
 
-3. Create a [metadata file](#prepare-the-metadata-file). 
+3. **Create a [metadata file](#prepare-the-metadata-file).** 
 Create a TSV (tab-separated values) file with one sequencing library per row and pertinent information related to that sequencing run in each column. 
 See the [section below on preparing a metadata file](#prepare-the-metadata-file) for more information on creating a metadata file for your samples.
 
-4. Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file).
+4. **Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file).**
 Create a configuration file that stores user defined parameters and a profile indicating the system and other system related settings to use for executing the workflow. 
 See the [section below on configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment) for more information on setting up the configuration files to run Nextflow on your system.
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -22,21 +22,21 @@
 
  ## Overview 
  
-To use `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus.
-After identifying the HPC that you will use to execute the nextflow workflow, you will need to take the following steps to complete the set up process: 
+Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 CPUs.
+After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process. 
+Here we provide an overview of the steps you will need to complete: 
 
-1. Install the necessary dependencies - Before you can begin, you will need to make sure you ahve the following software installed on your HPC: 
+1. Install the necessary dependencies - You will need to make sure you have the following software installed on your HPC (or where you plan to execute the workflow): 
   - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-  - [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singularity](https://www.nextflow.io/docs/latest/singularity.html)
+  - [Docker](https://docs.docker.com/get-docker/) or [Singularity](https://sylabs.io/guides/3.0/user-guide/installation.html#installation)
 
-2. Organize your files - You will also need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
+2. Organize your files - You will need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
 
-3. Create a [metadata file](#prepare-the-metadata-file) - 
+3. Create a [metadata file](#prepare-the-metadata-file) - Create a TSV (tab separated values) file with one sequencing library per row and pertinent information related to that sequencing run in each column. 
 
-4. Create a [config file] and [define a profile] -
+4. Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file) - Create a configuration file that stores user defined parameters and a profile indicating the system and other system related settings to use for executing the workflow. 
 
-Finally, you will need to create a [metadata file](#prepare-the-metadata-file) and a [nextflow configuration file](#configuration-files) (see below).
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
 
 ```bash
@@ -47,14 +47,15 @@ nextflow run AlexsLemonade/scpca-nf \
   --run_metafile <path to metadata file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined. 
+Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup, `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file), and `<path to metadata file>` is the **full** path to the [metadata file](#prepare-the-metadata-file) you created.  
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
-Successful completion of the workflow will result in gene expression files, a QC file, a metadata file, and associated intermediate files being written to the output directory specified in your config file. 
-See the outputs section for more information. 
+For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary html report and any relevant intermediate files. 
+For a complete description of the expected output files, see the section describing [output files](#output-files).
 
 ## File organization  
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -45,12 +45,11 @@ Once you have set up your environment and created these files you will be able t
 nextflow run AlexsLemonade/scpca-nf \
   -r v0.2.7
   -config <path to config file>  \
-  -profile <name of profile> \
-  --run_metafile <path to metadata file>
+  -profile <name of profile>
 ```
 
 This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined. 
-Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup, `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file), and `<path to metadata file>` is the **full** path to the [metadata file](#prepare-the-metadata-file) you created.  
+Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).   
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -22,21 +22,25 @@
 
  ## Overview
  
-Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 CPUs.
+Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 GB of RAM and 12 CPUs.
 After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process. 
 Here we provide an overview of the steps you will need to complete: 
 
-1. Install the necessary dependencies - You will need to make sure you have the following software installed on your HPC (or where you plan to execute the workflow): 
-  - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-  - [Docker](https://docs.docker.com/get-docker/) or [Singularity](https://sylabs.io/guides/3.0/user-guide/installation.html#installation)
+1. Install the necessary dependencies. 
+You will need to make sure you have the following software installed on your HPC where you plan to execute the workflow: 
+    - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
+    - [Docker](https://docs.docker.com/get-docker/) or [Singularity](https://sylabs.io/guides/3.0/user-guide/installation.html#installation)
 
-2. Organize your files - You will need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
+2. Organize your files. 
+You will need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
 
-3. Create a [metadata file](#prepare-the-metadata-file) - Create a TSV (tab separated values) file with one sequencing library per row and pertinent information related to that sequencing run in each column. 
+3. Create a [metadata file](#prepare-the-metadata-file). 
+Create a TSV (tab-separated values) file with one sequencing library per row and pertinent information related to that sequencing run in each column. 
 See the [section below on preparing a metadata file](#prepare-the-metadata-file) for more information on creating a metadata file for your samples.
 
-4. Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file) - Create a configuration file that stores user defined parameters and a profile indicating the system and other system related settings to use for executing the workflow. 
+4. Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file).
+Create a configuration file that stores user defined parameters and a profile indicating the system and other system related settings to use for executing the workflow. 
 See the [section below on configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment) for more information on setting up the configuration files to run Nextflow on your system.
 
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
@@ -48,14 +52,14 @@ nextflow run AlexsLemonade/scpca-nf \
   -profile <name of profile>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined. 
-Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).   
+Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).  
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
-For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary html report and any relevant intermediate files. 
+For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary HTML report and any relevant intermediate files. 
 For a complete description of the expected output files, see the section describing [output files](#output-files).
 
 ## File organization  

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -20,31 +20,41 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
- ## Overview
+ ## Overview 
  
-In order to use `scpca-nf` to process your own data, you will need to make sure you have the following installed: 
+To use `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 cpus.
+After identifying the HPC that you will use to execute the nextflow workflow, you will need to take the following steps to complete the set up process: 
 
-- [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-- [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singlularity](https://www.nextflow.io/docs/latest/singularity.html) (installed either locally or on an HPC) 
+1. Install the necessary dependencies - Before you can begin, you will need to make sure you ahve the following software installed on your HPC: 
+  - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation)
+  - [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singularity](https://www.nextflow.io/docs/latest/singularity.html)
 
-You will also need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
+2. Organize your files - You will also need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library. 
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
+
+3. Create a [metadata file](#prepare-the-metadata-file) - 
+
+4. Create a [config file] and [define a profile] -
 
 Finally, you will need to create a [metadata file](#prepare-the-metadata-file) and a [nextflow configuration file](#configuration-files) (see below).
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
-  -config my_config.config \
-  --run_metafile <path/to/metadata_file>
+  -r v0.2.7
+  -config <path to config file>  \
+  -profile <name of profile> \
+  --run_metafile <path to metadata file>
 ```
 
-This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the local configuration file `my_config.config`.
+This will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.
 
 **Note:** `scpca-nf` is under active development.
 We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
+
+Successful completion of the workflow will result in gene expression files, a QC file, a metadata file, and associated intermediate files being written to the output directory specified in your config file. 
+See the outputs section for more information. 
 
 ## File organization  
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -20,7 +20,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
- ## Overview 
+ ## Overview
  
 Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 gb of RAM and 12 CPUs.
 After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process. 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -34,8 +34,10 @@ Here we provide an overview of the steps you will need to complete:
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
 
 3. Create a [metadata file](#prepare-the-metadata-file) - Create a TSV (tab separated values) file with one sequencing library per row and pertinent information related to that sequencing run in each column. 
+See the [section below on preparing a metadata file](#prepare-the-metadata-file) for more information on creating a metadata file for your samples.
 
 4. Create a [config file](#configuration-files) and [define a profile](#setting-up-a-profile-in-the-configuration-file) - Create a configuration file that stores user defined parameters and a profile indicating the system and other system related settings to use for executing the workflow. 
+See the [section below on configuring `scpca-nf` for your environment](#configuring-scpca-nf-for-your-environment) for more information on setting up the configuration files to run Nextflow on your system.
 
 Once you have set up your environment and created these files you will be able to start your run as follows, adding any additional optional parameters that you may choose: 
 


### PR DESCRIPTION
Closes #157. 

Here I updated the external user instructions to include an overview of the entire process for setting up a workflow run and outlining the steps in a bit more detail then was there before. Previously we briefly mentioned the dependencies and then the files that we would need and had a command that people could use to run. 

Based on the issue described in #157 and some discussions in pilots, it seems like it would be beneficial to have the introduction section contain some more detail on the amount of work it takes to actually set up a run and a brief overview of setting things up with links to each section. What I did was create an outline in the overview section of the steps that users would need to take, providing a one sentence description of each step and then links to the relevant sections for that step. At the end of this overview section, I included a brief description of the output files and then a link to that section. 

I also included the command that users could use to run the workflow after following all of those steps. The command I chose to use is the one that we recommend using the most, which would require the version number, the configuration file, and the profile name. I took out the use of `--run_metafile` that was previously there, because if users are following the instructions that are outlined in the overview and throughout the document, they put the path to the `run_metafile` in the configuration file and won't need it at the command line. We do include instructions in the `configuring scpca-nf for your environment` section on how to run the workflow by specifying arguments at the command line vs. in the actual configuration file if they choose to do so that way. 

A few things to note: 

- I wrote these instructions with the intension of guiding people to use an HPC or other compute environment with the allocated resources by noting that at the beginning of the section. What I have not done yet is update the remainder of the docs to remove the instructions on running local. I think those changes are separate from these so other parts of this same doc will mention local still. However, this PR is to the `development` branch and it will not appear in the `main` branch until we prepare things for the next release which would include the entire updated instructions. 
- I also wanted to mention that as we make the edits to the mention of running local, we will be editing the reference to the commands that are used. At that point we could think about removing the number of times we reference the version number that's in this document. I did choose to keep the version number in the main command that is in the overview as we still want to point out that users should run with a version. 