### PR TITLE
Cut feature barcode file for salmon indexing

### DIFF
--- a/external-instructions.md
+++ b/external-instructions.md
@@ -63,7 +63,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ```
 
 Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
-This command will pull the `scpca-nf` workflow directly from Github, using the `v0.4.1` version, and run it based on the settings in the configuration file that you have defined.
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.4.2` version, and run it based on the settings in the configuration file that you have defined.
 
 **Note:** `scpca-nf` is under active development.
 Using the above command will run the workflow from the `main` branch of the workflow repository.
@@ -74,7 +74,7 @@ Released versions can be found on the [`scpca-nf` repo releases page](https://gi
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.4.1 \
+  -r v0.4.2 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -265,7 +265,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.4.1`, then you will want to set `-r v0.4.1` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.4.2`, then you will want to set `-r v0.4.2` for `get_refs.py` as well to be sure you have the correct containers.
 Be default,  `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -21,7 +21,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.4.1 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.4.2 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -9,6 +9,9 @@ process index_feature{
     tuple val(id), path("feature_index")
   script:
     """
+    # ensure salmon only gets the first 2 columns here
+    cut -f 1,2 ${feature_file} > feature_barcodes.txt
+
     salmon index \
       -t ${feature_file} \
       -i feature_index \

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -13,7 +13,7 @@ process index_feature{
     cut -f 1,2 ${feature_file} > feature_barcodes.txt
 
     salmon index \
-      -t ${feature_file} \
+      -t feature_barcodes.txt \
       -i feature_index \
       --features \
       -k 7

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.4.1'
+  version = 'v0.4.2'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
From this comment: https://github.com/AlexsLemonade/ScPCA-admin/issues/527#issuecomment-1534971056

> Since the changes in https://github.com/AlexsLemonade/scpca-nf/pull/305 are quite minimal and non-breaking, we should be able to create a PR that applies just those changes to `main` (along with version string updates) and create new point release. 

This PR makes the associated `cut` change to the feature barcode file on its way into `salmon index`, and bumps the minor release up accordingly. I think I got all the spots for the version string, but please let me know if I missed one! 