### PR TITLE
Catch errors in UMAP calculation

### DIFF
--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -144,7 +144,7 @@ filtered_sce <- scater::runPCA(filtered_sce,
 # calculate a UMAP matrix using the PCA results
 try({
   filtered_sce <- scater::runUMAP(filtered_sce,
-                                dimred = "PCA")
+                                  dimred = "PCA")
 })
 
 # write out original SCE with additional filtering column

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -110,12 +110,12 @@ try({
   # try and cluster similar cells
   # clustering will fail if < 100 cells in dataset
   qclust <- scran::quickCluster(filtered_sce)
-  
+
   # Compute sum factors for each cell cluster grouping
   filtered_sce <- scran::computeSumFactors(filtered_sce, clusters = qclust)
-  
+
   # Include note in metadata re: clustering before computing sum factors
-  metadata(filtered_sce)$normalization <- "deconvolution" 
+  metadata(filtered_sce)$normalization <- "deconvolution"
 })
 
 if (is.null(qclust)) {
@@ -142,8 +142,10 @@ filtered_sce <- scater::runPCA(filtered_sce,
                                subset_row = var_genes)
 
 # calculate a UMAP matrix using the PCA results
-filtered_sce <- scater::runUMAP(filtered_sce,
+try({
+  filtered_sce <- scater::runUMAP(filtered_sce,
                                 dimred = "PCA")
+})
 
 # write out original SCE with additional filtering column
 readr::write_rds(sce, opt$input_sce_file, compress = "gz")


### PR DESCRIPTION
Addresses #260 (closes with the help of https://github.com/AlexsLemonade/scpcaTools/pull/159) 

This just adds a `try` around the UMAP calculation in post processing. I tested these changes locally, but we will need the changes in `scpcaTools` to fully test this. This should get around failures in being able to calculate UMAP and the QC report related bugs will be handled in https://github.com/AlexsLemonade/scpcaTools/pull/159.