### PR TITLE
Integrate SCE's using fastMNN

### DIFF
--- a/bin/integrate_sce.R
+++ b/bin/integrate_sce.R
@@ -96,7 +96,7 @@ merged_hvgs <- metadata(merged_sce)$merged_hvgs
 
 # create list of arguments for either integration method
 integration_args <- list(
-  sce = merged_sce,
+  merged_sce = merged_sce,
   integration_method = opt$method,
   batch_column = "library_id",
   seed = opt$seed,

--- a/bin/integrate_sce.R
+++ b/bin/integrate_sce.R
@@ -39,6 +39,12 @@ option_list <- list(
             during integration with `harmony`."
   ),
   make_option(
+    opt_str = c("-t", "--threads"),
+    type = "integer",
+    default = 1,
+    help = "Number of multiprocessing threads to use"
+  ),
+  make_option(
     opt_str = c("--seed"),
     type = "integer",
     default = NULL,
@@ -68,11 +74,6 @@ if(is.null(opt$input_sce_file)) {
   }
 }
 
-# Check that both input and output files have RDS extensions
-if(!(grepl("\\.rds$", opt$input_sce_file, ignore.case = TRUE)) ||
-   !(grepl("\\.rds$", opt$output_sce_file, ignore.case = TRUE))) {
-  stop("The provided --input_sce_file and --output_sce_file files must be RDS files.")
-}
 
 # Read in SCE file -------------------------------------------------------------
 merged_sce <- readr::read_rds(opt$input_sce_file)
@@ -97,8 +98,8 @@ integrated_sce <- scpcaTools::integrate_sces(merged_sce,
                                              seed = opt$seed)
 # calculate UMAP from corrected PCA
 integrated_sce <- integrated_sce |>
-  scater::runUMAP(dimred = glue::glue("{integration_method}_PCA"),
-                  name = glue::glue("{integration_method}_UMAP"))
+  scater::runUMAP(dimred = glue::glue("{opt$method}_PCA"),
+                  name = glue::glue("{opt$method}_UMAP"))
 
 # write out integrated object with merged data + corrected PCA and UMAP
 readr::write_rds(integrated_sce, opt$output_sce_file)

--- a/bin/integrate_sce.R
+++ b/bin/integrate_sce.R
@@ -105,18 +105,22 @@ integration_args <- list(
 
 # append fastMNN only args
 if(opt$method == "fastMNN"){
-  integration_args <- append(integration_args,
-                             list(
-                               subset.row = merged_hvgs,
-                               auto.merge = TRUE,
-                               BPPARAM = bp_param
-                             ))
+  integration_args <-  append(
+    integration_args,
+    list(
+      subset.row = merged_hvgs,
+      auto.merge = TRUE,
+      BPPARAM = bp_param
+   ))
 }
 
 # append harmony only args
 if(opt$method == "harmony"){
-  integration_arts <- append(integration_args,
-                             covariate_cols = opt$harmony_covariate_cols)
+  integration_arts <- append(
+    integration_args,
+    list(
+      covariate_cols = opt$harmony_covariate_cols
+    ))
 }
 
 # perform integration

--- a/bin/integrate_sce.R
+++ b/bin/integrate_sce.R
@@ -1,3 +1,5 @@
+#!/usr/bin/env Rscript
+
 # Script used to perform integration on a given merged SCE object using R-based methods
 #
 # A merged SCE file in RDS format is read in. Integration is performed with either
@@ -7,6 +9,7 @@
 
 # import libraries
 library(optparse)
+library(SingleCellExperiment)
 
 # Set up optparse options
 option_list <- list(
@@ -49,26 +52,11 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 
 # Check and assign provided method based on available methods
-available_methods <- c("fastmnn", "harmony")
+available_methods <- c("fastMNN", "harmony")
 
-# helper function for method check fails
-stop_method <- function() {
-  stop(
-    paste("You must specify one of the following (case-insensitive) to --method:",
-          paste(available_methods, collapse = ", ")
-    )
-  )
+if(!(opt$method %in% available_methods)){
+  stop("You must specify either `fastMNN` or `harmony` to the --method.")
 }
-
-if (is.null(opt$method)) {
-  stop_method()
-} else {
-  integration_method <- tolower(opt$method)
-  if (!(integration_method %in% available_methods)) {
-    stop_method()
-  }
-}
-
 
 # Check that provided input file exists and is an RDS file
 if(is.null(opt$input_sce_file)) {
@@ -98,13 +86,13 @@ if(!is(merged_sce, "SingleCellExperiment")){
 batch_column <- merged_sce$library_id
 
 # hvgs to use for integration
-merged_hvgs <- metadata(merged_sce_obj)$merged_hvgs
+merged_hvgs <- metadata(merged_sce)$merged_hvgs
 
 # Integration ------------------------------------------------------------------
 
 # perform integration
 integrated_sce <- scpcaTools::integrate_sces(merged_sce,
-                                             integration_method = integration_method,
+                                             integration_method = opt$method,
                                              batch_column = batch_column,
                                              covariate_cols = opt$harmony_covariate_cols,
                                              subset.row = merged_hvgs,

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -41,7 +41,7 @@ option_list <- list(
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
 
-# check that file extension for output file is correct 
+# check that file extension for output file is correct
 if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
   stop("output file name must end in .rds")
 }
@@ -50,8 +50,8 @@ if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
 if(is.null(opt$input_sce_files)){
   stop("List of input files containing individual SCE objects to merge is missing.")
 } else {
-  # list of paths to sce files 
-  input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ',')) 
+  # list of paths to sce files
+  input_sce_files <- unlist(stringr::str_split(opt$input_sce_files, ','))
 }
 
 if(length(input_sce_files) == 1){
@@ -63,11 +63,14 @@ if(is.null(opt$input_library_ids)){
   # extract library ids from filename
   input_library_ids <- stringr::word(basename(input_sce_files), 1, sep = "_")
 } else {
-  # pull library ids from list 
-  input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ',')) 
+  # pull library ids from list
+  input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ','))
 }
 
-# check that input files exist 
+# create named list of sce files with library ids
+names(input_sce_files) <- input_library_ids
+
+# check that input files exist
 missing_sce_files <- input_sce_files[which(!file.exists(input_sce_files))]
 if(length(missing_sce_files) > 0){
   stop(
@@ -88,7 +91,6 @@ if(opt$threads > 1){
 
 # get list of sces
 sce_list <- purrr::map(input_sce_files, readr::read_rds)
-
 
 # check that all input RDS files contain SCE objects
 sce_checks <- purrr::map(sce_list,
@@ -130,16 +132,16 @@ multi_pca <- batchelor::multiBatchPCA(merged_sce,
                                       preserve.single = TRUE,
                                       BPPARAM = bp_param)
 
-# add PCA results to merged SCE object 
+# add PCA results to merged SCE object
 reducedDim(merged_sce, "PCA") <- multi_pca[[1]]
 
-# add UMAP 
+# add UMAP
 merged_sce <- scater::runUMAP(merged_sce,
                               dimred = "PCA",
                               BPPARAM = bp_param)
 
-# write out merged sce file 
-readr::write_rds(merged_sce, 
+# write out merged sce file
+readr::write_rds(merged_sce,
                  opt$output_sce_file,
                  compress = "gz",
                  compression = 2)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -58,17 +58,14 @@ if(length(input_sce_files) == 1){
   stop("Only 1 input file provided, no merging or integration will be performed for this group")
 }
 
-# set up library ids
+# use library ids to name list of input files
 if(is.null(opt$input_library_ids)){
   # extract library ids from filename
-  input_library_ids <- stringr::word(basename(input_sce_files), 1, sep = "_")
+  names(input_sce_files) <- stringr::word(basename(input_sce_files), 1, sep = "_")
 } else {
   # pull library ids from list
-  input_library_ids <- unlist(stringr::str_split(opt$input_library_ids, ','))
+  names(input_sce_files) <- unlist(stringr::str_split(opt$input_library_ids, ','))
 }
-
-# create named list of sce files with library ids
-names(input_sce_files) <- input_library_ids
 
 # check that input files exist
 missing_sce_files <- input_sce_files[which(!file.exists(input_sce_files))]

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -67,6 +67,9 @@ if(is.null(opt$input_library_ids)){
   names(input_sce_files) <- unlist(stringr::str_split(opt$input_library_ids, ','))
 }
 
+# sort inputs by library id
+input_sce_files <- input_sce_files[order(names(input_sce_files))]
+
 # check that input files exist
 missing_sce_files <- input_sce_files[which(!file.exists(input_sce_files))]
 if(length(missing_sce_files) > 0){

--- a/integrate.nf
+++ b/integrate.nf
@@ -55,6 +55,7 @@ process merge_sce {
 process integrate_fastmnn {
   container params.SCPCATOOLS_CONTAINER
   label 'mem_16'
+  label 'cpus_4'
   input:
     tuple val(integration_group), path(merged_sce_file)
   output:
@@ -66,7 +67,8 @@ process integrate_fastmnn {
       --input_sce_file "${merged_sce_file}" \
       --output_sce_file "${fastmnn_sce_file}" \
       --method "fastMNN" \
-      --seed ${params.seed}
+      --seed ${params.seed} \
+      --threads ${task.cpus}
     """
   stub:
     fastmnn_sce_file = "${integration_group}_fastmnn.rds"

--- a/integrate.nf
+++ b/integrate.nf
@@ -51,6 +51,30 @@ process merge_sce {
 
 }
 
+// integrate with fastMNN
+process integrate_fastmnn {
+  container params.SCPCATOOLS_CONTAINER
+  label 'mem_16'
+  input:
+    tuple val(integration_group), path(merged_sce_file)
+  output:
+    tuple val(integration_group), path(fastmnn_sce_file)
+  script:
+    fastmnn_sce_file = "${integration_group}_fastmnn.rds"
+    """
+    integrate_sce.R \
+      --input_sce_file "${merged_sce_file}" \
+      --output_sce_file "${fastmnn_sce_file}" \
+      --method "fastMNN" \
+      --seed ${params.seed}
+    """
+  stub:
+    fastmnn_sce_file = "${integration_group}_fastmnn.rds"
+    """
+    touch ${fastmnn_sce_file}
+    """
+}
+
 workflow {
 
     // select projects to integrate from params
@@ -93,5 +117,7 @@ workflow {
 
     merge_sce(grouped_meta_ch)
 
+    // integrate using fastmnn
+    integrate_fastmnn(merge_sce.out)
 }
 


### PR DESCRIPTION
Closes #247 and #237 

Here I added a script to be used for integrating a merged SCE object using either `fastMNN` or `harmony`. I tried to keep things pretty simple in terms of options and only have the input, output, and method as required options. I also included the harmony covariates as an option in case we ever do want to be able to incorporate that, we can then add a param to nextflow to do that. 

As far as the actual integration, I used the `scpcaTools::integrate_sces()` function that we have and incorporated the minor adjustment to add in a variable for the highly variable genes (https://github.com/AlexsLemonade/scpcaTools/pull/163). 

The other thing I did here was add a process to integrate using `fastMNN`, and the reason for that was so we could start seeing how this script would actually be used in the workflow. I wanted to get some feedback on some decisions I made in doing that: 

- The process that I added, and the script, take as input a merged SCE object and return a merged SCE object with corrected PCA and UMAP results added to the object. This means that each integration method will take the same input and then each produce an object that has the original merged counts and the new corrected PCA/UMAP. I think we want to keep these integration methods completely separate so that they each return their own unique objects and then in the last step (the creation of the report), we would read them both in and grab the results we need from each. What I'm leaning towards is not publishing the output from the `fastMNN` or `harmony`, but reading that output into a final step that will merge all of the results together to create one object that gets published. 
- I made the decision to never return the corrected expression results and therefore did not add an argument for it that could be used from the workflow. I don't really know why we would need them and don't think we want to make that an option. 

The last thing I did here was set the names of the `input_sce_files` list that was being created in the merging script. I noticed during testing that the output from merging contained numbers rather than library ids in the `library_id` column of the `colData`. 