### PR TITLE
Add filtering thresholds to metadata of processed SCE object

### DIFF
--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -92,7 +92,11 @@ if(all(is.na(sce$prob_compromised))){
     "Remove"
   )
   metadata(sce)$ccdl_filter_method <- "miQC"
+  metadata(sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
 }
+
+# add min gene cutoff to metadata
+metadata(sce)$min_gene_cutoff <- opt$gene_cutoff
 
 # filter sce using criteria in ccdl_filter
 filtered_sce <- sce[, which(sce$ccdl_filter == "Keep")]


### PR DESCRIPTION
Closes #227 

Here I added the minimum genes detected cutoff and the prob compromised cutoff to the metadata of the processed SCE object that is written out by `post_process_sce.R`. This will result in these values being printed in the `Cell Statistics` table found in the qc report being altered in AlexsLemonade/scpcaTools#131.