### PR TITLE
Add process for training celldex references for SingleR

### DIFF
--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -19,7 +19,7 @@ option_list <- list(
     opt_str = c("--ref_file"),
     type = "character",
     help = "path to rds file with reference dataset to use for cell type annotation.
-      These reference datasets must contain annotations labeld with 
+      These reference datasets must contain annotations labeled with
       `label.main`, `label.fine`, and `label.ont`."
   ),
   make_option(
@@ -98,11 +98,11 @@ models <- label_cols |>
  purrr::map(\(label_col) {
    SingleR::trainSingleR(
      ref_data,
-     labels = colData(ref_data)[, label],
+     labels = colData(ref_data)[, label_col],
      genes = "de",
      # only use genes found in index
      restrict = gene_ids,
-     BPPARAM = bp_param    
+     BPPARAM = bp_param
    )})
 
 # export models

--- a/build-index.nf
+++ b/build-index.nf
@@ -152,13 +152,13 @@ process train_singler_models {
 
 workflow {
   // generate splici and spliced cDNA reference fasta
-  //generate_reference(params.ref_fasta, params.ref_gtf, params.assembly)
+  generate_reference(params.ref_fasta, params.ref_gtf, params.assembly)
   // create index using reference fastas
-  //salmon_index(generate_reference.out.fasta_files, params.ref_fasta)
+  salmon_index(generate_reference.out.fasta_files, params.ref_fasta)
   // create cellranger index
-  //cellranger_index(params.ref_fasta, params.ref_gtf, params.assembly)
+  cellranger_index(params.ref_fasta, params.ref_gtf, params.assembly)
   // create star index
-  //star_index(params.ref_fasta, params.ref_gtf, params.assembly)
+  star_index(params.ref_fasta, params.ref_gtf, params.assembly)
 
 
   // create channel of cell type ref files and names

--- a/build-index.nf
+++ b/build-index.nf
@@ -132,6 +132,7 @@ process train_singler_models {
   label 'mem_16'
   input:
     tuple path(celltype_ref), val(ref_name)
+    path tx2gene
   output:
     path celltype_model
   script:
@@ -140,6 +141,7 @@ process train_singler_models {
     train_SingleR.R \
       --ref_file ${celltype_ref} \
       --output_file ${celltype_model} \
+      --fry_tx2gene ${tx2gene} \
       --seed ${params.seed} \
       --threads ${task.cpus}
 
@@ -168,5 +170,5 @@ workflow {
     ]}
 
   // train cell type references using SingleR
-  train_singler_models(celltype_refs_ch)
+  train_singler_models(celltype_refs_ch, params.t2g_3col_path)
 }

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -12,6 +12,9 @@ params{
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"
 
+  // cell type references
+  celltype_refs_metafile = "s3://ccdl-scpca-data/sample_info/celltype_annotation/celltype-reference-metadata.tsv"
+
   // Private CCDL containers
   CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
   SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -19,3 +19,7 @@ t2g_bulk_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced
 
 // barcode files
 barcode_dir      = "${params.ref_rootdir}/barcodes/10X"
+
+// cell type references
+celltype_ref_dir = 's3://nextflow-ccdl-data/reference/celldex'
+celltype_model_dir = 's3://nextflow-ccdl-data/reference/singler_models'


### PR DESCRIPTION
Closes #270 

Here I added a process to the `build-index.nf` script to train the references for use with SingleR for cell type annotation. We probably could separate this out into another file completely... but they are all references that will be used for `scpca-nf` so if others want me to put it in its own file I can. 

The process takes as input a reference file and then runs the `train_SingleR.R` script to generate a rds file with a list of models, one for each of the labels present in the `celldex` reference. Overall it was pretty straight forward. The only question I really have for now is where to store everything on S3. Since we are still in development, I am storing everything in our private bucket that we have, rather than writing it to the public `scpca-references`, but if we are comfortable with storing the models there I can update that path. I also did test this and everything worked as expected. 