### PR TITLE
Make publishing alevin-fry output optional

### DIFF
--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -4,6 +4,10 @@ params{
   run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
   cellhash_pool_file = 's3://ccdl-scpca-data/sample_info/scpca-multiplex-pools.tsv'
   outdir = "s3://nextflow-ccdl-results/scpca/processed"
+
+  // paths to output folders, ccdl format
+  checkpoints_dir = "$outdir/internal"
+  results_dir = "$outdir/publish"
   
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -304,8 +304,11 @@ See below for the expected structure of the `checkpoints` folder:
 ```
 checkpoints
 ├── rad
-│   └── library_id
-│       └── run_id-rna
+│   ├── library01
+│   │   ├── run01-rna
+│   │   └── run02-features
+│   └── library02
+│       └── run03-rna
 └── salmon
 ```
 

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -25,7 +25,7 @@ process alevin_feature{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/internal/rad/${meta.library_id}"
+  publishDir "${params.checkpoints_dir}/rad/${meta.library_id}", enabled: params.publish_fry_outs
   input:
     tuple val(meta), 
           path(read1), path(read2), 
@@ -65,7 +65,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.outdir}/internal/af/${meta.library_id}"
+  publishDir "${params.checkpoints_dir}/af/${meta.library_id}", enabled: params.publish_fry_outs
   input:
     tuple val(meta),
           path(run_dir)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -65,7 +65,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.checkpoints_dir}/af/${meta.library_id}", enabled: params.publish_fry_outs
+  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", enabled: params.publish_fry_outs
   input:
     tuple val(meta),
           path(run_dir)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -45,7 +45,7 @@ process fry_quant_rna{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.checkpoints_dir}/af/${meta.library_id}", enabled: params.publish_fry_outs
+  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", enabled: params.publish_fry_outs
 
   input:
     tuple val(meta), path(run_dir), path(barcode_file)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -45,7 +45,7 @@ process fry_quant_rna{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.outdir}/internal/af/${meta.library_id}"
+  publishDir "${params.checkpoints_dir}/af/${meta.library_id}", enabled: params.publish_fry_outs
 
   input:
     tuple val(meta), path(run_dir), path(barcode_file)
@@ -86,7 +86,7 @@ workflow map_quant_rna {
   main:
     // add rad publish directory, rad directory, and barcode file to meta
     rna_channel = rna_channel
-      .map{it.rad_publish_dir = "${params.outdir}/internal/rad/${it.library_id}";
+      .map{it.rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
            it.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna"; 
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -53,7 +53,7 @@ process salmon{
 
 process merge_bulk_quants {
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.outdir}/publish/${project_id}"
+    publishDir "${params.output_dir}/${project_id}"
     input:
         tuple val(project_id), path(salmon_directories)
         path(tx2gene)
@@ -92,7 +92,7 @@ workflow bulk_quant_rna {
     main: 
         bulk_channel = bulk_channel
           // add salmon directory and salmon file location to meta 
-          .map{it.salmon_publish_dir = "${params.outdir}/internal/salmon";
+          .map{it.salmon_publish_dir = "${params.checkpoints_dir}/salmon";
                it.salmon_results_dir = "${it.salmon_publish_dir}/${it.library_id}";
                it}
           // split based on whether repeat_mapping is false and the salmon quant.sf file exists 

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -20,7 +20,7 @@ workflow genetic_demux_vireo{
   main:
     // add vireo publish directory, vireo directory, and barcode file to meta
     multiplex_ch = multiplex_run_ch
-      .map{it.vireo_publish_dir = "${params.outdir}/internal/vireo/";
+      .map{it.vireo_publish_dir = "${params.checkpoints_dir}/vireo/";
            it.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo"; 
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -4,7 +4,7 @@
 process sce_qc_report{
     container params.SCPCATOOLS_CONTAINER
     tag "${meta.library_id}"
-    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -62,7 +62,7 @@ process filter_sce{
     container params.SCPCATOOLS_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
-    publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
     input: 
         tuple val(meta), path(unfiltered_rds)
     output:
@@ -81,7 +81,7 @@ process genetic_demux_sce{
   container params.SCPCATOOLS_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
-  publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(demux_meta), path(vireo_dir),
           val(meta), path(unfiltered_rds), path(filtered_rds)
@@ -104,7 +104,7 @@ process cellhash_demux_sce{
   container params.SCPCATOOLS_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
-  publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     path cellhash_pool_file

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -35,7 +35,7 @@ process spaceranger{
 
 process spaceranger_publish{
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${params.outdir}/publish/${meta.project_id}/${meta.sample_id}"
+  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
   input:
     tuple val(meta), path(spatial_out)
     val index
@@ -98,7 +98,7 @@ workflow spaceranger_quant{
         spatial_channel = spatial_channel
         // add sample names and spatial output directory to metadata
           .map{it.cr_samples = getCRsamples(it.files_directory);
-               it.spaceranger_publish_dir =  "${params.outdir}/internal/spaceranger/${it.library_id}";
+               it.spaceranger_publish_dir =  "${params.checkpoints_dir}/spaceranger/${it.library_id}";
                it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
                it}
           .branch{

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ params {
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   repeat_mapping = false // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
   repeat_gdemux = false // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_gdemux` to run these steps. 
-  publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--write_fry_outs` to publish these files to the `checkpoints` folder. 
+  publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder. 
 
   seed = 2021   // random number seed for filtering (0 means use system seed)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,10 @@ params {
   // Output base directory
   outdir = "scpca_out"
 
+  // create paths to output folders
+  checkpoints_dir = "$outdir/checkpoints"
+  results_dir = "$outdir/results"
+
   // File containing cellhash pool sample/antibody descriptions
   cellhash_pool_file = ""
 
@@ -31,7 +35,8 @@ params {
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
   repeat_mapping = false // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
   repeat_gdemux = false // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_gdemux` to run these steps. 
-  
+  publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--write_fry_outs` to publish these files to the `checkpoints` folder. 
+
   seed = 2021   // random number seed for filtering (0 means use system seed)
 
   // Docker container images


### PR DESCRIPTION
Closes #154. 

Here the main change I made was to publishing the alevin-fry output files for both the single-cell and CITE-seq alevin fry processes. I utilized the [`enabled` option within Nextflow `publishDir`](https://www.nextflow.io/docs/latest/process.html#publishdir) to only output the files when specified at the command line. I created the parameter  `--publish_fry_outs` (open to new names if anyone has ideas...) and stored it as `false` so that by default we aren't writing out the files. Then if we want to write out the files (or a user wants to write out the files, then you can just use `--publish_fry_outs` at the command line when setting up the run. I tested these changes and it worked as expected, only writing out the files when using `--publish_fry_outs`. 

The other change that was discussed in #154 was using a more meaningful name for the `internal` folder. Here, I switched the names of the folders: 
`internal` --> `checkpoints` 
`publish` --> `results` 
I'm not crazy about results and also thought maybe using `expression_data` or `counts_data`, but was torn so went with `results` and am open to new ideas. 

A few things I thought about when making this change: 
- If I were to just change every place we have `internal` to `checkpoints` then when we went back to re-process any of our internal projects we would have to start from scratch, because the location of the rad files would change. Although we could just re-name the folder on S3 there aren't really folders on S3 so I think we have to copy it to a new name. It's probably feasible but not ideal. 
-  I was noticing that I was making the change in a lot of places... You'll notice that there are a lot of files in this PR but that's mostly because there are files with one line changes from `internal` to `checkpoints`. It seemed not ideal to be making so many of the same changes to multiple files. 

The solution that I came up with to address this was to turn the `checkpoints_dir` and `results_dir` into parameters in the main config file, utilizing the `outdir` as a reference to build the paths to those directories. I did this in both the main `nextflow.config` as well as in the config that holds the `ccdl` profile. The reason for this is twofold - one because if you don't put it in the `ccdl` profile then the only one present is the one in the main config file and then it uses the `outdir` mentioned in the main config file and writes it to a folder `scpca_out` on your local computer rather to the location on S3 where it should be (even when specifying on the command line where to send the outs too). The second reason is this allows us to keep our internal structure for our use if we want and also use an external structure with more meaningful names for them. 

Lastly, I updated the external instructions to reflect the name change and the addition of the optional flag to write out the alevin-fry results. In doing this, I included a tree of the `checkpoints` folder that only shows a limited view of the files since there was a lot of discussion of trees being helpful during the pilots last week. 