### PR TITLE
Script for merging SCE objects 

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -32,20 +32,65 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 # list of paths to sce files 
 input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ','))
-# pull library ids from list 
-input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ','))
+
+# set up library ids
+if(is.null(opt$input_library_ids)){
+  # extract library ids from filename
+  input_library_ids <- stringr::word(basename(input_sce_files), 1, sep = "_")
+} else {
+  # pull library ids from list 
+  input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ',')) 
+}
 
 # check that input files exist 
+missing_sce_files <- input_sce_files[which(!file.exists(input_sce_files))]
+if(length(missing_sce_files) > 0){
+  stop(
+    glue::glue(
+      "\nMissing SCE object for {missing_sce_files}."
+    )
+  )
+}
+# Merge SCEs -------------------------------------------------------------------
 
 # get list of sces
 sce_list <- purrr::map(input_sce_files, readr::read_rds)
 names(sce_list) <- input_library_ids
 
-# create combined SCE object with function in scpcaTools 
+# create combined SCE object
+merged_sce <- scpcaTools::merge_sce_list(sce_list,
+                                         batch_column = "library_id",
+                                         preserve_rowdata_cols = "gene_symbol",
+                                         cell_id_column = "cell_id")
 
-# HVG calculation (from perform_hvg_selection in integration-helpers)
 
-# Dim Reduction PCA and UMAP 
+# HVG selection ----------------------------------------------------------------
+
+# extract the column with the block variable
+batch_column <- merged_sce$library_id
+
+# model gene variance
+gene_var_block <- scran::modelGeneVar(merged_sce,
+                                      block = batch_column)
+# identify subset of variable genes
+hvg_list <- scran::getTopHVGs(gene_var_block,
+                               n = 2000)
+
+metadata(merged_sce)$merged_highly_variable_genes <- hvg_list
+
+# Dim Reduction PCA and UMAP----------------------------------------------------
+
+# multi batch PCA on merged object
+multi_pca <- batchelor::multiBatchPCA(merged_sce,
+                                      subset.row = hvg_list,
+                                      batch = batch_column,
+                                      preserve.single = TRUE)
+
+# add PCA results to merged SCE object 
+reducedDim(merged_sce, "PCA") <- multi_pca@listData[[1]]
+
+# add UMAP 
+merged_sce <- scater::runUMAP(dimred = "PCA")
 
 # write out merged sce file 
-readr::write_rds(sce_list[1], opt$output_sce_file)
+readr::write_rds(merged_sce, opt$output_sce_file)

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.2.0'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/integrate.nf
+++ b/integrate.nf
@@ -25,6 +25,7 @@ if(param_error){
 // merge individual SCE objects into one SCE object
 process merge_sce {
   container params.SCPCATOOLS_CONTAINER
+  label 'mem_8'
   publishDir "${params.checkpoints_dir}/merged_sces"
   input:
     tuple val(integration_group), val(library_ids), path(scpca_nf_file)


### PR DESCRIPTION
Closes #243 
⚠️ Stacked on #240 

Here I'm updating the script for merging SCE's that was initiated in #240 to actually perform merging, combined HVG selection, multi batch PCA, and calculate UMAP. The output is a merged SCE object containing HVGs and dim reduction results stored in "PCA" and "UMAP". 

A few things: 

- Right now this script has an option to input both the SCE file names and the library IDs. However the library IDs are optional and if they are not input, then they are grabbed directly from the SCE file name. I was debating removing the library ID option all together and from the channel that gets passed as input to this script as we should always be able to grab the library IDs from the input SCE files. 
- This currently doesn't work all the way through because `batchelor` isn't quite yet in the `scpcaTools` docker image. It will be once https://github.com/AlexsLemonade/scpcaTools/pull/157 is merged. Right now it fails because it can't find `batchelor`, which is the second to last step before writing out the object. Once that PR is merged then I'll test this again and make any necessary updates. I just wanted to get any initial thoughts on structure or decisions made. 