### PR TITLE
Remove miQC try/while loop and update scpcaTools version 

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -61,12 +61,6 @@ filtered_sce <- filtered_sce |>
 # add prob_compromised to colData and miQC model to metadata
 filtered_sce <- scpcaTools::add_miQC(filtered_sce)
 
-# set prob_compromised to NA if miQC failed
-if (is.null(miqc_sce)){
-  filtered_sce$prob_compromised <- NA_real_
-}
-
-
 # grab names of altExp, if any
 alt_names <- altExpNames(filtered_sce)
 

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -59,7 +59,18 @@ filtered_sce <- filtered_sce |>
   scuttle::addPerFeatureQCMetrics()
 
 # add prob_compromised to colData and miQC model to metadata
-filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+# since this can fail, we will check for success
+miQC_worked <- FALSE
+try({
+  filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+  miQC_worked <- TRUE
+ })
+ 
+# set prob_compromised to NA if miQC failed
+if (!miQC_worked){
+  warning("miQC failed. Setting `prob_compromised` to NA.")
+  filtered_sce$prob_compromised <- NA_real_
+}
 
 # grab names of altExp, if any
 alt_names <- altExpNames(filtered_sce)

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -59,16 +59,8 @@ filtered_sce <- filtered_sce |>
   scuttle::addPerFeatureQCMetrics()
 
 # add prob_compromised to colData and miQC model to metadata
-# since this can fail, we will try it 3 times
-miqc_attempt <- 0
-miqc_sce <- NULL
-while (miqc_attempt < 3 && is.null(miqc_sce)){
-  miqc_attempt <- miqc_attempt + 1
-  try({
-    miqc_sce <- scpcaTools::add_miQC(filtered_sce)
-    filtered_sce <- miqc_sce
-    })
-}
+filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+
 # set prob_compromised to NA if miQC failed
 if (is.null(miqc_sce)){
   filtered_sce$prob_compromised <- NA_real_

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.6'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.5'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'


### PR DESCRIPTION
Since the new changes that have been incorporated into `scpcaTools` fix the errors seen in miQC we no longer need to have the try/while loop around adding the miQC results to the filtered sce object here. I've removed it and restored the line back to what it was previously, which was just calling `scpcaTools::add_miQC()`. I tested that the changes in `scpcaTools` were sufficient to catch the miQC error and fix it by using the `edge` tag for `scpcaTools` first and testing the workflow on some of the libraries that were previously failing. I confirmed that they do indeed pass now and complete the workflow. I also updated the tag and am using the tag for what will be the next release of `scpcaTools`. 