### PR TITLE
update param for merge_bulk_quants

### DIFF
--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -53,7 +53,7 @@ process salmon{
 
 process merge_bulk_quants {
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.output_dir}/${project_id}"
+    publishDir "${params.outdir}/${project_id}"
     input:
         tuple val(project_id), path(salmon_directories)
         path(tx2gene)


### PR DESCRIPTION
In testing autoscaling, we ran into a warning about the publishDir, which resulted from an error in the param setting for the `merge_bulk_quants` process. This should the one-line fix. Not sure why we didn't see this earlier?