### PR TITLE
Add scpca-meta.json outputs to more publishDirs

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -42,6 +42,8 @@ process alevin_feature{
                     '10Xv3.1': '1[17-28]']
     tech_version = meta.technology.split('_').last()
     umi_geom = umi_geom_map[tech_version]
+    // get meta to write as file
+    meta_json = Utils.makeJson(meta)
     """
     mkdir -p ${run_dir}
     salmon alevin \
@@ -57,6 +59,8 @@ process alevin_feature{
       -p ${task.cpus}
 
     cp ${feature_index}/t2g.tsv ${run_dir}/t2g.tsv
+
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
 }
 
@@ -75,6 +79,8 @@ process fry_quant_feature{
           path(run_dir)
 
   script:
+    // get meta to write as file
+    meta_json = Utils.makeJson(meta)
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
@@ -97,6 +103,8 @@ process fry_quant_feature{
 
     # remove large files
     rm ${run_dir}/*.rad ${run_dir}/*.bin
+
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
 }
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -57,6 +57,8 @@ process fry_quant_rna{
     tuple val(meta), path(run_dir)
 
   script:
+    // get meta to write as file
+    meta_json = Utils.makeJson(meta)
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
@@ -79,6 +81,8 @@ process fry_quant_rna{
 
     # remove large files
     rm ${run_dir}/*.rad ${run_dir}/*.bin
+
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,13 +62,13 @@ profiles{
     docker.enabled = true
     docker.userEmulation = true
   }
-  // AWS batch profile
-  batch {
-    includeConfig 'config/profile_awsbatch.config'
-  }
   // AWS batch profile with autoscaling disk
-  autobatch {
+  batch {
     includeConfig 'config/profile_awsbatch_auto.config'
+  }
+  // AWS batch profile with manual disk sizing
+  batch_manual {
+    includeConfig 'config/profile_awsbatch.config'
   }
   // CCDL-specific settings
   ccdl{


### PR DESCRIPTION
This PR adds scpca-meta.json outputs to a few more outputs, for future-proofing & potential tracing. The additions are to the feature rad & quant output directories and to the alevinfry quant directory. These outputs are only used if `--publish_fry_outs` is specified, so I wasn't thinking about them before, but I think it is useful to have the output files just in case!