### PR TITLE
Add metadata for multiplex counts to json

### DIFF
--- a/bin/add_demux_sce.R
+++ b/bin/add_demux_sce.R
@@ -91,7 +91,6 @@ if(is.null(opt$cellhash_pool_file)){
 
 # read in sce rds file
 sce <- readRDS(opt$sce_file)
-metadata(sce)
 
 # check for cellhash altExp if we will use it
 if( opt$hash_demux || opt$seurat_demux ){

--- a/bin/add_demux_sce.R
+++ b/bin/add_demux_sce.R
@@ -1,5 +1,10 @@
 #!/usr/bin/env Rscript
 
+# Script for adding demultiplexing information to a SingleCellExperiment object
+# If provided, it will add genetic demultiplexing information from vireo,
+# and/or demultiplexing based on cellhash data using Seurat::HTOdemux
+# and/or DropletUtils::HashedDrops
+
 # import libraries
 suppressPackageStartupMessages({
   library(optparse)
@@ -86,6 +91,7 @@ if(is.null(opt$cellhash_pool_file)){
 
 # read in sce rds file
 sce <- readRDS(opt$sce_file)
+metadata(sce)
 
 # check for cellhash altExp if we will use it
 if( opt$hash_demux || opt$seurat_demux ){

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -98,7 +98,7 @@ which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",
                                  opt$seq_unit == "nucleus" ~ "unspliced")
 
 # parse sample id list
-sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;"))
+sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -80,7 +80,7 @@ option_list <- list(
     opt_str = "--demux_method",
     type = "character",
     default = "vireo",
-    help = "Demultiplexing method to use for multiplexed samples. One of `vireo`, HTOdemux`, or `HashedDrops`"
+    help = "Demultiplexing method to use for multiplexed samples. One of `vireo`, `HTOdemux`, or `HashedDrops`"
   )
 )
 
@@ -94,6 +94,10 @@ if(is.null(opt$unfiltered_sce) || !file.exists(opt$unfiltered_sce)){
 }
 if(is.null(opt$filtered_sce) || !file.exists(opt$filtered_sce)){
   stop("Filtered .rds file missing or `filtered_sce` not specified.")
+}
+demux_methods <- c("vireo", "HTODemux", "HashedDrops")
+if(opt$demux_method %in% demux_methods){
+  stop("Unknown `demux_method` value. Must be one of `vireo`, `HTOdemux`, or `HashedDrops`")
 }
 
 if (opt$workflow_url == "null"){
@@ -165,12 +169,10 @@ metadata_list <- list(
 
 # estimate cell counts for multiplexed samples
 if(multiplexed){
-  demux_method = match.arg(opt$demux_method,
-                           c("vireo", "HTODemux", "HashedDrops"))
-  demux_column <- paste0(demux_method, "_sampleid")
+  demux_column <- paste0(opt$demux_method, "_sampleid")
   demux_counts <- colData(filtered_sce)[[demux_column]] |>
     table() |>
-    as.list()
+    as.list() # save as a list for json output
 
   # add demux info to the metadata list
   metadata_list <- append(

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -121,12 +121,12 @@ sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 multiplexed = if (length(sample_ids) > 1){TRUE} else {FALSE}
 
 # sanity check ids
-if (sce_meta$sample_id){
+if (!is.null(sce_meta$sample_id)){
   if (!all.equal(sample_ids, sce_meta$sample_id)){
     stop("--sample_id  does not match SCE metadata")
   }
 }
-if (sce_meta$library_id){
+if (!is.null(sce_meta$library_id)){
   if (opt$library_id != sce_meta$library_id){
     stop("--library_id  does not match SCE metadata")
   }

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -173,10 +173,12 @@ if(multiplexed){
     as.list()
 
   # add demux info to the metadata list
-  metadata_list <- c(metadata_list,
-                     demux_method = demux_method,
-                     demux_samples = sample_ids,
-                     sample_cell_estimates = demux_counts)
+  metadata_list <- append(
+    metadata_list,
+    list(demux_method = demux_method,
+         demux_samples = sample_ids,
+         sample_cell_estimates = demux_counts)
+  )
 }
 
 # Output metadata as JSON

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -140,7 +140,7 @@ has_cellhash <- "cellhash" %in% alt_expts
 
 metadata_list <- list(
   library_id = opt$library_id,
-  sample_id = sample_ids,
+  sample_id = opt$sample_id,
   technology = opt$technology,
   seq_unit = opt$seq_unit,
   is_multiplexed = multiplexed,
@@ -161,7 +161,7 @@ metadata_list <- list(
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
-  purrr::map(~if(is.null(.)) NA else .) # convert any NULLS to NA
+  purrr::map(~if(is.null(.)) NA else . ) # convert any NULLS to NA
 
 # estimate cell counts for multiplexed samples
 if(multiplexed){
@@ -172,9 +172,10 @@ if(multiplexed){
     table() |>
     as.list()
 
-  # add to the metadata list
+  # add demux info to the metadata list
   metadata_list <- c(metadata_list,
                      demux_method = demux_method,
+                     demux_samples = sample_ids,
                      sample_cell_estimates = demux_counts)
 }
 

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -6,8 +6,8 @@ params{
   outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
   // paths to output folders, ccdl format
-  checkpoints_dir = "$outdir/internal"
-  results_dir = "$outdir/publish"
+  checkpoints_dir = "${params.outdir}/internal"
+  results_dir = "${params.outdir}/publish"
   
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -13,6 +13,7 @@ process sce_qc_report{
         qc_report = "${meta.library_id}_qc.html"
         metadata_json = "${meta.library_id}_metadata.json"
         workflow_url = workflow.repository ?: workflow.manifest.homePage
+        workflow_version = workflow.revision ?: workflow.manifest.version
         """
         sce_qc_report.R \
           --library_id "${meta.library_id}" \
@@ -25,7 +26,7 @@ process sce_qc_report{
           --seq_unit "${meta.seq_unit}" \
           --genome_assembly "${params.assembly}" \
           --workflow_url "${workflow_url}" \
-          --workflow_version "${workflow.revision}" \
+          --workflow_version "${workflow_version}" \
           --workflow_commit "${workflow.commitId}"
         """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,6 @@ manifest{
   version = 'v0.2.7'
 }
 
-
 // global parameters for workflows
 params {
   // Input data table
@@ -18,8 +17,8 @@ params {
   outdir = "scpca_out"
 
   // create paths to output folders
-  checkpoints_dir = "$outdir/checkpoints"
-  results_dir = "$outdir/results"
+  checkpoints_dir = "${params.outdir}/checkpoints"
+  results_dir = "${params.outdir}/results"
 
   // File containing cellhash pool sample/antibody descriptions
   cellhash_pool_file = ""


### PR DESCRIPTION
Closes #175

This PR is primarily about adding a sampling of the demultiplexing results to the `_metadata.json` file. I decided to make teh demultiplexing method an option, rather than having it vary by sample. Currently it uses `vireo` by default, and I don't specify the option in the workflow itself, but it is present in the script. I could add it there if we think it would clarify anything, or as a pointer for sometime in the future when we might reconsider.

