### PR TITLE
Use vireo image

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -8,6 +8,7 @@ FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
 SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1'
 SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
 STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
+VIREO_CONTAINER = 'ghcr.io/alexslemonade/vireo-snp:v0.5.7'
 
 // 10X software containers not set by default
 CELLRANGER_CONTAINER = ''

--- a/main.nf
+++ b/main.nf
@@ -92,7 +92,7 @@ workflow {
       cellranger_index: params.cellranger_index,
       star_index: params.star_index,
       scpca_version: workflow.manifest.version,
-      nextflow_version: nextflow.version
+      nextflow_version: nextflow.version.toString()
     ]}
 
  runs_ch = unfiltered_runs_ch

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -30,7 +30,7 @@ process cellsnp{
 }
 
 process vireo{
-  container params.CONDA_CONTAINER
+  container params.VIREO_CONTAINER
   publishDir "${meta.vireo_publish_dir}"
   tag "${meta.run_id}"
   label 'cpus_8'
@@ -43,7 +43,6 @@ process vireo{
     outdir = file(meta.vireo_dir).name
     meta_json = Utils.makeJson(meta)
     """
-    pip install vireoSNP==0.5.6
     vireo \
       --cellData ${cellsnp_dir} \
       --donorFile ${vcf_file}  \


### PR DESCRIPTION
After creating the vireo image in https://github.com/AlexsLemonade/alsf-scpca/pull/170, this PR  implements its use in the workflow.

I also changed how the Nextflow version is stored in `meta`, as I found in testing that the previous code was storing it as an object type that was interfering with the `-resume` option. So now it is stored as just a string, which is easier to interpret anyway.

closes #219