### PR TITLE
Update version to 0.3.0 to prep for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.2.7 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.3.0 -profile ccdl,batch --project SCPCP000000
 ```

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -52,7 +52,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ```
 
 Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).  
-This command will pull the `scpca-nf` workflow directly from Github, using the `v0.2.7` version, and run it based on the settings in the configuration file that you have defined.  
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.3.0` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
 Using the above command will run the workflow from the `main` branch of the workflow repository. 
@@ -63,7 +63,7 @@ Released versions can be found on the [`scpca-nf` repo releases page](https://gi
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.2.7 \
+  -r v0.3.0 \
   -config <path to config file>  \
   -profile <name of profile>
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.2.7'
+  version = 'v0.3.0'
 }
 
 


### PR DESCRIPTION
This PR preps for the 0.3.0 release and updates the version in the appropriate documents from 0.2.7 to 0.3.0. I am filing this to the `development` branch and then after these changes are merged will create a PR with the changes from `development` to `main` as mentioned in the instructions in #172. 