### PR TITLE
Change arguments to `read_alevin`

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -93,16 +93,12 @@ mito_genes <- unique(scan(opt$mito_file, what = "character"))
 # read in gtf file (genes only for speed)
 gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 
-# convert seq_unit to spliced or unspliced to determine which types of transcripts to include in final counts matrix
-which_counts <- dplyr::case_when(opt$seq_unit == "cell" ~ "spliced",
-                                 opt$seq_unit == "nucleus" ~ "unspliced")
-
 # parse sample id list
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
-                              which_counts = which_counts,
+                              include_unspliced = TRUE,
                               usa_mode = TRUE,
                               tech_version = opt$technology,
                               library_id = opt$library_id,
@@ -112,7 +108,8 @@ unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
 # read and merge feature counts if present
 if (opt$feature_dir != ""){
   feature_sce <- read_alevin(quant_dir = opt$feature_dir,
-                             mtx_format = TRUE,
+                             include_unspliced = TRUE,
+                             usa_mode = TRUE,
                              library_id = opt$library_id,
                              sample_id = sample_ids)
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -12,11 +12,6 @@ suppressPackageStartupMessages({
 # set up arguments
 option_list <- list(
   make_option(
-    opt_str = c("-s", "--seq_unit"),
-    type = "character",
-    help = "`cell` or `nucleus`, which will determine whether to include counts for spliced cDNA only (cell) or unspliced and spliced cDNA (nucleus)"
-  ),
-  make_option(
     opt_str = c("-a", "--alevin_dir"),
     type = "character",
     help = "directory with alevin output files for RNA-seq quantification"
@@ -66,11 +61,6 @@ option_list <- list(
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
-
-# check for compatible sequencing unit types
-if(!(opt$seq_unit %in% c("cell", "nucleus"))){
-  stop("Sequencing unit must be of type cell or nucleus")
-}
 
 # check that output file name ends in .rds
 if(!(stringr::str_ends(opt$unfiltered_file, ".rds"))){

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -57,6 +57,11 @@ option_list <- list(
     opt_str = c("--sample_id"),
     type = "character",
     help = "sample id(s). If more than one, separated by commas and/or semicolons."
+  ),
+  make_option(
+    opt_str = c("--spliced_only"),
+    action = "store_true",
+    help = "include only the spliced counts as the main counts assay in the returned SCE object"
   )
 )
 
@@ -86,9 +91,16 @@ gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 # parse sample id list
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
+# set include unspliced for non feature data
+if(!is.null(spliced_only)){
+  include_unspliced <- FALSE
+} else {
+  include_unspliced <- TRUE
+}
+
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
-                              include_unspliced = TRUE,
+                              include_unspliced = include_unspliced,
                               fry_mode = TRUE,
                               tech_version = opt$technology,
                               library_id = opt$library_id,

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -89,7 +89,7 @@ sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
                               include_unspliced = TRUE,
-                              usa_mode = TRUE,
+                              fry_mode = TRUE,
                               tech_version = opt$technology,
                               library_id = opt$library_id,
                               sample_id = sample_ids)
@@ -98,8 +98,9 @@ unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
 # read and merge feature counts if present
 if (opt$feature_dir != ""){
   feature_sce <- read_alevin(quant_dir = opt$feature_dir,
-                             include_unspliced = TRUE,
-                             usa_mode = TRUE,
+                             include_unspliced = FALSE,
+                             fry_mode = TRUE,
+                             feature_data = TRUE,
                              library_id = opt$library_id,
                              sample_id = sample_ids)
 

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -15,7 +15,6 @@ process make_unfiltered_sce{
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         """
         generate_unfiltered_sce.R \
-          --seq_unit ${meta.seq_unit} \
           --alevin_dir ${alevin_dir} \
           --unfiltered_file ${unfiltered_rds} \
           --mito_file ${mito} \

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -21,7 +21,8 @@ process make_unfiltered_sce{
           --gtf_file ${gtf} \
           --technology ${meta.technology} \
           --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}"
+          --sample_id "${meta.sample_id}" \
+          ${params.spliced_only ? '--spliced_only' : ''}
         """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,7 @@ params {
   repeat_mapping = false // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
   repeat_gdemux = false // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_gdemux` to run these steps.
   publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
+  spliced_only = false // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
 
   seed = 2021   // random number seed for filtering and post-processing (0 means use system seed)
 


### PR DESCRIPTION
The changes we added to `scpcaTools::read_alevin` in https://github.com/AlexsLemonade/scpcaTools/pull/144 changed some argument names to remove the `intron_mode` and `which_counts` arguments and replace with one `include_unspliced`. Here I modified the script that generates the unfiltered SCE object and reads in the data to accommodate those changes. I know that `include_unspliced` is set to `TRUE` as the default in the function, but I just put it here to be explicit. I didn't add it as a param to the actual workflow, but we could if others think that's important? 

I also removed the `seq_unit` arg that was being passed into the script because we were using it before to figure out which counts to include spliced vs. unspliced. Now we are including both matrices for all of them so no longer need to know if the library is single-cell or nuclei. 