### PR TITLE
Change generate_qc_report argument name and update version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.3.1 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.3.2 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -187,7 +187,7 @@ if(multiplexed){
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
 
 scpcaTools::generate_qc_report(
-  sample_name = metadata_list$library_id,
+  library_id = metadata_list$library_id,
   unfiltered_sce = unfiltered_sce,
   filtered_sce = filtered_sce,
   output = opt$qc_report_file

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.7'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.6'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -52,7 +52,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ```
 
 Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).  
-This command will pull the `scpca-nf` workflow directly from Github, using the `v0.3.1` version, and run it based on the settings in the configuration file that you have defined.  
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.3.2` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
 Using the above command will run the workflow from the `main` branch of the workflow repository. 
@@ -63,7 +63,7 @@ Released versions can be found on the [`scpca-nf` repo releases page](https://gi
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.3.1 \
+  -r v0.3.2 \
   -config <path to config file>  \
   -profile <name of profile>
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.3.1'
+  version = 'v0.3.2'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
Closes #194. 

Here I changed the name for the argument used when calling `scpcaTools::generate_qc_report()` to reflect the new argument, `library_id`. I tested this and all looked good and produced a QC report as expected for a multiplexed library. 

I also am changing the version of `scpcaTools` that we are using to v0.1.7 and then updating the version for `scpca-nf` to v0.3.2 to prepare for the new release. 