### PR TITLE
Initiate the integration workflow

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -26,7 +26,7 @@ option_list <- list(
     type = "integer",
     default = 2000,
     help = "number of high variance genes to use for dimension reduction;
-            the default is n_hvg = 2000",
+            the default is n_hvg = 2000"
   )
 )
 
@@ -95,7 +95,7 @@ gene_var_block <- scran::modelGeneVar(merged_sce,
 hvg_list <- scran::getTopHVGs(gene_var_block,
                                n = opt$n_hvg)
 
-metadata(merged_sce)$merged_highly_variable_genes <- hvg_list
+metadata(merged_sce)$merged_hvgs <- hvg_list
 
 # Dim Reduction PCA and UMAP----------------------------------------------------
 
@@ -106,10 +106,13 @@ multi_pca <- batchelor::multiBatchPCA(merged_sce,
                                       preserve.single = TRUE)
 
 # add PCA results to merged SCE object 
-reducedDim(merged_sce, "PCA") <- multi_pca@listData[[1]]
+reducedDim(merged_sce, "PCA") <- multi_pca[[1]]
 
 # add UMAP 
 merged_sce <- scater::runUMAP(merged_sce, dimred = "PCA")
 
 # write out merged sce file 
-readr::write_rds(merged_sce, opt$output_sce_file)
+readr::write_rds(merged_sce, 
+                 opt$output_sce_file, 
+                 compress = "gz",
+                 compression = 2)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -38,7 +38,5 @@ input_library_ids <- stringr::str_split(opt$library_ids, ',')
 sce_list <- purrr::map(input_sce_files, readr::read_rds)
 names(sce_list) <- input_library_ids
 
-merged_sce <- sce_list[[1]]
-
 # write out merged sce file 
-readr::write_rds(merged_sce, opt$output_sce_file)
+readr::write_rds(sce_list, opt$output_sce_file)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -31,9 +31,9 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 # check that file extension for output file is correct 
 
-# list of paths to salmon files 
+# list of paths to sce files 
 input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ','))
-# pull library ids from list of 
+# pull library ids from list 
 input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ','))
 
 # check that input files exist 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -32,9 +32,9 @@ opt <- parse_args(OptionParser(option_list = option_list))
 # check that file extension for output file is correct 
 
 # list of paths to salmon files 
-input_sce_files <- stringr::str_split(opt$input_sce_files, ',')
+input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ','))
 # pull library ids from list of 
-input_library_ids <- stringr::str_split(opt$library_ids, ',')
+input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ','))
 
 # check that input files exist 
 
@@ -49,4 +49,4 @@ names(sce_list) <- input_library_ids
 # Dim Reduction PCA and UMAP 
 
 # write out merged sce file 
-readr::write_rds(sce_list, opt$output_sce_file)
+readr::write_rds(sce_list[1], opt$output_sce_file)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -1,0 +1,44 @@
+#!/usr/bin/env Rscript
+
+# import libraries
+library(magrittr)
+library(optparse)
+library(SingleCellExperiment)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("--input_library_ids"),
+    type = "character",
+    help = "Comma separated list of library IDs corresponding to the libraries being integrated."
+  ),
+  make_option(
+    opt_str = c("--input_sce_files"),
+    type = "character",
+    help = "Comma separated list of input sce file paths corresponding to the sces being integrated."
+  ),
+  make_option(
+    opt_str = c("-o", "--output_sce_file"),
+    type = "character",
+    help = "Path to output RDS file, must end in .rds"
+  )
+)
+
+# Setup ------------------------------------------------------------------------
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# list of paths to salmon files 
+input_sce_files <- stringr::str_split(opt$infiles, ',')
+# pull library ids from list of 
+input_library_ids <- stringr::str_split(opt$library_ids, ',')
+
+# get list of sces
+sce_list <- purrr::map(input_sce_files, readr::read_rds)
+names(sce_list) <- input_library_ids
+
+merged_sce <- sce_list[[1]]
+
+# write out merged sce file 
+readr::write_rds(merged_sce, opt$output_sce_file)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -1,7 +1,6 @@
 #!/usr/bin/env Rscript
 
 # import libraries
-library(magrittr)
 library(optparse)
 library(SingleCellExperiment)
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -29,14 +29,24 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
+# check that file extension for output file is correct 
+
 # list of paths to salmon files 
-input_sce_files <- stringr::str_split(opt$infiles, ',')
+input_sce_files <- stringr::str_split(opt$input_sce_files, ',')
 # pull library ids from list of 
 input_library_ids <- stringr::str_split(opt$library_ids, ',')
+
+# check that input files exist 
 
 # get list of sces
 sce_list <- purrr::map(input_sce_files, readr::read_rds)
 names(sce_list) <- input_library_ids
+
+# create combined SCE object with function in scpcaTools 
+
+# HVG calculation (from perform_hvg_selection in integration-helpers)
+
+# Dim Reduction PCA and UMAP 
 
 # write out merged sce file 
 readr::write_rds(sce_list, opt$output_sce_file)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -29,7 +29,7 @@ option_list <- list(
             the default is n_hvg = 2000"
   ),
   make_option(
-    opt_str = c("t", "--threads"),
+    opt_str = c("-t", "--threads"),
     type = "integer",
     default = 1,
     help = "Number of multiprocessing threads to use"
@@ -92,9 +92,8 @@ sce_list <- purrr::map(input_sce_files, readr::read_rds)
 
 # check that all input RDS files contain SCE objects
 sce_checks <- purrr::map(sce_list,
-                         \(sce)
-                         is(sce, "SingleCellExperiment"))
-if(!any(sce_checks)){
+                         \(x) is(x, "SingleCellExperiment"))
+if(!all(sce_checks)){
   stop(
     "All input files must contain a `SingleCellExperiment` object."
   )

--- a/integrate.nf
+++ b/integrate.nf
@@ -36,6 +36,9 @@ process merge_sce {
     echo $scpca_nf_file |
       tr -s ' ' '\n' > $merged_sce_file
 
+    # would then add in a call to merging script with the text file as input
+    # the merging script would output the merged_sce_file
+
     """
 
 }
@@ -76,7 +79,7 @@ workflow {
       // create tuple of just integration group and output file from scpca_nf
       .map{[
         it[1].integration_group,
-        it[2].scpca_nf_file
+        file(it[2].scpca_nf_file)
         ]}
       // grouped tuple of [integration_group, [file1, file2, file3, ...]]
       .groupTuple(by: 0)

--- a/integrate.nf
+++ b/integrate.nf
@@ -33,7 +33,7 @@ process merge_sce {
   script:
     input_sces = scpca_nf_file.join(',')
     input_library_ids = library_ids.join(',')
-    merged_sce_file = "${integration_group}_merged.txt"
+    merged_sce_file = "${integration_group}_merged.rds"
     """
     merge_sces.R \
       --input_library_ids "${input_library_ids} \

--- a/integrate.nf
+++ b/integrate.nf
@@ -62,6 +62,8 @@ workflow {
     // channel with run metadata, keeping only the columns we need
     runs_ch = Channel.fromPath(params.run_metafile)
       .splitCsv(header: true, sep: '\t')
+      // only include single-cell/single-nuclei and make sure no CITE-seq/ hashing libraries
+      .filter{it.technology in ['10Xv2', '10Xv2_5prime', '10Xv3', '10Xv3.1']}
       .map{[
         library_id: it.scpca_library_id,
         scpca_nf_file: "${params.results_dir}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"

--- a/integrate.nf
+++ b/integrate.nf
@@ -35,10 +35,10 @@ process merge_sce {
     input_library_ids = library_ids.join(',')
     merged_sce_file = "${integration_group}_merged.txt"
     """
-    echo $library_ids $input_sces > $merged_sce_file
-    # would then add in a call to merging script with the text file as input
-    # the merging script would output the merged_sce_file
-
+    merge_sces.R \
+      --input_library_ids "${input_library_ids} \
+      --input_sce_files "${input_sces} \
+      --output_sce_file ${merged_sce_file}
     """
 
 }

--- a/integrate.nf
+++ b/integrate.nf
@@ -36,8 +36,8 @@ process merge_sce {
     merged_sce_file = "${integration_group}_merged.rds"
     """
     merge_sces.R \
-      --input_library_ids "${input_library_ids} \
-      --input_sce_files "${input_sces} \
+      --input_library_ids "${input_library_ids}" \
+      --input_sce_files "${input_sces}" \
       --output_sce_file ${merged_sce_file}
     """
 

--- a/integrate.nf
+++ b/integrate.nf
@@ -1,0 +1,85 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+params.integration_metafile = 's3://ccdl-scpca-data/sample_info/scpca-integration-metadata.tsv'
+params.integration_group = "All"
+
+// parameter checks
+param_error = false
+
+if (!file(params.run_metafile).exists()) {
+  log.error("The 'run_metafile' file '${params.run_metafile}' can not be found.")
+  param_error = true
+}
+
+if (!file(params.integration_metafile).exists()) {
+  log.error("The 'integration_metafile' file '${params.integration_metafile}' can not be found.")
+  param_error = true
+}
+
+if(param_error){
+  System.exit(1)
+}
+
+process merge_sce {
+  container params.SCPCATOOLS_CONTAINER
+  publishDir "${params.checkpoints_dir}/merged_sces"
+  input:
+    tuple val(int_group), path(scpca_nf_file), val(library_ids), val(sample_ids)
+  output:
+    path merged_sce_file
+  script:
+    merged_sce_file = "${int_group}_merged.rds"
+    """
+    echo $scpca_nf_file > $merged_sce_file
+    """
+
+}
+
+workflow {
+
+    // select projects to integrate from params
+    int_groups = params.integration_group?.tokenize(',') ?: []
+    int_groups_all = int_groups[0] == "All" // create logical for including all groups or not when filtering later
+
+    // create channel of integration group and libraries to integrate
+    integration_meta_ch = Channel.fromPath(params.integration_metafile)
+      .splitCsv(header: true, sep: '\t')
+      .map{[
+        library_id: it.scpca_library_id,
+        integration_group: it.integration_group,
+        submitter: it.submitter
+      ]}
+      .filter{int_groups_all  || (it.integration_group in int_groups)}
+
+    // channel with run metadata, keeping only the columns we need
+    runs_ch = Channel.fromPath(params.run_metafile)
+      .splitCsv(header: true, sep: '\t')
+      .map{[
+        library_id: it.scpca_library_id,
+        run_id: it.scpca_run_id,
+        sample_id: it.scpca_sample_id.split(";").sort().join(","),
+        scpca_nf_file: "${params.outdir}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
+      ]}
+      .map{meta -> tuple(meta,
+                         scpca_nf_file: file(meta.scpca_nf_file)
+                         )}
+
+    all_meta_ch = integration_meta_ch
+      .map{[it["library_id"]] + it }
+      // pull out library_id from meta and use to join
+      .join(runs_ch.map{[it[1]["library_id"]] + it }, by: 0)
+      // create tuple of just integration group and output file from scpca_nf
+      .map{[
+        it[1].integration_group,
+        it[2].scpca_nf_file,
+        it[3].library_id,
+        it[3].sample_id]}
+      // grouped tuple of [integration_group, [file1, file2, file3, ...],
+      //                    [library1, library2, library3...], [sample1, sample2, sample3...]]
+      .groupTuple(by: 0)
+
+    merge_sce(all_meta_ch)
+
+}
+

--- a/integrate.nf
+++ b/integrate.nf
@@ -79,6 +79,7 @@ workflow {
       // create tuple of just integration group and output file from scpca_nf
       .map{[
         it[1].integration_group,
+        it[0],
         file(it[2].scpca_nf_file)
         ]}
       // grouped tuple of [integration_group, [file1, file2, file3, ...]]

--- a/integrate.nf
+++ b/integrate.nf
@@ -67,7 +67,7 @@ workflow {
       .filter{integration_groups_all  || (it.integration_group in integration_groups)}
 
     // channel with run metadata, keeping only the columns we need
-    runs_ch = Channel.fromPath(params.run_metafile)
+    libraries_ch = Channel.fromPath(params.run_metafile)
       .splitCsv(header: true, sep: '\t')
       // only include single-cell/single-nuclei and make sure no CITE-seq/ hashing libraries
       .filter{it.technology in ['10Xv2', '10Xv2_5prime', '10Xv3', '10Xv3.1']}

--- a/integrate.nf
+++ b/integrate.nf
@@ -66,7 +66,7 @@ workflow {
       .filter{it.technology in ['10Xv2', '10Xv2_5prime', '10Xv3', '10Xv3.1']}
       .map{[
         library_id: it.scpca_library_id,
-        scpca_nf_file: "${params.results_dir}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
+        scpca_nf_file: "${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
       ]}
 
     all_meta_ch = integration_meta_ch


### PR DESCRIPTION
Closes #236 

Here I am starting the template for the integration workflow so we can start to build in the individual steps. I focused here on the framework of the nextflow workflow and then once we have established what we want, we can move into building the actual script to merge.

For this workflow I started off with the minimum that we needed to get started. I added a param for integration groups and a param for the integration metadata file. For the integration group for now I set it up to be default of `All`, similar to how we have set up the run IDs in the main workflow. The other parameters that we will need for this workflow, the checkpoints directory, the outputs directory, and the library metadata file are all defined in the main config file so I didn't define them here. 

The main thing I worked on was setting up reading in the channels and getting them into the first process, which is the merging process. For the merging, I wanted to have it so that we provide all of the paths to the input SCE files that are going to be merged along with the `integration_group` or name associated with that group of SCE files. To do this I read in the integration metadata file and the library metadata file separately. For the integration group file I filter by the integration groups we want to run. For the library metadata file, I created a new column for the path to the SCE file for each library. I then joined that with the integration metadata and create a grouped tuple with `[integration_group, [scpca_nf_files]]` that become the input channel to the merging process. 

Within the merging process, I am planning to have as input the `integration_group` and a text file with the list of SCE file paths (similar to how we have it set up in the bulk salmon workflow when we read in multiple salmon output directories). I added creation of the text file with one file per line and one file per group as a test right now that Nextflow is set up correctly. 

The only issue that I'm seeing right now is that the text file that's being produced only prints out the file name and not the full path to the file, even though I'm defining it? I included an example of one of the outputs below. 

You should be able to test this by just using `nextflow run integrate.nf -profile batch,ccdl`.

In the meantime, I also think some of the steps we have in merging (like the actual combining of sces into one), might make sense to include as a function in `scpcaTools`. So we may want to make that addition there first before writing the script here. For right now I'm including this as a draft PR, also because we want to get `v0.4.0` of `scpca-nf` out before we start merging this in. 

I'm going to still request review just to get some 👀  on the set up. 
[acute_myeloid_leukemia-gawad_merged.txt](https://github.com/AlexsLemonade/scpca-nf/files/10045073/acute_myeloid_leukemia-gawad_merged.txt)
