### PR TITLE
Change miQC default filtering

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -27,6 +27,12 @@ option_list <- list(
     help = "probability compromised cutoff used for filtering cells with miQC"
   ),
   make_option(
+    opt_str = c("--enforce_left_cutoff"),
+    action = "store_true",
+    default = FALSE,
+    help = "flag to set the miQC's enforce_left_cutoff option to TRUE"
+  ),
+  make_option(
    opt_str = c("-r", "--random_seed"),
    type = "integer",
    help = "A random seed for reproducibility."
@@ -74,11 +80,12 @@ filtered_sce <- filtered_sce |>
 miQC_worked <- FALSE
 try({
   filtered_sce <- scpcaTools::add_miQC(filtered_sce,
-                                       posterior_cutoff = opt$prob_compromised_cutoff)
+                                       posterior_cutoff = opt$prob_compromised_cutoff,
+                                       enforce_left_cutoff = opt$enforce_left_cutoff)
   metadata(filtered_sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
   miQC_worked <- TRUE
  })
- 
+
 # set prob_compromised to NA if miQC failed
 if (!miQC_worked){
   warning("miQC failed. Setting `prob_compromised` to NA.")


### PR DESCRIPTION
In investigating #250, we found that the culprit, at least in part, is miQC's `enforce_left_cutoff` option. 

Here I am adding an option to our filtering script to make the default for our workflow to set that option as `FALSE`, and only set it as `TRUE` if the `--enforce_left_cutoff` flag is passed at the command line. 

Note that doing it this way requires no changes to the workflow itself!

⚠️ Requires changes to scpcaTools made in https://github.com/AlexsLemonade/scpcaTools/pull/156

closes #250