### PR TITLE
Cut to 2 barcode columns for salmon

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -9,6 +9,7 @@ process index_feature{
     tuple val(id), path("feature_index")
   script:
     """
+    # ensure salmon only gets the first 2 columns here
     cut -f 1,2 ${feature_file} > feature_barcodes.txt
 
     salmon index \
@@ -16,6 +17,9 @@ process index_feature{
       -i feature_index \
       --features \
       -k 7
+
+    # Remove "temporary" barcodes file
+    rm feature_barcodes.txt
 
     awk '{print \$1"\\t"\$1;}' ${feature_file} > feature_index/t2g.tsv
     """

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -9,8 +9,10 @@ process index_feature{
     tuple val(id), path("feature_index")
   script:
     """
+    cut -f 1,2 ${feature_file} > feature_barcodes.txt
+
     salmon index \
-      -t ${feature_file} \
+      -t feature_barcodes.txt \
       -i feature_index \
       --features \
       -k 7

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -18,8 +18,6 @@ process index_feature{
       --features \
       -k 7
 
-    # Remove "temporary" barcodes file
-    rm feature_barcodes.txt
 
     awk '{print \$1"\\t"\$1;}' ${feature_file} > feature_index/t2g.tsv
     """


### PR DESCRIPTION
Closes #304 

This PR `cut`s (keeping it interesting, would of course be too boring with 2 `awk`s 😅) out the first 2 columns from feature barcode files to pass into `salmon index`, which does not appreciate >2 columns.  

I also decided to remove the "temporary" file after its usage. These certainly aren't big files that _need_ to be removed, but who knows what kind of features this might take one day so I figured removing the file doesn't hurt.