### PR TITLE
Track metadata in checkpoints

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,11 +1,11 @@
 // Docker container images
 SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.1.9'
 
-ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.5.0--h7d875b9_0'
+ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
 CELLSNP_CONTAINER = 'quay.io/biocontainers/cellsnp-lite:1.2.2--h22771d5_0'
 FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
-SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.8.0--h7e5ed60_0'
+SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1'
 SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
 STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
 

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -5,10 +5,10 @@ params{
   cellhash_pool_file = 's3://ccdl-scpca-data/sample_info/scpca-multiplex-pools.tsv'
   outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
-  // paths to output folders, ccdl format
-  checkpoints_dir = "${params.outdir}/internal"
-  results_dir = "${params.outdir}/publish"
-  
+  // paths to output folders, redefined to use `outdir` above
+  checkpoints_dir = "${params.outdir}/checkpoints"
+  results_dir = "${params.outdir}/results"
+
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"
 

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -18,4 +18,4 @@ t2g_3col_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced
 t2g_bulk_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"
 
 // barcode files
-barcode_dir      = '${params.ref_rootdir}/barcodes/10X'
+barcode_dir      = "${params.ref_rootdir}/barcodes/10X"

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -1,20 +1,21 @@
-// reference params and files 
+// reference params and files
 assembly         = 'Homo_sapiens.GRCh38.104'
-ref_dir          = 's3://scpca-references/homo_sapiens/ensembl-104'
-ref_fasta        = "$ref_dir/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz"
-ref_fasta_index  = "$ref_dir/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai"
-ref_gtf          = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.gtf.gz"  
+ref_rootdir      = 's3://scpca-references'
+ref_dir          = "${params.ref_rootdir}/homo_sapiens/ensembl-104"
+ref_fasta        = "${params.ref_dir}/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz"
+ref_fasta_index  = "${params.ref_dir}/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai"
+ref_gtf          = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.gtf.gz"
 
-// index files 
-splici_index     = "$ref_dir/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome"
-bulk_index       = "$ref_dir/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome" 
-cellranger_index = "$ref_dir/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full"
-star_index       = "$ref_dir/star_index/Homo_sapiens.GRCh38.104.star_idx"
+// index files
+splici_index     = "${params.ref_dir}/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome"
+bulk_index       = "${params.ref_dir}/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome"
+cellranger_index = "${params.ref_dir}/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full"
+star_index       = "${params.ref_dir}/star_index/Homo_sapiens.GRCh38.104.star_idx"
 
-// annotation files 
-mito_file        = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt"
-t2g_3col_path    = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
-t2g_bulk_path    = "$ref_dir/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"  
+// annotation files
+mito_file        = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt"
+t2g_3col_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
+t2g_bulk_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"
 
 // barcode files
-barcode_dir      = 's3://scpca-references/barcodes/10X' 
+barcode_dir      = '${params.ref_rootdir}/barcodes/10X'

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -1,0 +1,17 @@
+// Groovy functions used in multiple modules/processes
+
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+
+class Utils {
+  def readMeta(path) {
+    meta = new JsonSlurper().parse(file(path))
+    return(meta)
+  }
+
+  def makeJson(meta) {
+    meta_json = JsonOutput.toJson(meta)
+    meta_json = JsonOutput.prettyPrint(meta_json)
+    return(meta_json)
+  }
+}

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -1,22 +1,42 @@
-// Groovy functions used in multiple modules/processes
 
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-
+/**
+ * Utility functions for scpca-nf
+ */
 class Utils {
+
+   /**
+     * Read a metadata file in JSON format
+     *
+     * @param file A Nextflow file object with metadata in JSON format
+     * @return Metadata as a groovy Map object
+     */
   static def readMeta(file) {
     def meta = new JsonSlurper().parse(file)
     return(meta)
   }
 
+  /**
+   * Write a metadata map to a JSON string
+   *
+   * @param meta A metadata map
+   * @return A JSON string
+   */
   static def makeJson(meta) {
     def meta_json = JsonOutput.toJson(meta)
     meta_json = JsonOutput.prettyPrint(meta_json)
     return(meta_json)
   }
 
-  static def getJsonVal(file, key){
+  /**
+   * Read an element from a metadata file in JSON format
+   *
+   * @param file A Nextflow file object with metadata in JSON format
+   * @return A value from the metadata
+   */
+  static def getMetaVal(file, key){
     def obj = new JsonSlurper().parse(file)
     return(obj[key])
   }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -15,4 +15,9 @@ class Utils {
     meta_json = JsonOutput.prettyPrint(meta_json)
     return(meta_json)
   }
+
+  static def getJsonVal(file, key){
+    def obj = new JsonSlurper().parse(file)
+    return(obj[key])
+  }
 }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -3,14 +3,15 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
+
 class Utils {
-  def readMeta(path) {
-    meta = new JsonSlurper().parse(file(path))
+  static def readMeta(file) {
+    def meta = new JsonSlurper().parse(file)
     return(meta)
   }
 
-  def makeJson(meta) {
-    meta_json = JsonOutput.toJson(meta)
+  static def makeJson(meta) {
+    def meta_json = JsonOutput.toJson(meta)
     meta_json = JsonOutput.prettyPrint(meta_json)
     return(meta_json)
   }

--- a/main.nf
+++ b/main.nf
@@ -81,7 +81,16 @@ workflow {
       feature_barcode_geom: it.feature_barcode_geom,
       files_directory: it.files_directory,
       slide_serial_number: it.slide_serial_number,
-      slide_section: it.slide_section
+      slide_section: it.slide_section,
+      ref_assembly: params.assembly,
+      ref_fasta: params.ref_fasta,
+      ref_gtf: params.ref_gtf,
+      salmon_splici_index: params.splici_index,
+      salmon_bulk_index: params.bulk_index,
+      cellranger_index: params.cellranger_index,
+      star_index: params.star_index,
+      scpca_version: workflow.manifest.version,
+      nextflow_version: nextflow.version
     ]}
 
  runs_ch = unfiltered_runs_ch

--- a/main.nf
+++ b/main.nf
@@ -131,7 +131,7 @@ workflow {
   // join feature & RNA quants for feature reads
   feature_rna_quant_ch = map_quant_feature.out
     .map{[it[0]["library_id"]] + it } // add library_id from metadata as first element
-    .join(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0, remainder: true, failOnDuplicate: true) // join by library_id
+    .join(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0, failOnDuplicate: true, failOnMismatch: true) // join by library_id
     .map{it.drop(1)} // remove library_id index
   // make rds for merged RNA and feature quants
   feature_sce_ch = generate_merged_sce(feature_rna_quant_ch)
@@ -158,7 +158,7 @@ workflow {
   // output structure: [meta_demux, vireo_dir, meta_sce, sce_rds]
   demux_results_ch = genetic_demux_vireo.out
     .map{[it[0]["library_id"]] + it }
-    .join(sce_ch.multiplex.map{[it[0]["library_id"]] + it }, by: 0, remainder: true, failOnDuplicate: true)
+    .join(sce_ch.multiplex.map{[it[0]["library_id"]] + it }, by: 0, failOnDuplicate: true, failOnMismatch: true)
     .map{it.drop(1)}
   // add genetic demux results to sce objects
   genetic_demux_sce(demux_results_ch)

--- a/main.nf
+++ b/main.nf
@@ -131,7 +131,8 @@ workflow {
   // join feature & RNA quants for feature reads
   feature_rna_quant_ch = map_quant_feature.out
     .map{[it[0]["library_id"]] + it } // add library_id from metadata as first element
-    .join(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0, failOnDuplicate: true, failOnMismatch: true) // join by library_id
+    // join rna quant to feature quant by library_id; expect mismatches for rna-only, so don't fail
+    .join(map_quant_rna.out.map{[it[0]["library_id"]] + it }, by: 0, failOnDuplicate: true, failOnMismatch: false)
     .map{it.drop(1)} // remove library_id index
   // make rds for merged RNA and feature quants
   feature_sce_ch = generate_merged_sce(feature_rna_quant_ch)

--- a/main.nf
+++ b/main.nf
@@ -68,7 +68,7 @@ workflow {
 
   unfiltered_runs_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
-    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
+    // convert row data to a metadata map, keeping columns we will need (& some renaming) and reference paths
     .map{[
       run_id: it.scpca_run_id,
       library_id: it.scpca_library_id,
@@ -86,7 +86,9 @@ workflow {
       ref_fasta: params.ref_fasta,
       ref_gtf: params.ref_gtf,
       salmon_splici_index: params.splici_index,
+      t2g_3col_path: params.t2g_3col_path,
       salmon_bulk_index: params.bulk_index,
+      t2g_bulk_path: params.t2g_bulk_path,
       cellranger_index: params.cellranger_index,
       star_index: params.star_index,
       scpca_version: workflow.manifest.version,

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -113,14 +113,14 @@ workflow map_quant_feature{
     index_feature(feature_barcodes_ch)
 
     // create tuple of [metadata, [Read1 files], [Read2 files]]
-    // We start by including the feature_barcode file so we can join to the indices, but that will be removed
+    // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
     feature_reads_ch = feature_channel
       .map{meta -> tuple(meta.feature_barcode_file,
                          meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
                          file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
-      .join(index_feature.out, by: 0) // join by the feature_barcode_file
+      .combine(index_feature.out, by: 0) // combine by the feature_barcode_file (reused indices, so combine is needed)
       .map{ it.drop(1)} // remove the first element (feature_barcode_file)
 
     cellbarcode_ch = feature_channel

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -2,7 +2,7 @@
 //index a feature barcode file
 process index_feature{
   container params.SALMON_CONTAINER
-  
+
   input:
     tuple val(id), path(feature_file)
   output:
@@ -13,7 +13,7 @@ process index_feature{
       -t ${feature_file} \
       -i feature_index \
       --features \
-      -k 7 
+      -k 7
 
     awk '{print \$1"\\t"\$1;}' ${feature_file} > feature_index/t2g.tsv
     """
@@ -27,8 +27,8 @@ process alevin_feature{
   tag "${meta.run_id}-features"
   publishDir "${params.checkpoints_dir}/rad/${meta.library_id}", enabled: params.publish_fry_outs
   input:
-    tuple val(meta), 
-          path(read1), path(read2), 
+    tuple val(meta),
+          path(read1), path(read2),
           path(feature_index)
   output:
     tuple val(meta),
@@ -73,8 +73,8 @@ process fry_quant_feature{
   output:
     tuple val(meta),
           path(run_dir)
-  
-  script: 
+
+  script:
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
@@ -86,7 +86,7 @@ process fry_quant_feature{
       --input-dir ${run_dir} \
       --rad-dir ${run_dir} \
       -t ${task.cpus}
-    
+
     alevin-fry quant \
       --input-dir ${run_dir} \
       --tg-map ${run_dir}/t2g.tsv \
@@ -96,7 +96,7 @@ process fry_quant_feature{
       -t ${task.cpus} \
 
     # remove large files
-    rm ${run_dir}/*.rad ${run_dir}/*.bin 
+    rm ${run_dir}/*.rad ${run_dir}/*.bin
     """
 }
 
@@ -120,17 +120,17 @@ workflow map_quant_feature{
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
                          file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
-      .combine(index_feature.out, by: 0) // combine by the feature_barcode_file
-      .map{ it.subList(1, it.size())} // remove the first element (feature_barcode_file)
-    
+      .join(index_feature.out, by: 0) // join by the feature_barcode_file
+      .map{ it.drop(1)} // remove the first element (feature_barcode_file)
+
     cellbarcode_ch = feature_channel
       .map{file("${params.barcode_dir}/${params.cell_barcodes[it.technology]}")}
 
     // run Alevin on feature reads
     alevin_feature(feature_reads_ch)
-    // quantify feature reads 
+    // quantify feature reads
     fry_quant_feature(alevin_feature.out, cellbarcode_ch)
-  
+
   emit: fry_quant_feature.out
   // a tuple of metadata map and the alevin-fry output directory
 }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -119,7 +119,7 @@ workflow map_quant_rna {
     // combine output from running alevin step with channel containing libraries that skipped creating a RAD file
     all_rad_ch = alevin_rad.out.mix(rna_rad_ch)
       // add barcode and t2g files to channel to use in fry_quant_rna process
-      .map{it.toList() += [file(it[0].barcode_file), file(it[0].t2g_3col_path)]}
+      .map{it += [file(it[0].barcode_file), file(it[0].t2g_3col_path)]}
 
     // quantify with alevin-fry
     fry_quant_rna(all_rad_ch)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -119,7 +119,7 @@ workflow map_quant_rna {
     // combine output from running alevin step with channel containing libraries that skipped creating a RAD file
     all_rad_ch = alevin_rad.out.mix(rna_rad_ch)
       // add barcode and t2g files to channel to use in fry_quant_rna process
-      .map{it += [file(it[0].barcode_file), file(it[0].t2g_3col_path)]}
+      .map{it.toList() + [file(it[0].barcode_file), file(it[0].t2g_3col_path)]}
 
     // quantify with alevin-fry
     fry_quant_rna(all_rad_ch)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -9,11 +9,11 @@ process alevin_rad{
   tag "${meta.run_id}-rna"
   publishDir "${meta.rad_publish_dir}"
   input:
-    tuple val(meta), 
+    tuple val(meta),
           path(read1), path(read2)
     path index
   output:
-    tuple val(meta), path(rad_dir) 
+    tuple val(meta), path(rad_dir)
   script:
     // define the local location for the rad output
     rad_dir = file(meta.rad_dir).name
@@ -22,7 +22,9 @@ process alevin_rad{
                  '10Xv2_5prime': '--chromium',
                  '10Xv3': '--chromiumV3',
                  '10Xv3.1': '--chromiumV3']
-    // run alevin like normal with the --rad flag 
+    // get meta to write as file
+    meta_json = Utils.makeJson(meta)
+    // run alevin like normal with the --rad flag
     // creates output directory with RAD file needed for alevin-fry
     """
     mkdir -p ${rad_dir}
@@ -36,6 +38,8 @@ process alevin_rad{
       -p ${task.cpus} \
       --dumpFeatures \
       --rad
+
+    echo '${meta_json}' > ${rad_dir}/scpca-meta.json
     """
 }
 
@@ -52,8 +56,8 @@ process fry_quant_rna{
     path tx2gene_3col
   output:
     tuple val(meta), path(run_dir)
-  
-  script: 
+
+  script:
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
@@ -65,7 +69,7 @@ process fry_quant_rna{
       --input-dir ${run_dir} \
       --rad-dir ${run_dir} \
       -t ${task.cpus}
-    
+
     alevin-fry quant \
       --input-dir ${run_dir} \
       --tg-map ${tx2gene_3col} \
@@ -75,7 +79,7 @@ process fry_quant_rna{
       -t ${task.cpus} \
 
     # remove large files
-    rm ${run_dir}/*.rad ${run_dir}/*.bin 
+    rm ${run_dir}/*.rad ${run_dir}/*.bin
     """
 }
 
@@ -87,16 +91,16 @@ workflow map_quant_rna {
     // add rad publish directory, rad directory, and barcode file to meta
     rna_channel = rna_channel
       .map{it.rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
-           it.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna"; 
+           it.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna";
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
-          has_rad: !params.repeat_mapping && file(it.rad_dir).exists()    
+          has_rad: !params.repeat_mapping && file(it.rad_dir).exists()
           make_rad: true
-       }     
-    
-    // If We need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])   
+       }
+
+    // If We need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
     rna_reads_ch = rna_channel.make_rad
       .map{meta -> tuple(meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
@@ -106,20 +110,20 @@ workflow map_quant_rna {
     // if the rad directory has been created and repeat_mapping is set to false
     // create tuple of (metdata map, rad_directory) to be used directly as input to alevin-fry quantification
     rna_rad_ch = rna_channel.has_rad
-      .map{meta -> tuple(meta, 
+      .map{meta -> tuple(Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json")),
                          file(meta.rad_dir)
                          )}
 
     // run Alevin for mapping on libraries that don't have RAD directory already created
     alevin_rad(rna_reads_ch, params.splici_index)
 
-    // combine ouput from running alevin step with channel containing libraries that skipped creating a RAD file 
+    // combine ouput from running alevin step with channel containing libraries that skipped creating a RAD file
     all_rad_ch = alevin_rad.out.mix(rna_rad_ch)
       .map{it.toList() << file(it[0].barcode_file)} // add barcode file to channel to use in fry_quant_rna process
 
     // quantify with alevin-fry
     fry_quant_rna(all_rad_ch, params.t2g_3col_path)
-  
+
   emit: fry_quant_rna.out
   // a tuple of meta and the alevin-fry output directory
 }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -100,7 +100,7 @@ workflow map_quant_rna {
           make_rad: true
        }
 
-    // If We need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
+    // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
     rna_reads_ch = rna_channel.make_rad
       .map{meta -> tuple(meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
@@ -108,7 +108,7 @@ workflow map_quant_rna {
                         )}
 
     // if the rad directory has been created and repeat_mapping is set to false
-    // create tuple of (metdata map, rad_directory) to be used directly as input to alevin-fry quantification
+    // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
     rna_rad_ch = rna_channel.has_rad
       .map{meta -> tuple(Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json")),
                          file(meta.rad_dir)

--- a/modules/bulk-pileup.nf
+++ b/modules/bulk-pileup.nf
@@ -39,7 +39,7 @@ workflow pileup_multibulk{
     pileup_ch = multiplex_ch
       .map{[it.sample_id.tokenize(","), it.library_id, it]} // split out sample ids into a tuple, add library_id separately
       .transpose() // one element per sample (library & meta objects repeated)
-      .join(sample_bulk_ch, by: 0) // join by individual sample ids
+      .combine(sample_bulk_ch, by: 0) // combine by individual sample ids (use combine because of repeated values)
       .groupTuple(by: 1) // group by library id
       .map{[
         [ // create a meta object for each group of samples

--- a/modules/bulk-pileup.nf
+++ b/modules/bulk-pileup.nf
@@ -14,7 +14,7 @@ process mpileup{
     # create sample file to use for header
     echo "${meta.sample_ids.join('\n')}" > samples.txt
 
-    # call genotypes against reference, filter sites with missing genotypes 
+    # call genotypes against reference, filter sites with missing genotypes
     # & use sample names for header (replacing file names)
     bcftools mpileup -Ou \
       --fasta-ref ${ref_fasta} \
@@ -30,17 +30,17 @@ workflow pileup_multibulk{
   take:
     multiplex_ch // a channel of multiplex meta objects, with sample_ids joined by `,` in their ids
     bulk_mapped_ch // output of bulk mapping: [meta, bamfile, bamfile_index]
-  
+
   main:
     //pull sample to front of bulk_mapped_ch
     sample_bulk_ch = bulk_mapped_ch
-      .map{[it[0].sample_id] + it} 
+      .map{[it[0].sample_id] + it}
 
-    pileup_ch = multiplex_ch 
+    pileup_ch = multiplex_ch
       .map{[it.sample_id.tokenize(","), it.library_id, it]} // split out sample ids into a tuple, add library_id separately
       .transpose() // one element per sample (library & meta objects repeated)
-      .combine(sample_bulk_ch, by: 0) // combine by individual sample ids
-      .groupTuple(by: 1) // group by library id 
+      .join(sample_bulk_ch, by: 0) // join by individual sample ids
+      .groupTuple(by: 1) // group by library id
       .map{[
         [ // create a meta object for each group of samples
           sample_ids: it[0],
@@ -58,7 +58,7 @@ workflow pileup_multibulk{
       ]}
 
     mpileup(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
-  
+
   emit:
     mpileup.out
 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -105,6 +105,7 @@ workflow bulk_quant_rna {
               has_quants: (!params.repeat_mapping
                            && file(it.salmon_results_dir).exists()
                            && Utils.getJsonVal(file("${it.salmon_results_dir}/scpca-meta.json"), "ref_assembly") == params.assembly
+                           && Utils.getJsonVal(file("${it.salmon_results_dir}/scpca-meta.json"), "t2g_bulk_path") == params.t2g_bulk_path
                           )
               make_quants: true
           }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -113,7 +113,7 @@ workflow bulk_quant_rna {
                              )}
 
         // If the quant.sf file from salmon exits and repeat_mapping is false
-        // create tuple of metadata map, salmon output directory to use as input to merge_bulk_quants
+        // create tuple of metadata map (read from output), salmon output directory to use as input to merge_bulk_quants
         quants_ch = bulk_channel.has_quants
           .map{meta -> tuple(Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json")),
                              file(meta.salmon_results_dir)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -104,8 +104,8 @@ workflow bulk_quant_rna {
           .branch{
               has_quants: (!params.repeat_mapping
                            && file(it.salmon_results_dir).exists()
-                           && Utils.getJsonVal(file("${it.salmon_results_dir}/scpca-meta.json"), "ref_assembly") == params.assembly
-                           && Utils.getJsonVal(file("${it.salmon_results_dir}/scpca-meta.json"), "t2g_bulk_path") == params.t2g_bulk_path
+                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "ref_assembly") == params.assembly
+                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "t2g_bulk_path") == params.t2g_bulk_path
                           )
               make_quants: true
           }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -6,11 +6,11 @@ process fastp{
     label 'cpus_8'
     label 'mem_8'
     tag "${meta.library_id}-bulk"
-    input: 
+    input:
         tuple val(meta), path(read1), path(read2)
-    output: 
+    output:
         tuple val(meta), path(trimmed_reads)
-    script: 
+    script:
         trimmed_reads = "${meta.library_id}_trimmed"
         fastp_report = "${meta.library_id}_fastp.html"
         """
@@ -29,24 +29,28 @@ process salmon{
     label 'mem_24'
     tag "${meta.library_id}-bulk"
     publishDir "${meta.salmon_publish_dir}"
-    input: 
+    input:
         tuple val(meta), path(read_dir)
         path (index)
-    output: 
-        tuple val(meta), path(salmon_results_dir)
+    output:
+        tuple val(meta), path(salmon_dir)
     script:
-        salmon_results_dir = "${meta.library_id}"
+        salmon_dir = file(meta.salmon_results_dir).name
+        // get meta to write as file
+        meta_json = Utils.makeJson(meta)
         """
         salmon quant -i ${index} \
         -l A \
         ${meta.technology == 'paired_end' ? "-1": "-r"} ${read_dir}/*_R1_*.fastq.gz \
         ${meta.technology == 'paired_end' ? "-2 ${read_dir}/*_R2_*.fastq.gz" : "" } \
-        -o ${salmon_results_dir} \
+        -o ${salmon_dir} \
         --validateMappings \
         --rangeFactorizationBins 4 \
         --gcBias \
         --seqBias \
         --threads ${task.cpus}
+
+        echo '${meta_json}' > ${salmon_dir}/scpca-meta.json
         """
 
 }
@@ -87,20 +91,20 @@ process merge_bulk_quants {
 }
 
 workflow bulk_quant_rna {
-    take: bulk_channel 
+    take: bulk_channel
     // a channel with a map of metadata for each rna library to process
-    main: 
+    main:
         bulk_channel = bulk_channel
-          // add salmon directory and salmon file location to meta 
+          // add salmon directory and salmon file location to meta
           .map{it.salmon_publish_dir = "${params.checkpoints_dir}/salmon";
                it.salmon_results_dir = "${it.salmon_publish_dir}/${it.library_id}";
                it}
-          // split based on whether repeat_mapping is false and the salmon quant.sf file exists 
+          // split based on whether repeat_mapping is false and the salmon quant.sf file exists
           .branch{
               has_quants: !params.repeat_mapping && file(it.salmon_results_dir).exists()
               make_quants: true
           }
-        
+
         // If we need to run salmon, create tuple of (metadata map, [Read 1 files], [Read 2 files])
         bulk_reads_ch = bulk_channel.make_quants
           .map{meta -> tuple(meta,
@@ -108,14 +112,14 @@ workflow bulk_quant_rna {
                              file("${meta.files_directory}/*_R2_*.fastq.gz")
                              )}
 
-        // If the quant.sf file from salmon exits and repeat_mapping is false 
+        // If the quant.sf file from salmon exits and repeat_mapping is false
         // create tuple of metadata map, salmon output directory to use as input to merge_bulk_quants
         quants_ch = bulk_channel.has_quants
-          .map{meta -> tuple(meta,
+          .map{meta -> tuple(Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json")),
                              file(meta.salmon_results_dir)
                              )}
 
-        
+
         // run fastp and salmon for libraries that are not skipping salmon
         fastp(bulk_reads_ch)
         salmon(fastp.out, params.bulk_index)
@@ -128,7 +132,7 @@ workflow bulk_quant_rna {
         // create tsv file and combined metadata for each project containing all libraries
         merge_bulk_quants(grouped_salmon_ch, params.t2g_bulk_path, params.run_metafile)
 
-    emit: 
+    emit:
         bulk_counts = merge_bulk_quants.out.bulk_counts
         bulk_metadata = merge_bulk_quants.out.bulk_metadata
 }

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -26,10 +26,10 @@ process bulkmap_star{
 }
 
 workflow star_bulk{
-  take: 
+  take:
     bulk_channel // a channel with a map of metadata for each rna library to process
-    
-  main: 
+
+  main:
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
     bulk_reads_ch = bulk_channel
         .map{meta -> tuple(meta,
@@ -38,7 +38,7 @@ workflow star_bulk{
     // map and index
     bulkmap_star(bulk_reads_ch, file(params.star_index)) \
     | index_bam
-  
-  emit: 
+
+  emit:
     index_bam.out
 }

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -63,9 +63,9 @@ workflow cellsnp_vireo {
     mpileup_ch = mpileup_vcf_ch
       .map{[it[0].multiplex_library_id] + it} // pull out library id for combining
     star_mpileup_ch = starsolo_bam_ch.map{[it[0].library_id] + it} // add library id at start
-      .join(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0, failOnDuplicate: true) // join starsolo outs by library_id
+      .join(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0, failOnDuplicate: true, failOnMismatch: true) // join starsolo outs by library_id
       .map{[it[0], it[1], it[2], it[3], it[5]]} // remove redundant meta
-      .join(mpileup_ch, by: 0, failOnDuplicate: true) // join starsolo and mpileup by library id
+      .join(mpileup_ch, by: 0, failOnDuplicate: true, failOnMismatch: true) // join starsolo and mpileup by library id
       .map{it.drop(1)} // drop library id
       //result: [meta, star_bam, star_bai, star_quant, meta_mpileup, vcf_file]
 

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -63,9 +63,9 @@ workflow cellsnp_vireo {
     mpileup_ch = mpileup_vcf_ch
       .map{[it[0].multiplex_library_id] + it} // pull out library id for combining
     star_mpileup_ch = starsolo_bam_ch.map{[it[0].library_id] + it} // add library id at start
-      .join(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0) // join starsolo outs by library_id
+      .join(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0, failOnDuplicate: true) // join starsolo outs by library_id
       .map{[it[0], it[1], it[2], it[3], it[5]]} // remove redundant meta
-      .join(mpileup_ch, by: 0) // join starsolo and mpileup by library id
+      .join(mpileup_ch, by: 0, failOnDuplicate: true) // join starsolo and mpileup by library id
       .map{it.drop(1)} // drop library id
       //result: [meta, star_bam, star_bai, star_quant, meta_mpileup, vcf_file]
 

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -53,11 +53,11 @@ process vireo{
       --nproc ${task.cpus}
 
     echo '${meta_json}' > ${outdir}/scpca-meta.json
-    """ 
+    """
 }
 
 workflow cellsnp_vireo {
-  take: 
+  take:
     starsolo_bam_ch //channel of [meta, bamfile, bam.bai]
     starsolo_quant_ch //channel of [meta, starsolo_dir]
     mpileup_vcf_ch // channel of [meta_mpileup, vcf_file]
@@ -65,9 +65,9 @@ workflow cellsnp_vireo {
     mpileup_ch = mpileup_vcf_ch
       .map{[it[0].multiplex_library_id] + it} // pull out library id for combining
     star_mpileup_ch = starsolo_bam_ch.map{[it[0].library_id] + it} // add library id at start
-      .combine(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0) // join starsolo outs by library_id 
+      .join(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0) // join starsolo outs by library_id
       .map{[it[0], it[1], it[2], it[3], it[5]]} // remove redundant meta
-      .combine(mpileup_ch, by: 0) // join starsolo and mpileup by library id
+      .join(mpileup_ch, by: 0) // join starsolo and mpileup by library id
       .map{it.drop(1)} // drop library id
       //result: [meta, star_bam, star_bai, star_quant, meta_mpileup, vcf_file]
 

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -1,4 +1,3 @@
-import groovy.json.JsonOutput
 
 process cellsnp{
   container params.CELLSNP_CONTAINER
@@ -42,8 +41,7 @@ process vireo{
     tuple val(meta), path(outdir)
   script:
     outdir = file(meta.vireo_dir).name
-    meta_json = JsonOutput.toJson(meta)
-    meta_json = JsonOutput.prettyPrint(meta_json)
+    meta_json = Utils.makeJson(meta)
     """
     pip install vireoSNP==0.5.6
     vireo \

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -2,35 +2,28 @@
 // include processes
 include { star_bulk } from './bulk-star.nf'
 include { pileup_multibulk } from './bulk-pileup.nf'
-include { starsolo_map } from './starsolo.nf' 
+include { starsolo_map } from './starsolo.nf'
 include { cellsnp_vireo } from './cellsnp.nf'
-
-import groovy.json.JsonSlurper
-
-def read_meta(path) {
-  meta = new JsonSlurper().parse(file(path))
-  return(meta)
-}
 
 
 workflow genetic_demux_vireo{
-  take: 
+  take:
     multiplex_run_ch
     unfiltered_runs_ch
   main:
     // add vireo publish directory, vireo directory, and barcode file to meta
     multiplex_ch = multiplex_run_ch
       .map{it.vireo_publish_dir = "${params.checkpoints_dir}/vireo/";
-           it.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo"; 
+           it.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo";
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
-          has_demux: !params.repeat_gdemux && file(it.vireo_dir).exists()    
+          has_demux: !params.repeat_gdemux && file(it.vireo_dir).exists()
           make_demux: true
-       } 
-    
-    
+       }
+
+
     // get the bulk samples that correspond to multiplexed samples
     bulk_samples = multiplex_ch.make_demux
       .map{[it.sample_id.tokenize(",")]} // split out sample ids into a tuple
@@ -42,22 +35,22 @@ workflow genetic_demux_vireo{
     bulk_ch = unfiltered_runs_ch
       .filter{it.technology in params.bulk_techs}
       .filter{it.sample_id in bulk_samples.getVal()}
-    
+
     // map bulk samples
     star_bulk(bulk_ch)
-    
+
     // pileup bulk samples by multiplex groups
     pileup_multibulk(multiplex_ch.make_demux, star_bulk.out)
 
     // map multiplexed single cell samples
     starsolo_map(multiplex_ch.make_demux)
 
-    // call cell snps and genotype cells 
+    // call cell snps and genotype cells
     cellsnp_vireo(starsolo_map.out.bam,  starsolo_map.out.quant, pileup_multibulk.out)
 
     // construct demux output for skipped as [meta, vireo_dir] & join newly processed libraries
     demux_out = multiplex_ch.has_demux
-      .map{[read_meta("${it.vireo_dir}/scpca-meta.json"), file(it.vireo_dir)]}
+      .map{[Utils.readMeta("${it.vireo_dir}/scpca-meta.json"), file(it.vireo_dir)]}
       .mix(cellsnp_vireo.out)
 
   emit:

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -50,7 +50,10 @@ workflow genetic_demux_vireo{
 
     // construct demux output for skipped as [meta, vireo_dir] & join newly processed libraries
     demux_out = multiplex_ch.has_demux
-      .map{[Utils.readMeta(file("${it.vireo_dir}/scpca-meta.json")), file(it.vireo_dir)]}
+      .map{meta -> tuple(
+                         Utils.readMeta(file("${meta.vireo_dir}/scpca-meta.json")),
+                         file(meta.vireo_dir)
+                        )}
       .mix(cellsnp_vireo.out)
 
   emit:

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -50,7 +50,7 @@ workflow genetic_demux_vireo{
 
     // construct demux output for skipped as [meta, vireo_dir] & join newly processed libraries
     demux_out = multiplex_ch.has_demux
-      .map{[Utils.readMeta("${it.vireo_dir}/scpca-meta.json"), file(it.vireo_dir)]}
+      .map{[Utils.readMeta(file("${it.vireo_dir}/scpca-meta.json")), file(it.vireo_dir)]}
       .mix(cellsnp_vireo.out)
 
   emit:

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -5,7 +5,7 @@ process sce_qc_report{
     container params.SCPCATOOLS_CONTAINER
     tag "${meta.library_id}"
     publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
-    input: 
+    input:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:
         tuple val(meta), path(qc_report), path(metadata_json)
@@ -24,7 +24,7 @@ process sce_qc_report{
           --metadata_json ${metadata_json} \
           --technology "${meta.technology}" \
           --seq_unit "${meta.seq_unit}" \
-          --genome_assembly "${params.assembly}" \
+          --genome_assembly "${meta.ref_assembly}" \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow_version}" \
           --workflow_commit "${workflow.commitId}"

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -120,6 +120,7 @@ workflow spaceranger_quant{
         spaceranger(spaceranger_reads, params.cellranger_index)
 
         // gather spaceranger output for completed libraries
+        // make a tuple of metadata (read from prior output) and prior results directory
         spaceranger_quants_ch = spatial_channel.has_spatial
           .map{meta -> tuple(Utils.readMeta(file("${meta.spaceranger_results_dir}/scpca-meta.json")),
                              file("${meta.spaceranger_results_dir}")

--- a/modules/starsolo.nf
+++ b/modules/starsolo.nf
@@ -10,7 +10,7 @@ process starsolo{
   input:
     tuple val(meta), path(read1), path(read2), path(barcode_file)
     path star_index
-    
+
   output:
     tuple val(meta), path(output_dir), emit: starsolo_dir
     tuple val(meta), path(output_bam), emit: star_bam
@@ -22,7 +22,7 @@ process starsolo{
     features_flag = meta.seq_unit == "nucleus" ? "--soloFeatures Gene GeneFull" : "--soloFeatures Gene"
     output_dir = "${meta.run_id}_star"
     output_bam = "${meta.run_id}.sorted.bam"
-    
+
     """
     mkdir -p ${output_dir}/Solo.out/Gene/raw
     STAR \
@@ -51,7 +51,7 @@ workflow starsolo_map{
   take:
     singlecell_ch
 
-  main: 
+  main:
     sc_reads_ch = singlecell_ch
       .map{meta -> tuple(meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
@@ -60,7 +60,7 @@ workflow starsolo_map{
                          )}
     starsolo(sc_reads_ch, file(params.star_index))
     index_bam(starsolo.out.star_bam)
-  
+
   emit:
     bam = index_bam.out
     quant = starsolo.out.starsolo_dir


### PR DESCRIPTION
The primary change here is to track metadata by writing a json file with the contents of the `meta` object when we write files to a checkpoint. 

I did this primarily by implementing the same system as in the `genetic-demux` workflow, but I moved some of the logic out to a separate file, `lib/Utils.groovy` which is automatically loaded by Nextflow (I can't find the documentation for this behavior, but  it seems to load any groovy files in the lib directory, and `nf-core` relies on it, so I don't expect it to change. The closest to documentation I could find was that there is a `-lib` argument to `nextflow`, which I guess might allow a different library to be loaded (as well? instead?))

A limitation of this approach is that it seems like some of the Nextflow functions and objects are not available when the `Utils` class is compiled, so I couldn't use the `file()` function within class. Instead, we have to use that when calling the function, which is ugly, but it works.

To simplify some tracking, I also wrote the paths of the references and other information to `meta` in the initial setup. Most of this is unused, but I did switch where we used `params.assembly` in the QC report to use the value from the `meta` object, which will now track what was used at the mapping step rather than at any later run. Similarly, we now track the transcript2gene file so that we know it will match the rad file that was used. Workflow version, however, is still set by the version active when compiling the QC report.

I considered outputting the metadata in the final publish directories too, but decided that was not worth doing, partly because it includes a bunch of file paths that may or may not be relevant.

### Bulk mapping

Bulk mapping is treated a bit differently. Since we are combining all of the bulk samples into a single matrix for output, I decided to check that all mappings used the same assembly, and that was equal to the version specified in the `params`.  So now if the assembly version in the stored metadata does not match `params.assembly`, mapping is repeated. I did this because it is easier to check against the params than to check all against one another, but I am not sure this is a good long-term solution, as we probably want to keep old mappings if we can, but I haven't come up with a good solution as yet.


### Additional changes
- Since this change is a breaking change in that we now expect a `scpca-meta.json` file in any checkpoint output, I also changed the output directory paths in the `ccdl` profile to match the defaults of `checkpoints` and `results`. I thought I would be able to just delete those redefinitions, but the order of how `params` are resolved means that these have to be repeated.

- Updated salmon and alevin versions. Again, as long as I am making breaking changes that require us to repeat mappings, this seemed a good time.

- Another change is using `join` in place of `combine` in a few places when merging channels. This should not have any functional change, but allowed me distinguish between cases where we are doing one-to-one joining, as in the case of joining together two components of a library (rna & features) vs one-to-many, as we do when joining a feature reference to the fastq files that use it. In the former case, we can add some extra checks to be sure the files are as expected.


Closes #149 
Closes #218 
