### PR TITLE
Update alevin-fry and salmon versions

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,11 +1,11 @@
 // Docker container images
 SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.5'
 
-ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.2--h7d875b9_0'
+ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
 CELLSNP_CONTAINER = 'quay.io/biocontainers/cellsnp-lite:1.2.2--h22771d5_0'
 FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
-SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
+SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.8.0--h7e5ed60_0'
 SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
 STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
 

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -6,8 +6,8 @@ params{
   outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
   // paths to output folders, ccdl format
-  checkpoints_dir = "$outdir/internal"
-  results_dir = "$outdir/publish"
+  checkpoints_dir = "${params.outdir}/internal"
+  results_dir = "${params.outdir}/publish"
   
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,8 +18,8 @@ params {
   outdir = "scpca_out"
 
   // create paths to output folders
-  checkpoints_dir = "$outdir/checkpoints"
-  results_dir = "$outdir/results"
+  checkpoints_dir = "${params.outdir}/checkpoints"
+  results_dir = "${params.outdir}/results"
 
   // File containing cellhash pool sample/antibody descriptions
   cellhash_pool_file = ""


### PR DESCRIPTION
Closes #181. Pretty much does what it says and updates the containers that we are using for alevin-fry and Salmon to include the latest versions, 1.8.0 for Salmon and 0.5.0 for alevin-fry. 
I also included the updates to use the parameters to build the `checkpoints_dir` and `results_dir`. 
