### PR TITLE
Add instructions for downloading local reference files

### DIFF
--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -41,21 +41,22 @@ profiles{
  cluster {
     process {
       executor = 'slurm'
-      // queue name for your cluster
+      // Queue name for your cluster
       queue = 'normal'
-      // optionally set the location for process working files
-      // the below setting assumes an environment variable $SCRATCH is set on your cluster
+      // Optionally set the location for process working files.
+      // The below setting assumes an environment variable $SCRATCH is set on your cluster.
       scratch = "$SCRATCH"
-      // if your HPC requires software to be loaded as a module, otherwise this line can be removed
+      // If your HPC requires software to be loaded as a module, otherwise this line can be removed
       beforeScript = 'module load singularity'
     }
     // singularity is often required on HPC in place of docker
     singularity {
       enabled = true
       autoMounts = true
-      // if you pre-download container images locally (for example if nodes do not have internet access).
-      // the singularity cache directory should be specified (below is singularity's default)
-      cacheDir = "$HOME/.singularity/cache"
+      // If you pre-pull container images locally the singularity cache directory should be specified 
+      // The setting below assumes that `$SINGULARITY_CACHE` is defined on your cluster
+      // Note that the singularity default is `$HOME/.singularity/cache`
+      cacheDir = "$SINGULARITY_CACHE"
     }
     docker.enabled = false
     // If access to protected resources on AWS is not required, it may be more

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -53,6 +53,9 @@ profiles{
     singularity {
       enabled = true
       autoMounts = true
+      // if you pre-download container images locally (for example if nodes do not have internet access).
+      // the singularity cache directory should be specified (below is singularity's default)
+      cacheDir = "$HOME/.singularity/cache"
     }
     docker.enabled = false
     // If access to protected resources on AWS is not required, it may be more

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -250,6 +250,10 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 #### Downloading container images
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
+When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.3.4`, then you will want to set `-r v0.3.4` for `get_refs.py` as well to be sure you have the correct containers.
+Be default,  `get_refs.py` will download files and images associated with the latest release.
+
 If your system uses Docker, you can add the `--docker` flag:
 
 ```

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -37,7 +37,7 @@ You will need to make sure you have the following software installed on your HPC
     These usually require installation by system administrators, but most HPC systems have one available (usually Singularity).
     - Other software dependencies are handled by Nextflow, which will download Docker or Singularity images as required
 
-1. **Organize your files.**
+2. **Organize your files.**
 You will need to have your files organized in a particular manner so that each folder contains only the FASTQ files that pertain to a single library.
 See the [section below on file organization](#file-organization) for more information on how to set up your files.
 

--- a/external-data-instructions.md
+++ b/external-data-instructions.md
@@ -11,7 +11,8 @@
   - [Setting up a profile in the configuration file](#setting-up-a-profile-in-the-configuration-file)
   - [Using `scpca-nf` with AWS Batch](#using-scpca-nf-with-aws-batch)
   - [Using `scpca-nf` on nodes without direct internet access](#using-scpca-nf-on-nodes-without-direct-internet-access)
-    - [Downloading container files](#downloading-container-files)
+    - [Additional reference files](#additional-reference-files)
+    - [Downloading container images](#downloading-container-images)
 - [Repeating mapping steps](#repeating-mapping-steps)
 - [Special considerations for specific data types](#special-considerations-for-specific-data-types)
   - [Libraries with additional feature data (CITE-seq or cellhash)](#libraries-with-additional-feature-data-cite-seq-or-cellhash)
@@ -219,9 +220,10 @@ chmod +x get_refs.py
 ./get_refs.py
 ```
 
-By default, this will download the files required for mapping gene expression data sets to the subdirectory `scpca-references` at your current location, as well as a parameter file named `localref_params.yaml` that sets the `ref_rootdir` and `assembly` nextflow parameters.
+By default, this will download the files required for mapping gene expression data sets to the subdirectory `scpca-references` at your current location.
+The script will also create a parameter file named `localref_params.yaml` that defines the `ref_rootdir` and `assembly` Nextflow parameter variables required to use these local data files.
 
-You can then direct nextflow to use these parameters with a command such as the following:
+You can then direct Nextflow to use these parameters using the `-params-file` argument in a command such as the following:
 
 ```
 nextflow run AlexsLemonade/scpca-nf \
@@ -234,8 +236,35 @@ Note that other configuration settings such as [profiles](#setting-up-a-profile-
 However, you should **not** put `params.ref_rootdir` in the configuration file, as Nextflow may not properly create the sub-paths for the various reference files due to [Nextflow's precedence rules of setting parameters](https://www.nextflow.io/docs/latest/config.html#configuration-file).
 The `ref_rootdir` parameter should *only* be specified in a parameter file or at the command line with the `--ref_rootdir` argument.
 
-#### Downloading container files
+#### Additional reference files
 
+If you wil be performing genetic demultiplexing for hashed samples, you will need STAR index files as well as the ones included by default.
+To obtain these files, you can add the `--star_index` flag:
+
+```
+./get_refs.py --star_index
+```
+
+If you will be analyzing spatial expression data, you will also need the Cell Ranger index as well, which can be obtained by adding the `--cellranger_index` flag.
+
+#### Downloading container images
+
+If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
+If your system uses Docker, you can add the `--docker` flag:
+
+```
+./get_refs.py --docker
+```
+
+For Singularity, you can similarly use the `--singularity` flag to pull images and cache them for use by Nextflow.
+These images will be placed by default in a `singularity` directory at your current location.
+If you would like to store them in a different location, use the `--singularity_dir` argument to specify that path.
+The example below stores the image files in `$HOME/singularity`.
+You will also need to set the `singularity.cacheDir` variable to match this location in your [configuration file profile](#setting-up-a-profile-in-the-configuration-file).
+
+```
+./get_refs.py --singularity --singularity_dir "$HOME/singularity"
+```
 
 ## Repeating mapping steps
 

--- a/get_refs.py
+++ b/get_refs.py
@@ -28,7 +28,7 @@ parser.add_argument("--paramfile", type=str,
 parser.add_argument("--overwrite_refs",
                     action = "store_true",
                     help = "replace previously downloaded files")
-parser.add_argument("--revision", type=str,
+parser.add_argument("-r", "--revision", type=str,
                     default="main",
                     metavar = "vX.X.X",
                     help = "tag for a specific workflow version (defaults to latest revision)")

--- a/get_refs.py
+++ b/get_refs.py
@@ -296,5 +296,5 @@ if args.singularity:
             f"docker://{loc}"
         ])
     print("Done pulling singularity images")
-    print(f"Singularity images located at {image_dir.absolute()}")
+    print(f"Singularity images located at {image_dir.absolute()}; be sure to set `singularity.cacheDir` in your configuration file to this value")
     print()

--- a/get_refs.py
+++ b/get_refs.py
@@ -44,9 +44,9 @@ parser.add_argument("--docker",
 parser.add_argument("--singularity",
                     action = "store_true",
                     help = "pull and cache images for singularity")
-parser.add_argument("--singularity_cache", type=str,
-                    metavar = "CACHE_DIR",
-                    help = "cache directory for singularity")
+parser.add_argument("--singularity_dir", type=str,
+                    default = "singularity",
+                    help = "directory to store singularity image files (default: `singularity`)")
 args = parser.parse_args()
 
 # scpca-nf resource urls
@@ -280,14 +280,21 @@ if args.docker:
 # pull singularity images if requested (to optionally specified cache location)
 if args.singularity:
     print("Pulling singularity images...")
-    if args.singularity_cache:
-        os.environ['SINGULARITY_CACHEDIR'] = os.path.abspath(args.singularity_cache)
+    image_dir = Path(args.singularity_dir)
+    image_dir.mkdir(parents=True, exist_ok=True)
     for loc in containers.values():
-        subprocess.run(
-            ["singularity", "pull", "--force", f"docker://{loc}"],
-            env = os.environ
-        )
+        # create image file name from location for nextflow
+        image_file = loc.replace("/", "-").replace(":", "-") + ".img"
+        print(image_file)
+        image_path = image_dir / image_file
+        print(image_path)
+        if image_path.exists():
+            image_path.unlink()
+        subprocess.run([
+            "singularity", "pull",
+            "--name", image_path,
+            f"docker://{loc}"
+        ])
     print("Done pulling singularity images")
-    if args.singularity_cache:
-        print(f"Singularity images located at {os.environ['SINGULARITY_CACHEDIR']}")
+    print(f"Singularity images located at {image_dir.absolute()}")
     print()

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -25,7 +25,7 @@ process alevin_feature{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.checkpoints_dir}/rad/${meta.library_id}", enabled: params.publish_fry_outs
+  publishDir "${params.checkpoints_dir}/rad/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
   input:
     tuple val(meta),
           path(read1), path(read2),
@@ -65,7 +65,7 @@ process fry_quant_feature{
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", enabled: params.publish_fry_outs
+  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
   input:
     tuple val(meta),
           path(run_dir)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -7,7 +7,7 @@ process alevin_rad{
   label 'mem_24'
   label 'disk_big'
   tag "${meta.run_id}-rna"
-  publishDir "${meta.rad_publish_dir}"
+  publishDir "${meta.rad_publish_dir}", mode: 'copy'
   input:
     tuple val(meta),
           path(read1), path(read2)
@@ -49,7 +49,7 @@ process fry_quant_rna{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-rna"
-  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", enabled: params.publish_fry_outs
+  publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
 
   input:
     tuple val(meta), path(run_dir), path(barcode_file), path(tx2gene_3col)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -28,7 +28,7 @@ process salmon{
     label 'cpus_12'
     label 'mem_24'
     tag "${meta.library_id}-bulk"
-    publishDir "${meta.salmon_publish_dir}"
+    publishDir "${meta.salmon_publish_dir}", mode: 'copy'
     input:
         tuple val(meta), path(read_dir)
         path (index)
@@ -57,7 +57,7 @@ process salmon{
 
 process merge_bulk_quants {
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${params.results_dir}/${project_id}"
+    publishDir "${params.results_dir}/${project_id}", mode: 'copy'
     input:
         tuple val(project_id), path(salmon_directories)
         path(tx2gene)

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -31,7 +31,7 @@ process cellsnp{
 
 process vireo{
   container params.VIREO_CONTAINER
-  publishDir "${meta.vireo_publish_dir}"
+  publishDir "${meta.vireo_publish_dir}", mode: 'copy'
   tag "${meta.run_id}"
   label 'cpus_8'
   label 'mem_16'

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -4,7 +4,7 @@
 process sce_qc_report{
     container params.SCPCATOOLS_CONTAINER
     tag "${meta.library_id}"
-    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
+    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
     input:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
     output:

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -126,7 +126,7 @@ process post_process_sce{
     container params.SCPCATOOLS_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
-    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
+    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
     input:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl=2
 
 process spaceranger{
   container params.SPACERANGER_CONTAINER
-  publishDir "${meta.spaceranger_publish_dir}"
+  publishDir "${meta.spaceranger_publish_dir}", mode: 'copy'
   tag "${meta.run_id}-spatial"
   label 'cpus_12'
   label 'mem_24'
@@ -39,7 +39,7 @@ process spaceranger{
 
 process spaceranger_publish{
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}"
+  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
   input:
     tuple val(meta), path(spatial_out)
     val index


### PR DESCRIPTION
Closes #211

Mostly this is documentation, but I also had to make some changes to the `get_refs.py` to give pulled/cached image files the names Nextflow expects them to have (this is mostly undocumented, so yay). 

Please let me know if these docs make sense. We will get another set of eyes when we deploy to testers.

I think this may also address #213, as I seemed to run into that when testing. I think the issue may have been somehow invalid symbolic links created by publish steps when skipping remapping. To address this, I changed all publish steps to include `mode: 'copy'`. This should prevent any deletion of temp or scratch files from removing results in checkpoints or results.