### PR TITLE
Jashapiro default multiplex

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ params {
   results_dir = "${params.outdir}/results"
 
   // File containing cellhash pool sample/antibody descriptions
-  cellhash_pool_file = ""
+  cellhash_pool_file = "multiplex_pools.tsv"
 
   // run_ids are comma separated list to be parsed into 
   // a list of run ids, library ids, and or sample_ids


### PR DESCRIPTION
This adds a dummy file name to hopefully fix a bug when a real multiplex pool file is not specified.