### PR TITLE
Document addition of specifying references on a single-sample level

### DIFF
--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -9,18 +9,3 @@ barcode_dir      = "${params.ref_rootdir}/barcodes/10X"
 // cell type references
 celltype_ref_dir = "${params.ref_rootdir}/celltype/references"
 celltype_model_dir = "${params.ref_rootdir}/celltype/singler_models"
-
-// old params for references
-ref_dir          = "${params.ref_rootdir}/homo_sapiens/ensembl-104"
-ref_fasta        = "${params.ref_dir}/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz"
-ref_fasta_index  = "${params.ref_dir}/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai"
-ref_gtf          = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.gtf.gz"
-// index files
-splici_index     = "${params.ref_dir}/salmon_index/Homo_sapiens.GRCh38.104.spliced_intron.txome"
-bulk_index       = "${params.ref_dir}/salmon_index/Homo_sapiens.GRCh38.104.spliced_cdna.txome"
-cellranger_index = "${params.ref_dir}/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full"
-star_index       = "${params.ref_dir}/star_index/Homo_sapiens.GRCh38.104.star_idx"
-// annotation files
-mito_file        = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt"
-t2g_3col_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
-t2g_bulk_path    = "${params.ref_dir}/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,29 +2,29 @@
 
 ## Example files
 
-This directory contains an example [metadata file](../external-data-instructions.md#prepare-the-metadata-file) and [configuration file](../external-data-instructions.md#configuration-files) for the `scpca-nf` workflow. 
+This directory contains an example [metadata file](../external-data-instructions.md#prepare-the-metadata-file) and [configuration file](../external-data-instructions.md#configuration-files) for the `scpca-nf` workflow.
 These files should be used as an example of formats and content, but note that the values in these files may not be applicable or sufficient to allow running `scpca-nf` to be used directly on your system.
 
-## Testing your setup with example data 
+## Testing your setup with example data
 
-:warning: These instructions are only intended to be used to test accurate set up of a configuration file. 
+:warning: These instructions are only intended to be used to test accurate set up of a configuration file.
 Before following these instructions, please ensure that you have already set up your own [configuration file](../external-data-instructions.md#configuration-files) and have [created and named a profile to use](../external-data-instructions.md#setting-up-a-profile-in-the-configuration-file).
 
 You can test your configuration setup by performing a test run with the example data that we have provided.
 
-We recommend using the example 10X dataset from a [human glioblastoma donor that was processed using the 10X Genomics' Next GEM Single Cell 3' Reagent Kits v3.1](https://www.10xgenomics.com/resources/datasets/2-k-sorted-cells-from-human-glioblastoma-multiforme-3-v-3-1-3-1-standard-6-0-0)(note: you may be prompted to provide an email and register upon navigating to the 10X downloads site). 
+We recommend using the example 10X dataset from a [human glioblastoma donor that was processed using the 10X Genomics' Next GEM Single Cell 3' Reagent Kits v3.1](https://www.10xgenomics.com/resources/datasets/2-k-sorted-cells-from-human-glioblastoma-multiforme-3-v-3-1-3-1-standard-6-0-0)(note: you may be prompted to provide an email and register upon navigating to the 10X downloads site).
 The fastq files for this example data can be downloaded from the following link (**note:** These files will take approximately 10 GB of disk space upon download and expanding the tar file): [Brain_Tumor_3p_fastqs.tar](https://cf.10xgenomics.com/samples/cell-exp/6.0.0/Brain_Tumor_3p/Brain_Tumor_3p_fastqs.tar).
 
 
-Following download and unzipping of the fastq files, you will need to create a tab-separated values metadata file that looks like the following: 
+Following download and unzipping of the fastq files, you will need to create a tab-separated values metadata file that looks like the following:
 
-| scpca_run_id | scpca_library_id | scpca_sample_id | scpca_project_id | technology | seq_unit | files_directory | 
-| ------------ | ---------------- | --------------- | ---------------- | ---------- | -------- | --------------- | 
-| run01 | library01 | sample01 | project01 | 10Xv3.1 | cell | /path/to/example_fastq_files | 
+| scpca_run_id | scpca_library_id | scpca_sample_id | scpca_project_id | technology | seq_unit | sample_reference | files_directory |
+| ------------ | ---------------- | --------------- | ---------------- | ---------- | -------- | ---------------- | --------------- |
+| run01 | library01 | sample01 | project01 | 10Xv3.1 | cell | Homo_sapiens.GRCh38.104 | /path/to/example_fastq_files |
 
 Be sure to enter the **full** path to the directory containing the fastq files in the `files_directory` column.
 
-The following command can then be used to test your configuration setup with the example data: 
+The following command can then be used to test your configuration setup with the example data:
 
 ```
 nextflow run AlexsLemonade/scpca-nf \
@@ -33,11 +33,11 @@ nextflow run AlexsLemonade/scpca-nf \
   --run_metafile <path to metadata file>
 ```
 
-Where `<path to config file>` is the **relative** path to the configuration file that you have setup after following the instructions on [creating a configuration file](../external-data-instructions.md#configuration-files), `<name of profile>` is the name of the profile that you chose when creating a profile, and `<path to metadata file>` is the **full** path to the metadata TSV you created. 
-For the [example configuration file that we provided](./user_template.config), we used the profile name `cluster` and would indicate that we would like to use that profile at the command line with `-profile cluster`. 
-For more detailed information on setting up the metadata file for your own data, see instructions on [preparing the metadata file](../external-data-instructions.md#prepare-the-metadata-file). 
+Where `<path to config file>` is the **relative** path to the configuration file that you have setup after following the instructions on [creating a configuration file](../external-data-instructions.md#configuration-files), `<name of profile>` is the name of the profile that you chose when creating a profile, and `<path to metadata file>` is the **full** path to the metadata TSV you created.
+For the [example configuration file that we provided](./user_template.config), we used the profile name `cluster` and would indicate that we would like to use that profile at the command line with `-profile cluster`.
+For more detailed information on setting up the metadata file for your own data, see instructions on [preparing the metadata file](../external-data-instructions.md#prepare-the-metadata-file).
 
-## Example output 
+## Example output
 
-You can download an example of the expected output files here: [`scpca_out.zip`](https://s3.amazonaws.com/scpca-references/example-data/scpca_out.zip). 
-For more information on the file structure and what to expect see the description of the [output files](../external-data-instructions.md#output-files). 
+You can download an example of the expected output files here: [`scpca_out.zip`](https://s3.amazonaws.com/scpca-references/example-data/scpca_out.zip).
+For more information on the file structure and what to expect see the description of the [output files](../external-data-instructions.md#output-files).

--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -2,6 +2,7 @@ scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_un
 run01	library01	sample01	project01	10Xv3.1	cell	Homo_sapiens.GRCh38.104	example_fastqs/run01
 run02	library01	sample01	project01	CITEseq_10Xv3	cell	Homo_sapiens.GRCh38.104	example_fastqs/run02	example_barcode_files/cite_barcodes.tsv	2[1-15]
 run03	library02	sample02	project01	visium	spot	Homo_sapiens.GRCh38.104	example_fastqs/run03			A1	VXXXX-XXX
-run04	library03	sample03;sample04	project01	10Xv3.1	cell	Mus_musculus.GRCm39.109	example_fastqs/run04
-run05	library03	sample03;sample04	project01	cellhash	cell	Mus_musculus.GRCm39.109	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]
-run06	library04	sample05	project01	paired_end	bulk	Mus_musculus.GRCm39.109	example_fastqs/run06
+run04	library03	sample03;sample04	project01	10Xv3.1	cell	Mus_musculus.GRCm39.104	example_fastqs/run04
+run05	library03	sample03;sample04	project01	cellhash	cell	Mus_musculus.GRCm39.104	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]
+run06	library04	sample05	project01	paired_end	bulk	Mus_musculus.GRCm39.104	example_fastqs/run06
+

--- a/examples/example_metadata.tsv
+++ b/examples/example_metadata.tsv
@@ -1,7 +1,7 @@
-scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_unit	files_directory	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number
-run01	library01	sample01	project01	10Xv3.1	cell	example_fastqs/run01				
-run02	library01	sample01	project01	CITEseq_10Xv3	cell	example_fastqs/run02	example_barcode_files/cite_barcodes.tsv	2[1-15]		
-run03	library02	sample02	project01	visium	spot	example_fastqs/run03			A1	VXXXX-XXX
-run04	library03	sample03;sample04	project01	10Xv3.1	cell	example_fastqs/run04				
-run05	library03	sample03;sample04	project01	cellhash	cell	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]		
-run06	library04	sample05	project01	paired_end	bulk	example_fastqs/run06				
+scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	seq_unit	sample_reference	files_directory	feature_barcode_file	feature_barcode_geom	slide_section	slide_serial_number
+run01	library01	sample01	project01	10Xv3.1	cell	Homo_sapiens.GRCh38.104	example_fastqs/run01
+run02	library01	sample01	project01	CITEseq_10Xv3	cell	Homo_sapiens.GRCh38.104	example_fastqs/run02	example_barcode_files/cite_barcodes.tsv	2[1-15]
+run03	library02	sample02	project01	visium	spot	Homo_sapiens.GRCh38.104	example_fastqs/run03			A1	VXXXX-XXX
+run04	library03	sample03;sample04	project01	10Xv3.1	cell	Mus_musculus.GRCm39.109	example_fastqs/run04
+run05	library03	sample03;sample04	project01	cellhash	cell	Mus_musculus.GRCm39.109	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]
+run06	library04	sample05	project01	paired_end	bulk	Mus_musculus.GRCm39.109	example_fastqs/run06

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -120,6 +120,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_project_id` | A unique ID for each group of related samples. All results for samples with the same project ID will be returned in the same folder labeled with the project ID. |
 | `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For cellhash libraries use either `cellhash_10Xv2`, `cellhash_10Xv3`, or `cellhash_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use `visium`      |
 | `seq_unit`        | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`)|
+| `sample_reference`| The name of the reference to use for mapping, available references include: `Homo_sapiens.GRCh38.104` and `Mus_musculus.GRCm39.109` |
 | `files_directory` | path/uri to directory containing fastq files (unique per run) |
 
 The following columns may be necessary for running other data modalities (CITE-seq, spatial trancriptomics) or are optional and can be included in the metadata file if desired:
@@ -228,7 +229,7 @@ chmod +x get_refs.py
 
 
 Once you have downloaded the script and made it executable with the `chmod` command, running the script will download the files required for mapping gene expression data sets to the subdirectory `scpca-references` at your current location.
-The script will also create a parameter file named `localref_params.yaml` that defines the `ref_rootdir` and `assembly` Nextflow parameter variables required to use these local data files.
+The script will also create a parameter file named `localref_params.yaml` that defines the `ref_rootdir` Nextflow parameter required to use these local data files.
 To run with these settings
 
 ```sh

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -120,7 +120,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_project_id` | A unique ID for each group of related samples. All results for samples with the same project ID will be returned in the same folder labeled with the project ID. |
 | `technology`      | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, or `10Xv31`. <br> For CITE-seq libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For cellhash libraries use either `cellhash_10Xv2`, `cellhash_10Xv3`, or `cellhash_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use `visium`      |
 | `seq_unit`        | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`)|
-| `sample_reference`| The name of the reference to use for mapping, available references include: `Homo_sapiens.GRCh38.104` and `Mus_musculus.GRCm39.109` |
+| `sample_reference`| The name of the reference to use for mapping, available references include: `Homo_sapiens.GRCh38.104` and `Mus_musculus.GRCm39.104` |
 | `files_directory` | path/uri to directory containing fastq files (unique per run) |
 
 The following columns may be necessary for running other data modalities (CITE-seq, spatial trancriptomics) or are optional and can be included in the metadata file if desired:

--- a/get_refs.py
+++ b/get_refs.py
@@ -77,8 +77,7 @@ for line in ref_file:
 root_re = re.compile(r'\$\{?(params.)?ref_rootdir\}?$')
 refdir_re = re.compile(r'\$\{?(params.)?ref_dir\}?$')
 
-# get assembly and root location
-assembly = refs.get("assembly", "NA")
+# get root location
 # split out protocol from the root URI
 root_parts = refs.get("ref_rootdir").split('://', maxsplit = 1)
 if root_parts[0] == 's3':
@@ -243,7 +242,6 @@ if args.paramfile:
         shutil.move(pfile, str(pfile) + ".bak")
     # create parameter dictionary
     nf_params = {
-        'assembly': assembly,
         'ref_rootdir': os.path.abspath(args.refdir)
     }
     with open(pfile, 'w') as f:


### PR DESCRIPTION
Closes #297 

Here I updated the external documentation to account for the new changes to the workflow that require specifying the reference/organism to use on a per sample level. 

- I added a note about the `sample_reference` in the preparation of the metadata section of the external docs. 
- I removed the extra reference params that we no longer use from the config file. 
- I updated the `get_refs.py` to only write out the `ref_rootdir` param to the config file that it creates and remove the `assembly`. 
- The example metadata now contains the `sample_reference` column in both the readme and the actual table. 

I believe that was everything that needed to be updated, but let me know if you think I missed something. This PR is also stacked on #289, as we will wait until everything is accounted for and good to go before merging all the changes together into the `development` branch.