### PR TITLE
Include resource requirements and remove local running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To process samples that are not part of the ScPCA project, please see the [instr
 To process single-cell and single-nuclei samples using `scpca-nf` you will need access to 24 GB of RAM and 12 CPUs, so we recommend using AWS batch.
 The first step in running the workflow is ensuring that your AWS credentials are configured. 
 
-You can then run the workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
-Note that you will also need the `ccdl` profile, and you can specify both with by separating them with a comma. 
+You can then run the workflow with the `batch` profile, which has been named in the `nextflow.config` file with full settings set up in the `profile_awsbatch.config` file. 
+Note that you will also need to use the `ccdl` profile to set file paths, and you can specify both profiles by separating them with a comma. 
 
 You can then run the workflow use the following command: 
 

--- a/README.md
+++ b/README.md
@@ -28,16 +28,13 @@ The instructions below assume that you are a member of the CCDL with access to A
 Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure. 
 To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md). 
 
-To run `scpca-nf` in its default configuration for the CCDL, you can use the following command: 
-
-```
-nextflow run AlexsLemonade/scpca-nf -profile ccdl
-```
-Although running workflows locally can be done, we recommend using AWS batch for this workflow. 
+To process single-cell and single-nuclei samples using `scpca-nf` you will need access to 24 GB of RAM and 12 CPUs, so we recommend using AWS batch.
 The first step in running the workflow is ensuring that your AWS credentials are configured. 
 
-You can then run the same workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
-Note that you will still need the `ccdl` profile, and you can specify both with by separating them with a comma. 
+You can then run the workflow with the `batch` profile, which has been configured in the `nextflow.config` file. 
+Note that you will also need the `ccdl` profile, and you can specify both with by separating them with a comma. 
+
+You can then run the workflow use the following command: 
 
 ```
 nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
@@ -48,5 +45,3 @@ When running the workflow for a project or group of samples that is ready to be 
 ```
 nextflow run AlexsLemonade/scpca-nf -r v0.2.7 -profile ccdl,batch --project SCPCP000000
 ```
-
-

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -148,9 +148,10 @@ nextflow run AlexsLemonade/scpca-nf \
 
 For reference, we provide an example template configuration file, [`user_template.config`](examples/user_template.config), which includes some other workflow parameters that may be useful, as well as an example of configuring a profile for executing the workflow on a cluster, discussed below.
 
-**Note:** This example tells Nextflow to use the configuration set up in the configuration file, but it does not invoke a specific profile, which is necessary to tell Nextflow where to execute the workflow.
-Without a profile name, Nextflow will attempt to run the workflow locally which will not work without access to the minimum computing requirements, 24 GB of RAM and 12 CPUs.
-For more on [creating and using a profile](#setting-up-a-profile-in-the-configuration-file) see the below section. 
+**Note:** This example tells Nextflow to use the configuration set up in the configuration file, but it does not invoke a specific profile, and will use the `standard` profile.
+Under the `standard` profile, Nextflow will attempt to run the workflow locally using Docker. 
+This will most likely result in an error unless the minimum computing requirements (24 GB of RAM and 12 CPUs) are met on the local machine.
+For more on [creating and using a profile](#setting-up-a-profile-in-the-configuration-file) see the section below. 
 
 See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) and the below sections for more detail on creating your own configuration file.
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -47,7 +47,7 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7
+  -r v0.2.7 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -122,14 +122,7 @@ Two workflow parameters are required for running `scpca-nf` on your own data:
 - `outdir`: the output directory where results will be stored.
   - The default output is `scpca_out`, but again, you will likely want to customize this.
 
-By default, the workflow is set up to run in a local environment, and these parameters can be set at the command line as follows:
-
-```sh
-nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
-  --run_metafile <path/to/metadata_file> \
-  --outdir <path/to/output>
-```
+These parameters can be set at the command line using `--run_metafile <path to run_metafile>` or `--outdir <path to output>`, but we encourage you to set them in the configuration file, following the [configuration file setup instructions below](#configuration-files).
 
 Note that *workflow* parameters such as `--run_metafile` and `--outdir` are denoted at the command line with double hyphen prefix, while options that affect Nextflow itself have only a single hyphen. 
 
@@ -141,25 +134,29 @@ We could first create a file `my_config.config` (or a filename of your choice) w
 
 ```groovy
 // my_config.config
-params.run_metafile = '<path/to/metadata_file>'
-params.outdir = '<path/to/output>'
+params.run_metafile = '<path to run_metafile>'
+params.outdir = '<path to output>'
 ```
 
 This file is then used with the `-config` (or `-c`) argument at the command line:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
+  -r <tagged version number> \
   -config my_config.config 
 ```
 
 For reference, we provide an example template configuration file, [`user_template.config`](examples/user_template.config), which includes some other workflow parameters that may be useful, as well as an example of configuring a profile for executing the workflow on a cluster, discussed below.
 
+**Note:** This example tells Nextflow to use the configuration set up in the configuration file, but it does not invoke a specific profile, which is necessary to tell Nextflow where to execute the workflow.
+Without a profile name, Nextflow will attempt to run the workflow locally which will not work without access to the minimum computing requirements, 24 GB of RAM and 12 CPUs.
+For more on [creating and using a profile](#setting-up-a-profile-in-the-configuration-file) see the below section. 
+
 See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) and the below sections for more detail on creating your own configuration file.
 
 ### Setting up a profile in the configuration file
 
-Local running may be sufficient for small jobs or testing, but you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
+Processing single-cell and single-nuclei samples requires access to 24 GB of RAM and 12 CPUs so you will most likely want to run your workflow in a high performance computing environment (HPC), such as an institutional computing cluster or on a cloud service like AWS.
 To do this, we recommend using [Nextflow profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) to encapsulate settings like the [`executor`](https://www.nextflow.io/docs/latest/executor.html) that will be used to run each process and associated details that may be required, such as queue names or the container engine (i.e., [Docker](https://www.nextflow.io/docs/latest/docker.html) or [Singularity](https://www.nextflow.io/docs/latest/singularity.html)) your system uses.
 You will likely want to consult your HPC documentation and/or support staff to determine recommended settings.
 
@@ -167,7 +164,7 @@ In our example template file [`user_template.config`](examples/user_template.con
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
+  -r <tagged version number> \
   -config user_template.config \
   -profile cluster
 ```
@@ -194,7 +191,7 @@ The Data Lab's [AWS Batch config file](https://github.com/AlexsLemonade/scpca-nf
 
 ## Repeating mapping steps
 
-By default, `scpca-nf` is set up to skip the `salmon` mapping steps for any libraries in which the output files from the mapping step exist in the `internal` folder of the output directory (i.e. the `.rad` files from `salmon alevin` and `quant.sf` files from `salmon quant`). 
+By default, `scpca-nf` is set up to skip the `salmon` mapping steps for any libraries in which the output files from the mapping step exist in the `checkpoints` folder of the output directory (i.e. the `.rad` files from `salmon alevin` and `quant.sf` files from `salmon quant`). 
 If the `salmon` version and transcriptome index are unchanged, this will save substantial processing time and cost, and avoids some of the sensitivity of the caching system used by `nextflow -resume`, which can sometimes result in rerunning steps unnecessarily.
 However, if there have been updates to the `scpca-nf` workflow that include changes to the salmon version or transcriptome index (or if you change those on your own), you may want to repeat the mapping process. 
 
@@ -202,7 +199,7 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
+  -r <tagged version number> \
   --repeat_mapping
 ```
 
@@ -318,6 +315,7 @@ This will tell the workflow to save the `alevin-fry` outputs to a folder labeled
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
+  -r <tagged version number> \
   -config <path to config file>  \
   -profile <name of profile> \
   --publish_fry_outs

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -55,7 +55,9 @@ Where `<path to config file>` is the **relative** path to the [configuration fil
 This command will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
-Using the above command will run the latest version of the workflow. 
+Using the above command will run the workflow from the `main` branch of the workflow repository. 
+To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command. 
+ 
 To  be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -47,7 +47,6 @@ Once you have set up your environment and created these files you will be able t
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -56,8 +55,16 @@ Where `<path to config file>` is the **relative** path to the [configuration fil
 This command will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
-We strongly encourage you to use a release tagged version of the workflow, set here with the `-r` flag.
+Using the above command will run the latest version of the workflow. 
+To  be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
 Released versions can be found on the [`scpca-nf` repo releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
+
+```bash
+nextflow run AlexsLemonade/scpca-nf \
+  -r v0.2.7 \
+  -config <path to config file>  \
+  -profile <name of profile>
+```
 
 For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary HTML report and any relevant intermediate files. 
 For a complete description of the expected output files, see the section describing [output files](#output-files).
@@ -142,7 +149,6 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r <tagged version number> \
   -config my_config.config 
 ```
 
@@ -165,7 +171,6 @@ In our example template file [`user_template.config`](examples/user_template.con
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r <tagged version number> \
   -config user_template.config \
   -profile cluster
 ```
@@ -200,7 +205,6 @@ To force repeating the mapping process, use the `--repeat_mapping` flag at the c
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r <tagged version number> \
   --repeat_mapping
 ```
 
@@ -316,7 +320,6 @@ This will tell the workflow to save the `alevin-fry` outputs to a folder labeled
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r <tagged version number> \
   -config <path to config file>  \
   -profile <name of profile> \
   --publish_fry_outs


### PR DESCRIPTION
Closes #153. This PR removes any remaining areas of both the main readme and then the external instructions that mentioned running the workflow locally. I also added in statements throughout that mentioned the resource requirements to hopefully drive the point home. 

On the main readme page, I updated the instructions for Data Lab staff to only include running with batch, removing the command that runs locally. 

For the external instructions document, I removed any comments that referred to running the workflow locally and added in the resource requirements in a few places. When referring to setting up parameters I also removed the command that showed setting them at the command line as that didn't have a config file or profile there so if people copy and paste that it would run locally. Instead I included the flag in a sentence of how you could invoke them at the command line but that we encourage people to set them in the config file and linking to the below section. 

In the config file section, I added in a note about how the example command doesn't invoke a profile name and that if using that command as is, it would attempt to run locally which is not advised. Do we think that note is sufficient or do we want to maybe remove that command alltogether (or modify to include a profile)? I was trying to think of the least confusing way to say don't just copy this but this is how to use a config file. 

The other thing I did while going through these instructions was remove the number of times we have the version tag and replaced it with `-r <tagged version number>` throughout. I kept it in the first time we refer to it and then explain what the `-r` means but removed it for the remainder of the command examples to minimize the amount of times we need to change it for a release. 