### PR TITLE
Script for building SingleR model

### DIFF
--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -24,7 +24,7 @@ option_list <- list(
   make_option(
     opt_str = c("--output_file"),
     type = "character",
-    help = "path to output rds file to store trained model for reference dataset"
+    help = "path to output rds file to store trained model for reference dataset."
   ),
   make_option(
     opt_str = c("--fry_tx2gene"),
@@ -41,13 +41,11 @@ option_list <- list(
     opt_str = c("-t", "--threads"),
     type = "integer",
     default = 1,
-    help = "Number of multiprocessing threads to use"
+    help = "Number of multiprocessing threads to use."
   )
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
-
-opt$ref_file <- "/Users/allyhawkins/Documents/ALSF/git_repos/ScPCA-admin/sample_info/celltype_annotation/references/celldex-blueprint_encode.rds"
 
 # Set up -----------------------------------------------------------------------
 
@@ -84,6 +82,11 @@ tx2gene <- readr::read_tsv(opt$fry_tx2gene,
 
 # select genes to use for model restriction
 gene_ids <- unique(tx2gene$gene)
+
+# check that genes aren't empty
+if (length(gene_ids) == 0){
+  stop("Provided tx2gene tsv file does not contain any genes.")
+}
 
 # Train models -----------------------------------------------------------------
 

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -1,0 +1,106 @@
+#!/usr/bin/env Rscript
+
+# This script is used to build and train a model to be used for SingleR. 
+# The expected input is a SummarizedExperiment containing a reference dataset and a
+# 3-column, transcript to gene tsv file (as used with Alevin-fry), to provide the expected
+# geneset to be used for training the reference dataset. 
+
+# import libraries
+suppressPackageStartupMessages({
+  library(optparse)
+  library(SingleCellExperiment)
+})
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("--ref_file"),
+    type = "character",
+    help = "path to rds file with input sce object to be processed"
+  ),
+  make_option(
+    opt_str = c("--output_file"),
+    type = "character",
+    help = "path to output rds file to store processed sce object. Must end in .rds"
+  ),
+  make_option(
+    opt_str = c("--fry_tx2gene"),
+    type = "character",
+    help = "path to "
+  ),
+  make_option(
+    opt_str = c("-r", "--random_seed"),
+    type = "integer",
+    help = "A random seed for reproducibility."
+  ),
+  make_option(
+    opt_str = c("-t", "--threads"),
+    type = "integer",
+    default = 1,
+    help = "Number of multiprocessing threads to use"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Set up -----------------------------------------------------------------------
+
+# set seed
+set.seed(opt$random_seed)
+
+# check that input files exist
+if(!file.exists(opt$ref_file)){
+  stop("Missing input file with cell type reference.")
+}
+
+if(!file.exists(opt$fry_tx2gene)){
+  stop("Missing `fry_tx2gene` file.")
+}
+
+# set up multiprocessing params
+if(opt$threads > 1){
+  bp_param = BiocParallel::MulticoreParam(opt$threads)
+} else {
+  bp_param = BiocParallel::SerialParam()
+}
+
+# read in model 
+ref_data <- readr::read_rds(opt$ref_file)
+
+# read in tx2gene 
+tx2gene <- readr::read_tsv(opt$fry_tx2gene,
+                           col_names = c("transcript", "gene", "transcript_type"))
+
+# select genes to use for model restriction 
+gene_ids <- tx2gene |>
+  dplyr::select(gene) |>
+  unique()
+
+# Train models -----------------------------------------------------------------
+
+# train using fine labels
+fine_model <- SingleR::trainSingleR(
+  ref_data,
+  labels = ref_data$label.fine,
+  genes = "de", 
+  # only use genes found in index 
+  restrict = gene_ids,
+  BPPARAM = bp_param
+) 
+
+# train using main labels 
+main_model <- SingleR::trainSingleR(
+  ref_data,
+  labels = ref_data$label.main,
+  genes = "de", 
+  # only use genes found in index 
+  restrict = gene_ids,
+  BPPARAM = bp_param
+) 
+
+# combine into one object 
+all_models <- list(fine = fine_model,
+     main = main_model)
+
+# export models
+readr::write_rds(all_models, opt$output_file)

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -95,14 +95,15 @@ label_cols <- c("label.main", "label.fine", "label.ont")
 names(label_cols) <- label_cols
 
 models <- label_cols |>
- purrr::map(\(labels) {SingleR::trainSingleR(
-                   ref_data,
-                   labels = ref_data[[labels]],
-                   genes = "de",
-                   # only use genes found in index
-                   restrict = gene_ids,
-                   BPPARAM = bp_param
-                 )})
+ purrr::map(\(label_col) {
+   SingleR::trainSingleR(
+     ref_data,
+     labels = ref_data[[label_col]],
+     genes = "de",
+     # only use genes found in index
+     restrict = gene_ids,
+     BPPARAM = bp_param    
+   )})
 
 # export models
 readr::write_rds(models, opt$output_file)

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -98,7 +98,7 @@ models <- label_cols |>
  purrr::map(\(label_col) {
    SingleR::trainSingleR(
      ref_data,
-     labels = ref_data[[label_col]],
+     labels = colData(ref_data)[, label],
      genes = "de",
      # only use genes found in index
      restrict = gene_ids,

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -54,7 +54,7 @@ set.seed(opt$random_seed)
 
 # check that input files exist
 if(!file.exists(opt$ref_file)){
-  stop("Missing input file with cell type reference.")
+  stop("Missing input file with cell type reference (`ref_file`).")
 }
 
 if(!file.exists(opt$fry_tx2gene)){

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -21,7 +21,7 @@ option_list <- list(
   make_option(
     opt_str = c("--output_file"),
     type = "character",
-    help = "path to output rds file to store processed sce object. Must end in .rds"
+    help = "path to output rds file to store processed sce object. Must have `.rds` extension."
   ),
   make_option(
     opt_str = c("--fry_tx2gene"),
@@ -72,9 +72,7 @@ tx2gene <- readr::read_tsv(opt$fry_tx2gene,
                            col_names = c("transcript", "gene", "transcript_type"))
 
 # select genes to use for model restriction 
-gene_ids <- tx2gene |>
-  dplyr::select(gene) |>
-  unique()
+gene_ids <- unique(tx2gene$gene)
 
 # Train models -----------------------------------------------------------------
 


### PR DESCRIPTION
Partially addresses #270 

Here I started to add in a step to the `scpca-nf` workflow for building and training the models for the reference datasets to use when classifying cell types with `SingleR`. I am just starting by adding in a script that will take as input the reference data, stored as a `SummarizedExperiment` in a rds file and output a rds file with a list of two models, one containing a model using the `label.fine` and one containing `label.main`. This script will then be executed within a process in the `scpca-nf` workflow for creating the models, where all references for the specified project(s) or samples from a project being processed will go through the training step. 

A few comments on decisions I made here: 

- Right now, and for the forseeable future we are only using the `celldex` references, so because of that I didn't make an option to specify which labels to build the model with. I am using both labels each time. This will not work if the reference is not `celldex`, because the labels will be different. One approach is to make the labels to use an argument. Rather than make an argument, I chose to make models with both types of labels for now for testing purposes, but if others think we should change it I'm open to trying it. 
- The other thing I had to incorporate here was reading in the tx2gene reference file we use during the mapping step. The reason for that is I think we want to provide the genes to restrict when creating the model, and all of the SCE objects will contain the genes in this file. Alternatively we could just not restrict the genes? 

Once we have this script in, we can then add a new process to the workflow to run this script on each reference file. We will also need to create a metadata file that has the project id's and references for each project before we do that. I started to play around with this, but it was getting kind of tricky so I wanted to get some feedback just on the building the model part first before getting to the nextflow part. The other thought I had was for development purposes to keep the cell type module separate right now so testing and development is much easier and faster. Then once we feel confident about that we can write the code to link `main.nf` to the cell type module. 