### PR TITLE
Make the metadata.json look pretty

### DIFF
--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -184,7 +184,7 @@ if(multiplexed){
 }
 
 # Output metadata as JSON
-jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
+jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE, pretty = TRUE)
 
 scpcaTools::generate_qc_report(
   library_id = metadata_list$library_id,


### PR DESCRIPTION
Closes #222 

Mainly because I was tired of scrolling to look at the metadata file, but also because it looks so much better now, this just changes printing out the metadata file to turn it into pretty format. 