### PR TITLE
change ccdl -> scpca for filtering and update template

### DIFF
--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -65,27 +65,27 @@ if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
 # read in input rds file
 sce <- readr::read_rds(opt$input_sce_file)
 
-# create ccdl_filter column
+# create scpca_filter column
 if(all(is.na(sce$miQC_pass))){
-  colData(sce)$ccdl_filter <- ifelse(
+  colData(sce)$scpca_filter <- ifelse(
     sce$detected >= opt$gene_cutoff, "Keep", "Remove"
   )
-  metadata(sce)$ccdl_filter_method <- "Minimum_gene_cutoff"
+  metadata(sce)$scpca_filter_method <- "Minimum_gene_cutoff"
 } else {
   # create filter using miQC and min gene cutoff
-  colData(sce)$ccdl_filter <- ifelse(
+  colData(sce)$scpca_filter <- ifelse(
     sce$miQC_pass & sce$detected >= opt$gene_cutoff,
     "Keep",
     "Remove"
   )
-  metadata(sce)$ccdl_filter_method <- "miQC"
+  metadata(sce)$scpca_filter_method <- "miQC"
 }
 
 # add min gene cutoff to metadata
 metadata(sce)$min_gene_cutoff <- opt$gene_cutoff
 
-# filter sce using criteria in ccdl_filter
-filtered_sce <- sce[, which(sce$ccdl_filter == "Keep")]
+# filter sce using criteria in scpca_filter
+filtered_sce <- sce[, which(sce$scpca_filter == "Keep")]
 
 # replace existing stats with recalculated gene stats
 drop_cols = colnames(rowData(filtered_sce, alt)) %in% c('mean', 'detected')

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -38,7 +38,7 @@ For more information on setting up profiles see https://www.nextflow.io/docs/lat
 */
 
 profiles{
- cluster {
+  cluster { // the profile name: all settings for the 'cluster' profile are within this block
     process {
       executor = 'slurm'
       // Queue name for your cluster
@@ -53,10 +53,11 @@ profiles{
     singularity {
       enabled = true
       autoMounts = true
-      // If you pre-pull container images locally the singularity cache directory should be specified 
-      // The setting below assumes that `$SINGULARITY_CACHE` is defined on your cluster
-      // Note that the singularity default is `$HOME/.singularity/cache`
-      cacheDir = "$SINGULARITY_CACHE"
+      // If you pre-pull container images (i.e., if nodes do not have internet access) 
+      // then the nextflow singularity cache directory should be specified.
+      // This setting is optional otherwise, though you may get a warning if it is not set, 
+      // and a default location will be used.
+      // cacheDir = "$HOME/nextflow/singularity"
     }
     docker.enabled = false
     // If access to protected resources on AWS is not required, it may be more


### PR DESCRIPTION
A bit of a twofer here. 

One part is updating the references to `ccdl_filter` to scpca, which is a bit more specific, and avoids some branding issues. (see https://github.com/AlexsLemonade/scpca-docs/pull/100/files/b23fbc57a2622d1b9a288b89b73602ee04d7c6eb..8b4bf0723a38e6d527e4485136bf55f557d72ed3#r1024292671)

The other is a small change to talk about cacheDir for singularity, which is a thing that has come up with updates to allow pre-pulling images (I should have fixed this in the last PR but missed it)