### PR TITLE
Reorganize example metadata

### DIFF
--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -1,7 +1,7 @@
-scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_unit	files_directory	submitter_id	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number
-run01	library01	sample01	project01	10Xv3.1	cell	example_fastqs/run01	example01				
-run02	library01	sample01	project01	CITEseq_10Xv3	cell	example_fastqs/run02	example02	example_barcode_files/cite_barcodes.tsv	2[1-15]		
-run03	library02	sample02	project01	visium	spot	example_fastqs/run03	example03			A1	VXXXX-XXX
-run04	library03	sample03;sample04	project01	10Xv3.1	cell	example_fastqs/run04	example04				
-run05	library03	sample03;sample04	project01	cellhash	cell	example_fastqs/run05	example05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]		
-run06	library04	sample05	project01	paired_end	bulk	example_fastqs/run06	example06				
+scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_unit	files_directory	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number
+run01	library01	sample01	project01	10Xv3.1	cell	example_fastqs/run01				
+run02	library01	sample01	project01	CITEseq_10Xv3	cell	example_fastqs/run02	example_barcode_files/cite_barcodes.tsv	2[1-15]		
+run03	library02	sample02	project01	visium	spot	example_fastqs/run03			A1	VXXXX-XXX
+run04	library03	sample03;sample04	project01	10Xv3.1	cell	example_fastqs/run04				
+run05	library03	sample03;sample04	project01	cellhash	cell	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]		
+run06	library04	sample05	project01	paired_end	bulk	example_fastqs/run06				

--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -1,7 +1,7 @@
-scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	submitter	technology	seq_unit	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number	files_directory
-SCPCR999991	SCPCL999991	SCPCS999991	SCPCP999991	example	10Xv3.1	cell					example_fastqs/example1
-SCPCR999992	SCPCL999991	SCPCS999991	SCPCP999991	example	CITEseq_10Xv3	cell	example_barcode_files/cite_barcodes.tsv	2[1-15]			example_fastqs/example2
-SCPCR999993	SCPCL999993	SCPCS999992	SCPCP999992	example	visium_v1	spot			A1	VXXXX-XXX	example_fastqs/example3
-SCPCR999994	SCPCL999994	SCPCS999993;SCPCS999994	SCPCP999993	example	10Xv3.1	cell					example_fastqs/example4
-SCPCR999995	SCPCL999994	SCPCS999993;SCPCS999994	SCPCP999993	example	cellhash	cell	example_barcode_files/cellhash_barcodes.tsv	2[1-10]			example_fastqs/example5
-SCPCR999996	SCPCL999996	SCPCS999996	SCPCP999996	example	paired_end	bulk					example_fastqs/example6
+scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_unit	files_directory	submitter_id	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number
+run01	library01	sample01	project01	10Xv3.1	cell	example_fastqs/run01	example01				
+run02	library01	sample01	project01	CITEseq_10Xv3	cell	example_fastqs/run02	example02	example_barcode_files/cite_barcodes.tsv	2[1-15]		
+run03	library02	sample02	project01	visium	spot	example_fastqs/run03	example03			A1	VXXXX-XXX
+run04	library03	sample03;sample04	project01	10Xv3.1	cell	example_fastqs/run04	example04				
+run05	library03	sample03;sample04	project01	cellhash	cell	example_fastqs/run05	example05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]		
+run06	library04	sample05	project01	paired_end	bulk	example_fastqs/run06	example06				

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -97,6 +97,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_run_id`    | A unique run ID                                              |
 | `scpca_library_id`| A unique library ID for each unique set of cells             |
 | `scpca_sample_id` | A unique sample ID for each tissue or unique source. <br> For multiplexed libraries, separate multiple samples with semicolons (`;`)          |
+| `scpca_project_id` | A unique ID for each group of related samples. All results for samples with the same project ID will be returned in the same folder labeled with the project ID. |
 | `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For cellhash libraries use either `cellhash_10Xv2`, `cellhash_10Xv3`, or `cellhash_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use `visium`      |
 | `seq_unit`        | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`)|
 | `files_directory` | path/uri to directory containing fastq files (unique per run) |
@@ -106,7 +107,6 @@ The following columns may be necessary for running other data modalities (CITE-s
 | column_id       | contents                                                       |
 |-----------------|----------------------------------------------------------------|
 | `submitter_id`    | Original sample identifier defined by user (for reference only; optional)|
-| `submitter`       | Name of user submitting name/id  (optional)                  |
 | `feature_barcode_file` | path/uri to file containing the feature barcode sequences (only required for CITE-seq and cellhash samples)  |	
 | `feature_barcode_geom` | A salmon `--read-geometry` layout string. <br> See https://github.com/COMBINE-lab/salmon/releases/tag/v1.4.0 for details (only required for CITE-seq and cellhash samples) |
 | `slide_section`   | The slide section for spatial transcriptomics samples (only required for spatial transcriptomics) |

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -106,7 +106,6 @@ The following columns may be necessary for running other data modalities (CITE-s
 
 | column_id       | contents                                                       |
 |-----------------|----------------------------------------------------------------|
-| `submitter_id`    | Original sample identifier defined by user (for reference only; optional)|
 | `feature_barcode_file` | path/uri to file containing the feature barcode sequences (only required for CITE-seq and cellhash samples)  |	
 | `feature_barcode_geom` | A salmon `--read-geometry` layout string. <br> See https://github.com/COMBINE-lab/salmon/releases/tag/v1.4.0 for details (only required for CITE-seq and cellhash samples) |
 | `slide_section`   | The slide section for spatial transcriptomics samples (only required for spatial transcriptomics) |


### PR DESCRIPTION
Closes #158 and #163. 

Here I am updating the `example_metadata.tsv` file that we provide to mirror the external user instructions and to have run/library/sample ID's that are easier to understand for external users and not of the format `SCPCX`. I started by moving all of the optional fields to be in the second half of the columns so that the first columns are all of the required fields. 

In doing this I made a few changes to the actual columns: 

- I added `scpca_project_id` to the list of required columns. Previously it wasn't listed at all although we had it in the example file. The reasoning for this is because right now the workflow is set up to nest the output by project ID. If a project ID is not present then it will nest the output into a folder with `no project` as the name. I thought the simpler way to go about this was to add it to the required input rather than to explain that it's optional and that you will get results in a `no project` folder. I also was thinking that maybe we should figure out a way to make nesting by project ID optional in general... but that's a different discussion entirely.
- I also removed `submitter` from the example metadata and changed it to `submitter_id`. We had listed both of these columns in the optional columns list, but I'm not sure what value `submitter` is giving external users since they are the ones trying to run their own data. I thought that `submitter_id` made more sense as that allows them to map back to any original ID's that they use, especially in a case where we might provide them run/sample/library IDs they would be able to use that column to map back to their own personal sample Ids. 

In addition to rearranging the columns I modified the formatting of the IDs, using the format of `run01` and `library01` rather than `SCPCX`. This is consistent with what we landed on when writing the instructions for testing the example data. I updated the ID's and updated the example paths to the fastq files, using the format of `example_fastqs/run01`. Hopefully that makes things a little more clear that each folder should hold an individual sequencing run. If others have other suggestions on how to format these ids please let me know and I'm happy to discuss them. 