### PR TITLE
Skip demultiplexing if only one cellhash ID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release: 
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.3.2 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.3.3 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data 

--- a/bin/add_demux_sce.R
+++ b/bin/add_demux_sce.R
@@ -103,22 +103,25 @@ if( opt$hash_demux || opt$seurat_demux ){
   }
 }
 
+cellhash_ids <- rownames(altExp(sce))
 
-
-# add HashedDrops results
-if(opt$hash_demux){
-  sce <- scpcaTools::add_demux_hashedDrops(sce)
-}
-
-# add Seurat results
-if(opt$seurat_demux){
-  sce <- scpcaTools::add_demux_seurat(sce)
-}
-
-# add vireo results
-if(!is.null(opt$vireo_dir)){
-  vireo_table <- readr::read_tsv(vireo_file)
-  sce <- scpcaTools::add_demux_vireo(sce, vireo_table)
+# only perform demultiplexing if more than one HTO is detected
+if(length(cellhash_ids) > 1) {
+  # add HashedDrops results
+  if(opt$hash_demux){
+    sce <- scpcaTools::add_demux_hashedDrops(sce)
+  }
+  
+  # add Seurat results
+  if(opt$seurat_demux){
+    sce <- scpcaTools::add_demux_seurat(sce)
+  }
+  
+  # add vireo results
+  if(!is.null(opt$vireo_dir)){
+    vireo_table <- readr::read_tsv(vireo_file)
+    sce <- scpcaTools::add_demux_vireo(sce, vireo_table)
+  } 
 }
 
 # write filtered sce to output

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.8'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.7'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -52,7 +52,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ```
 
 Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).  
-This command will pull the `scpca-nf` workflow directly from Github, using the `v0.3.2` version, and run it based on the settings in the configuration file that you have defined.  
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.3.3` version, and run it based on the settings in the configuration file that you have defined.  
 
 **Note:** `scpca-nf` is under active development.
 Using the above command will run the workflow from the `main` branch of the workflow repository. 
@@ -63,7 +63,7 @@ Released versions can be found on the [`scpca-nf` repo releases page](https://gi
 
 ```bash
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.3.2 \
+  -r v0.3.3 \
   -config <path to config file>  \
   -profile <name of profile>
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.3.2'
+  version = 'v0.3.3'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
When running the library that had only one HTO, but was classified as demultiplexing, Seurat was failing to perform demultiplexing. To avoid this, we discussed skipping demultiplexing altogether if there is only one HTO and not reporting sample calls. 

Here I check for the number of cellhash ID's and if that's > 1, then we continue with add the demultiplexing results. We are also making changes in scpcaTools to the QC report to adjust for samples like this (AlexsLemonade/scpcaTools#111). I will wait until that gets merged and I can then test those changes with`scpcaTools::edge` and these changes before wrapping up this PR, so I'm going to keep it in a draft state for now. I did test these changes and things worked successfully, but I would like to test in combination with the changes to `scpcaTools`. 