### PR TITLE
Pass probability compromised cutoff through filtering script 

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -84,7 +84,7 @@ try({
 if (!miQC_worked){
   warning("miQC failed. Setting `prob_compromised` to NA.")
   filtered_sce$prob_compromised <- NA_real_
-  filtered_sce$miQC_pass <- "miQC_failed"
+  filtered_sce$miQC_pass <- NA_real_
   metadata(filtered_sce)$prob_compromised_cutoff <- NA
 }
 

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -76,7 +76,7 @@ miQC_worked <- FALSE
 try({
   filtered_sce <- scpcaTools::add_miQC(filtered_sce,
                                        posterior_cutoff = opt$prob_compromised_cutoff)
-  metadata(sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
+  metadata(filtered_sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
   miQC_worked <- TRUE
  })
  
@@ -85,7 +85,7 @@ if (!miQC_worked){
   warning("miQC failed. Setting `prob_compromised` to NA.")
   filtered_sce$prob_compromised <- NA_real_
   filtered_sce$miQC_pass <- "miQC_failed"
-  metadata(sce)$prob_compromised_cutoff <- NA
+  metadata(filtered_sce)$prob_compromised_cutoff <- NA
 }
 
 # grab names of altExp, if any

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -24,8 +24,7 @@ option_list <- list(
     opt_str = c("--prob_compromised_cutoff"),
     type = "double",
     default = 0.75,
-    help = "probability compromised cutoff used for filtering cells with miQC",
-    metavar = "double"
+    help = "probability compromised cutoff used for filtering cells with miQC"
   ),
   make_option(
    opt_str = c("-r", "--random_seed"),
@@ -84,7 +83,7 @@ try({
 if (!miQC_worked){
   warning("miQC failed. Setting `prob_compromised` to NA.")
   filtered_sce$prob_compromised <- NA_real_
-  filtered_sce$miQC_pass <- NA_real_
+  filtered_sce$miQC_pass <- NA
   metadata(filtered_sce)$prob_compromised_cutoff <- NA
 }
 

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -66,13 +66,13 @@ if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
 sce <- readr::read_rds(opt$input_sce_file)
 
 # create ccdl_filter column
-if(all(is.na(sce$prob_compromised))){
+if(all(is.na(sce$miQC_pass))){
   colData(sce)$ccdl_filter <- ifelse(
     sce$detected >= opt$gene_cutoff, "Keep", "Remove"
   )
   metadata(sce)$ccdl_filter_method <- "Minimum_gene_cutoff"
 } else {
-  # remove cells that passed miQC + min gene cutoff
+  # create filter using miQC and min gene cutoff
   colData(sce)$ccdl_filter <- ifelse(
     sce$miQC_pass & sce$detected >= opt$gene_cutoff,
     "Keep",

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -72,6 +72,7 @@ process filter_sce{
         filter_sce_rds.R \
           --unfiltered_file ${unfiltered_rds} \
           --filtered_file ${filtered_rds} \
+          --prob_compromised_cutoff ${params.prob_compromised_cutoff} \
           ${params.seed ? "--random_seed ${params.seed}" : ""}
         """
 }
@@ -137,7 +138,6 @@ process post_process_sce{
         post_process_sce.R \
           --input_sce_file ${filtered_rds} \
           --output_sce_file ${processed_rds} \
-          --prob_compromised_cutoff ${params.prob_compromised_cutoff} \
           --gene_cutoff ${params.gene_cutoff} \
           --n_hvg ${params.num_hvg} \
           --n_pcs ${params.num_pcs} \


### PR DESCRIPTION
Closes #232 

Here I altered the `filter_sce_rds.R` script to take the probability compromised cutoff param used for filtering in as an argument rather than passing it through the post process script. This change allows us to use it to directly create the `miQC_pass` column that is present in the SCE that gets written to `_filtered.rds`. As a result of this I also stored the cutoff in the metadata of that object, rather than only in the processed object. 

Then in the post processing script I changed the removal of bad cells to directly use the `miQC_pass` column, if miQC was successful, in combination with the minimum gene cutoff. I believe I addressed everything that was mentioned in the issue, but let me know if I missed something. 

The test run is about halfway done, so I'll wait for that to complete successfully before requesting a review. 