### PR TITLE
Initiate integration report

### DIFF
--- a/bin/integration-report.Rmd
+++ b/bin/integration-report.Rmd
@@ -4,6 +4,7 @@ params:
   merged_sce: NULL
   fastmnn_sce: NULL
   harmony_sce: NULL
+  output_file: "example_group.rds"
   batch_column: "batch"
 
 title: "`r glue::glue('Integration report for {params$integration_group}')`"
@@ -108,6 +109,10 @@ batch_umaps <- purrr::map(umap_names, \(name){
 
 patchwork::wrap_plots(batch_umaps, ncol = 2,
                       guides = "collect")
+```
+
+```{r}
+readr::write_rds(merged_sce, params$output_file)
 ```
 
 ```{r}

--- a/bin/integration-report.Rmd
+++ b/bin/integration-report.Rmd
@@ -1,0 +1,116 @@
+---
+params:
+  integration_group: "example_group"
+  merged_sce: NULL
+  fastmnn_sce: NULL
+  harmony_sce: NULL
+  batch_column: "batch"
+
+title: "`r glue::glue('Integration report for {params$integration_group}')`"
+author: "CCDL"
+date: "`r params$date`"
+output:
+  html_document:
+    toc: true
+    toc_depth: 3
+    toc_float: true
+---
+
+```{r setup, message = FALSE, echo = FALSE}
+# knitr options
+knitr::opts_chunk$set(
+  echo = FALSE
+)
+
+library(SingleCellExperiment)
+library(ggplot2)
+
+# Set default ggplot theme
+theme_set(theme_bw() + 
+          theme(plot.margin = margin(rep(20, 4))))
+```
+
+```{r}
+# check that input files are provided 
+if(is.null(params$merged_sce)){
+  stop("Must provide a path to a RDS file containing a merged SCE object.")
+}
+
+if(is.null(params$fastmnn_sce)){
+  stop("Must provide a path to a RDS file containing a SCE object post integration with fastMNN.")
+}
+
+if(is.null(params$harmony_sce)){
+  stop("Must provide a path to a RDS file containing a SCE object post integration with harmony.")
+}
+
+# define batch column 
+batch_column <- params$batch_column
+```
+
+
+```{r}
+integrated_sce_files <- list(fastmnn = params$fastmnn_sce,
+                             harmony = params$harmony_sce)
+
+# only load in the embeddings since we don't need to store the entire object 
+integrated_embeddings <- purrr::map(integrated_sce_files, readr::read_rds) |>
+  purrr::map(reducedDims) |> 
+  # select only those that have a method and then dimreduction name
+  purrr::map(~.x[grep("_PCA$|_UMAP$", names(.x))]) |>
+  # convert from SimpleList and then flatten
+  purrr::map(as.list) |> 
+  purrr::flatten()
+```
+
+
+```{r}
+# read in merged object
+merged_sce <- readr::read_rds(params$merged_sce)
+
+# get list of methods and dimreductions to be added
+methods <- c("fastmnn", "harmony")
+pca_names <- glue::glue("{methods}_PCA")
+umap_names <- glue::glue("{methods}_UMAP")
+dimred_names <- c(pca_names, umap_names)
+
+# add dimreductions to merged sce 
+for(name in dimred_names){
+  reducedDim(merged_sce, name) <- integrated_embeddings[[name]]
+}
+```
+
+UMAP showing batches before and after integration.
+
+```{r}
+# randomly shuffle cells prior to plotting
+col_order <- sample(ncol(merged_sce))
+shuffled_sce <- merged_sce[,col_order]
+
+# set plot colors 
+num_colors <- length(unique(sce_coldata[[batch_column]]))
+plot_colors <- rainbow(num_colors)    
+
+umap_plot_names <- c("UMAP", umap_names)
+
+batch_umaps <- purrr::map(umap_names, \(name){
+  scater::plotReducedDim(shuffled_sce,
+                         dimred = name,
+                         colour_by = batch_column,
+                         point_size = 0.1,
+                         point_alpha = 0.4) +
+    scale_color_manual(values = plot_colors, 
+                       name = "Batch ID") +
+    # relabel legend and resize dots
+    guides(color = guide_legend(override.aes = list(size = 3),
+                                label.theme = element_text(size = 10))) 
+})
+
+patchwork::wrap_plots(batch_umaps, ncol = 2,
+                      guides = "collect")
+```
+
+```{r}
+sessioninfo::session_info()
+```
+

--- a/integrate.nf
+++ b/integrate.nf
@@ -4,6 +4,7 @@ nextflow.enable.dsl=2
 // integration specific parameters
 params.integration_metafile = 's3://ccdl-scpca-data/sample_info/scpca-integration-metadata.tsv'
 params.integration_group = "All"
+params.integration_template = "${projectDir}/bin/integration-report.Rmd"
 
 // parameter checks
 param_error = false
@@ -110,10 +111,10 @@ process integration_report {
   label 'mem_16'
   input:
     tuple val(integration_group), path(merged_sce_file), path(fastmnn_sce_file), path(harmony_sce_file)
+    path(report_template)
   output:
     tuple path(integrated_sce), path(integration_report)
   script:
-    report_template = "${projectDir}/bin/integration-report.Rmd"
     integrated_sce = "${integration_group}.rds"
     integration_report = "${integration_group}_summary_report.html"
     """
@@ -181,6 +182,6 @@ workflow {
     // result is a tuple of [ integration group, merged sce file, fastmnn sce file, harmony sce file ]
     all_integrated_ch = merge_sce.out.combine(integrate_fastmnn.out, by: 0)
       .combine(integrate_harmony.out, by: 0)
-    integration_report(all_integrated_ch)
+    integration_report(all_integrated_ch, params.integration_template)
 }
 

--- a/integrate.nf
+++ b/integrate.nf
@@ -60,7 +60,7 @@ process integrate_fastmnn {
   input:
     tuple val(integration_group), path(merged_sce_file)
   output:
-    tuple val(integration_group), path(merged_sce_file), path(fastmnn_sce_file)
+    tuple val(integration_group), path(fastmnn_sce_file)
   script:
     fastmnn_sce_file = "${integration_group}_fastmnn.rds"
     """
@@ -86,7 +86,7 @@ process integrate_harmony {
   input:
     tuple val(integration_group), path(merged_sce_file)
   output:
-    tuple val(integration_group), path(merged_sce_file), path(harmony_sce_file)
+    tuple val(integration_group), path(harmony_sce_file)
   script:
     harmony_sce_file = "${integration_group}_harmony.rds"
     """
@@ -103,7 +103,7 @@ process integrate_harmony {
     """
 }
 
-// create single object with merged and integrated results
+// create integrated report and single object
 process integration_report {
   container params.SCPCATOOLS_CONTAINER
   publishDir "${params.results_dir}/integration"
@@ -179,7 +179,8 @@ workflow {
 
     // join together by integration group and merged sce file
     // result is a tuple of [ integration group, merged sce file, fastmnn sce file, harmony sce file ]
-    integrate_fastmnn.out.join(integrate_harmony.out, by: [0,1]) \
-      | integration_report
+    all_integrated_ch = merge_sce.out.combine(integrate_fastmnn.out, by: 0)
+      .combine(integrate_harmony.out, by: 0)
+    integration_report(all_integrated_ch)
 }
 

--- a/integrate.nf
+++ b/integrate.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl=2
 // integration specific parameters
 params.integration_metafile = 's3://ccdl-scpca-data/sample_info/scpca-integration-metadata.tsv'
 params.integration_group = "All"
-params.integration_template = "${projectDir}/bin/integration-report.Rmd"
+params.integration_template = "${projectDir}/templates/integration-report.Rmd"
 
 // parameter checks
 param_error = false

--- a/templates/integration-report.Rmd
+++ b/templates/integration-report.Rmd
@@ -89,12 +89,12 @@ col_order <- sample(ncol(merged_sce))
 shuffled_sce <- merged_sce[,col_order]
 
 # set plot colors 
-num_colors <- length(unique(sce_coldata[[batch_column]]))
+num_colors <- length(unique(merged_sce[[batch_column]]))
 plot_colors <- rainbow(num_colors)    
 
 umap_plot_names <- c("UMAP", umap_names)
 
-batch_umaps <- purrr::map(umap_names, \(name){
+batch_umaps <- purrr::map(umap_plot_names, \(name){
   scater::plotReducedDim(shuffled_sce,
                          dimred = name,
                          colour_by = batch_column,
@@ -112,6 +112,7 @@ patchwork::wrap_plots(batch_umaps, ncol = 2,
 ```
 
 ```{r}
+# export single object with merged data and integrated embeddings 
 readr::write_rds(merged_sce, params$output_file)
 ```
 


### PR DESCRIPTION
Closes #272 

Here I started the initial steps for adding in the integration report to the integration workflow. I kept the actual report itself very simple and just am creating a UMAP colored by batches for now. I think we could also add in a table of number of cells per batch and then the UMAPs by cell type, but since we don't actually have cell types implemented yet I decided to hold off. The main thing I want to figure out here is how exactly we are going to read in all of the integrated objects and merged objects, combine everything, and create the report. 

What I chose to do here is directly read the merged sce, fastmnn sce, and harmony sce into the notebook. I also don't need to actually keep the integrated objects around, I just grab the dimension reductions from post integration and then add those to the merged SCE object. At the end of the report I'm saving the merged SCE object with the integrated results now being added in and that is getting published to the results directory. Technically we could have a separate script that does this and then the report could directly read in the merged object that already contains all the results. I could be convinced either way. 

The other thing I chose to do here was directly render the report in the Nextflow process, rather than writing a script to render it. I did think about creating a script that first does the data wrangling and exports the SCE object and then renders the template, but I had already spent a lot of time on this and wanted to get others opinions before I did that to see if it was even necessary. 

I did have a question on the best place to store the `.Rmd` files? I think we probably want to create a separate folder for templates? Any thoughts on naming that folder or do we want to move it to `bin` instead? 

Also you'll notice that I have two consecutive `.combine` steps to get a tuple containing the integration group, merged SCE file, fastmnn SCE file, and harmony SCE file. I tried to pass the merged SCE file as output from both integration processes and then just have one `.combine` step using `by: [0:1]`, but Nextflow kept skipping the process, making me think it didn't like passing the merged SCE file as input and output? 

I'm still doing some testing and debugging to get this to run to completion, but I wanted to get this up. 