### PR TITLE
Small fixes to match updates in scpcaTools

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -61,6 +61,7 @@ option_list <- list(
   make_option(
     opt_str = c("--spliced_only"),
     action = "store_true",
+    default = FALSE,
     help = "include only the spliced counts as the main counts assay in the returned SCE object"
   )
 )
@@ -93,7 +94,6 @@ sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # set include unspliced for non feature data
 include_unspliced <- !opt$spliced_only
-}
 
 # get unfiltered sce
 unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -92,7 +92,7 @@ gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # set include unspliced for non feature data
-include_unspliced <- !opts$spliced_only
+include_unspliced <- !opt$spliced_only
 }
 
 # get unfiltered sce

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -92,10 +92,7 @@ gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # set include unspliced for non feature data
-if(!is.null(opt$spliced_only)){
-  include_unspliced <- FALSE
-} else {
-  include_unspliced <- TRUE
+include_unspliced <- !opts$spliced_only
 }
 
 # get unfiltered sce

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -92,7 +92,7 @@ gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # set include unspliced for non feature data
-if(!is.null(spliced_only)){
+if(!is.null(opt$spliced_only)){
   include_unspliced <- FALSE
 } else {
   include_unspliced <- TRUE

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -159,7 +159,7 @@ metadata_list <- list(
   has_cellhash = has_cellhash,
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
-  empty_drops_filtering_method = filtered_sce_meta$filtering_method,
+  droplet_filtering_method = filtered_sce_meta$filtering_method,
   total_reads = sce_meta$total_reads,
   mapped_reads = sce_meta$mapped_reads,
   genome_assembly = opt$genome_assembly,

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -19,6 +19,11 @@ option_list <- list(
     help = "path to rds file with filtered sce object"
   ),
   make_option(
+    opt_str = c("-p", "--processed_sce"),
+    type = "character",
+    help = "path to rds file with processed sce object"
+  ),
+  make_option(
     opt_str = c("-l", "--library_id"),
     type = "character",
     help = "Library identifier for report and metadata file"
@@ -113,10 +118,12 @@ if (opt$workflow_commit == "null"){
 # read sce files
 unfiltered_sce <- readr::read_rds(opt$unfiltered_sce)
 filtered_sce <- readr::read_rds(opt$filtered_sce)
+processed_sce <- readr::read_rds(opt$processed_sce)
 
 # Compile metadata for output files
 sce_meta <- metadata(unfiltered_sce)
 filtered_sce_meta <- metadata(filtered_sce)
+processed_sce_meta <- metadata(processed_sce)
 
 # Parse sample ids
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
@@ -152,12 +159,16 @@ metadata_list <- list(
   has_cellhash = has_cellhash,
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
-  filtering_method = filtered_sce_meta$filtering_method,
+  empty_drops_filtering_method = filtered_sce_meta$filtering_method,
   total_reads = sce_meta$total_reads,
   mapped_reads = sce_meta$mapped_reads,
   genome_assembly = opt$genome_assembly,
   mapping_index = sce_meta$reference_index,
   transcript_type = sce_meta$transcript_type,
+  cell_filtering_method = processed_sce_meta$scpca_filter_method,
+  normalization_method = processed_sce_meta$normalization,
+  min_gene_cutoff = processed_sce_meta$min_gene_cutoff,
+  prob_compromised_cutoff = processed_sce_meta$prob_compromised_cutoff,
   date_processed = lubridate::format_ISO8601(lubridate::now(tzone = "UTC"), usetz = TRUE),
   salmon_version = sce_meta$salmon_version,
   alevin_fry_version = sce_meta$alevinfry_version,
@@ -190,6 +201,7 @@ scpcaTools::generate_qc_report(
   library_id = metadata_list$library_id,
   unfiltered_sce = unfiltered_sce,
   filtered_sce = filtered_sce,
+  processed_sce = processed_sce,
   output = opt$qc_report_file
 )
 

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.2.0'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -20,6 +20,7 @@ process sce_qc_report{
           --sample_id "${meta.sample_id}" \
           --unfiltered_sce ${unfiltered_rds} \
           --filtered_sce ${filtered_rds} \
+          --processed_sce ${processed_rds} \
           --qc_report_file ${qc_report} \
           --metadata_json ${metadata_json} \
           --technology "${meta.technology}" \

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -45,7 +45,6 @@ process make_merged_unfiltered_sce{
 
         """
         generate_unfiltered_sce.R \
-          --seq_unit ${meta.seq_unit} \
           --alevin_dir ${alevin_dir} \
           --feature_dir ${feature_alevin_dir} \
           --feature_name ${meta.feature_type} \
@@ -54,7 +53,8 @@ process make_merged_unfiltered_sce{
           --gtf_file ${gtf} \
           --technology ${meta.technology} \
           --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}"
+          --sample_id "${meta.sample_id}" \
+          ${params.spliced_only ? '--spliced_only' : ''}
         """
 }
 


### PR DESCRIPTION
In testing for the upcoming release of `scpcaTools`, I found a few small errors that needed to be addressed here. 

- Passing the processed SCE object through to the QC report 
- In passing the processed SCE object through, I also added some values to the `metadata.json` that gets produced to reflect filtering and normalization additions. 
- Adding a missing `opt`
- remove extra `--seq_unit` option

I also changed to use the tag for what is about to be the most recent release of `scpcaTools`. I did test it with the new `edge` tag that just built after merging https://github.com/AlexsLemonade/scpcaTools/pull/151 and things looked as expected, even in the QC report.