### PR TITLE
Handle failures to quickCluster before normalization

### DIFF
--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -106,16 +106,19 @@ for (alt in altExpNames(filtered_sce)) {
 
 # cluster prior to normalization
 qclust <- NULL
-tryCatch({
-  # Cluster similar cells
+try({
+  # try and cluster similar cells
+  # clustering will fail if < 100 cells in dataset
   qclust <- scran::quickCluster(filtered_sce)
+})
 
+if(!is.null(qclust)){
   # Compute sum factors for each cell cluster grouping
   filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust)
-
+  
   # Include note in metadata re: clustering before computing sum factors
-  metadata(filtered_sce)$normalization <- "deconvolution"
-})
+  metadata(filtered_sce)$normalization <- "deconvolution" 
+}
 
 if (is.null(qclust)) {
   # Include note in metadata re: failed clustering

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -110,15 +110,13 @@ try({
   # try and cluster similar cells
   # clustering will fail if < 100 cells in dataset
   qclust <- scran::quickCluster(filtered_sce)
-})
-
-if(!is.null(qclust)){
+  
   # Compute sum factors for each cell cluster grouping
   filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust)
   
   # Include note in metadata re: clustering before computing sum factors
   metadata(filtered_sce)$normalization <- "deconvolution" 
-}
+})
 
 if (is.null(qclust)) {
   # Include note in metadata re: failed clustering


### PR DESCRIPTION
In starting to re-process projects through `scpca-nf` v0.4.0, I found one library that failed normalization and caused the workflow to stop. We had not been properly handling errors in `scran::quickCluster` so I made the necessary adjustments here to actually catch if that fails. The reason that it can fail is if there are fewer than 100 cells in a library, because we are using the default for minimum cluster size of 100. We could instead enforce a check for how many cells are in the library, but then we wouldn't catch if it fails for other reasons (although I'm not sure what other reasons it would fail?)

I also wanted to note what the downstream UMAPs look like for a library like this. I'm attaching a copy of the updated report for this particular sample after making the adjustments in this PR. These UMAPs aren't the greatest or informative and we could not print them out for libraries of low quality like this... if we wanted to go down that path... 

[SCPCL000519_qc.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/10170264/SCPCL000519_qc.html.zip)