### PR TITLE
Add stub to integration workflow

### DIFF
--- a/integrate.nf
+++ b/integrate.nf
@@ -42,6 +42,11 @@ process merge_sce {
       --output_sce_file "${merged_sce_file}" \
       --n_hvg ${params.num_hvg}
     """
+  stub:
+    merged_sce_file = "${integration_group}_merged.rds"
+    """
+    touch ${merged_sce_file}
+    """
 
 }
 


### PR DESCRIPTION
Stacked on #240 
Here I'm just adding a stub to the first process that's part of the integration workflow being added in #240. In the future we should be sure to include a stub in each of our processes for quick testing. 