### PR TITLE
Change mouse index to use ensembl 104

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -17,8 +17,8 @@ process generate_reference{
     tuple path(splici_fasta), path(spliced_cdna_fasta), emit: fasta_files
     tuple path("annotation/*.gtf.gz"), path("annotation/*.tsv"), path("annotation/*.txt"),  emit: annotations
   script:
-    splici_fasta = "fasta/" + file("${meta.splici_fasta}").name
-    spliced_cdna_fasta =  "fasta/" + file("${meta.splici_cdna_fasta}").name
+    splici_fasta = "fasta/" + file("${meta.splici_index}").name + ".fa.gz"
+    spliced_cdna_fasta =  "fasta/" + file("${meta.salmon_bulk_index}").name + ".fa.gz"
     """
     make_reference_fasta.R \
       --gtf ${gtf} \
@@ -34,7 +34,7 @@ process generate_reference{
 
 process salmon_index{
   container params.SALMON_CONTAINER
-  publishDir "${params.ref_rootdir}/${file(meta.splici_index).parent}", mode: 'copy'
+  publishDir "${params.ref_rootdir}/${meta.ref_dir}/salmon_index", mode: 'copy'
   label 'cpus_8'
   label 'mem_16'
   input:
@@ -69,7 +69,7 @@ process salmon_index{
 
 process cellranger_index{
   container params.CELLRANGER_CONTAINER
-  publishDir "${params.ref_rootdir}/${file(meta.cellranger_index).parent}", mode: 'copy'
+  publishDir "${params.ref_rootdir}/${meta.ref_dir}/cellranger_index", mode: 'copy'
   label 'cpus_12'
   label 'mem_24'
   input:
@@ -92,7 +92,7 @@ process cellranger_index{
 
 process star_index{
   container params.STAR_CONTAINER
-  publishDir "${params.ref_rootdir}/${file(meta.star_index).parent}", mode: 'copy'
+  publishDir "${params.ref_rootdir}/${meta.ref_dir}/star_index", mode: 'copy'
   label 'cpus_12'
   memory '64.GB'
   input:
@@ -146,10 +146,10 @@ workflow {
   // create index using reference fastas
   salmon_index(generate_reference.out.fasta_files, ref_ch)
   // create cellranger index
-  cellranger_index(ref_ch)
+  //cellranger_index(ref_ch)
   // create star index
-  star_index(ref_ch)
+  //star_index(ref_ch)
 
   // build celltype references
-  build_celltype_ref()
+  //build_celltype_ref()
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -146,10 +146,10 @@ workflow {
   // create index using reference fastas
   salmon_index(generate_reference.out.fasta_files, ref_ch)
   // create cellranger index
-  //cellranger_index(ref_ch)
+  cellranger_index(ref_ch)
   // create star index
-  //star_index(ref_ch)
+  star_index(ref_ch)
 
   // build celltype references
-  //build_celltype_ref()
+  build_celltype_ref()
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -13,7 +13,7 @@ process generate_reference{
   input:
     tuple val(ref_name), val(meta), path(fasta), path(gtf)
   output:
-    tuple val(ref_name), val(meta), path(fasta), path(gtf), emit: ref_info
+    tuple val(ref_name), val(meta), emit: ref_info
     tuple path(splici_fasta), path(spliced_cdna_fasta), emit: fasta_files
     tuple path("annotation/*.gtf.gz"), path("annotation/*.tsv"), path("annotation/*.txt"),  emit: annotations
   script:

--- a/references/ref-metadata.tsv
+++ b/references/ref-metadata.tsv
@@ -1,3 +1,3 @@
 organism	assembly	version
 Homo_sapiens	GRCh38	104
-Mus_musculus	GRCm39	109
+Mus_musculus	GRCm39	104

--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -12,17 +12,17 @@
     "cellranger_index": "homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full",
     "star_index": "homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx"
   },
-  "Mus_musculus.GRCm39.109": {
-    "ref_dir": "mus_musculus/ensembl-109",
-    "ref_fasta": "mus_musculus/ensembl-109/fasta/Mus_musculus.GRCm39.dna.primary_assembly.fa.gz",
-    "ref_fasta_index": "mus_musculus/ensembl-109/fasta/Mus_musculus.GRCm39.dna.primary_assembly.fa.fai",
-    "ref_gtf": "mus_musculus/ensembl-109/annotation/Mus_musculus.GRCm39.109.gtf.gz",
-    "mito_file": "mus_musculus/ensembl-109/annotation/Mus_musculus.GRCm39.109.mitogenes.txt",
-    "t2g_3col_path": "mus_musculus/ensembl-109/annotation/Mus_musculus.GRCm39.109.spliced_intron.tx2gene_3col.tsv",
-    "t2g_bulk_path": "mus_musculus/ensembl-109/annotation/Mus_musculus.GRCm39.109.spliced_cdna.tx2gene.tsv",
-    "splici_index": "mus_musculus/ensembl-109/salmon_index/Mus_musculus.GRCm39.109.spliced_intron.txome",
-    "salmon_bulk_index": "mus_musculus/ensembl-109/salmon_index/Mus_musculus.GRCm39.109.spliced_cdna.txome",
-    "cellranger_index": "mus_musculus/ensembl-109/cellranger_index/Mus_musculus.GRCm39.109_cellranger_full",
-    "star_index": "mus_musculus/ensembl-109/star_index/Mus_musculus.GRCm39.109.star_idx"
+  "Mus_musculus.GRCm39.104": {
+    "ref_dir": "mus_musculus/ensembl-104",
+    "ref_fasta": "mus_musculus/ensembl-104/fasta/Mus_musculus.GRCm39.dna.primary_assembly.fa.gz",
+    "ref_fasta_index": "mus_musculus/ensembl-104/fasta/Mus_musculus.GRCm39.dna.primary_assembly.fa.fai",
+    "ref_gtf": "mus_musculus/ensembl-104/annotation/Mus_musculus.GRCm39.104.gtf.gz",
+    "mito_file": "mus_musculus/ensembl-104/annotation/Mus_musculus.GRCm39.104.mitogenes.txt",
+    "t2g_3col_path": "mus_musculus/ensembl-104/annotation/Mus_musculus.GRCm39.104.spliced_intron.tx2gene_3col.tsv",
+    "t2g_bulk_path": "mus_musculus/ensembl-104/annotation/Mus_musculus.GRCm39.104.spliced_cdna.tx2gene.tsv",
+    "splici_index": "mus_musculus/ensembl-104/salmon_index/Mus_musculus.GRCm39.104.spliced_intron.txome",
+    "salmon_bulk_index": "mus_musculus/ensembl-104/salmon_index/Mus_musculus.GRCm39.104.spliced_cdna.txome",
+    "cellranger_index": "mus_musculus/ensembl-104/cellranger_index/Mus_musculus.GRCm39.104_cellranger_full",
+    "star_index": "mus_musculus/ensembl-104/star_index/Mus_musculus.GRCm39.104.star_idx"
   }
 }


### PR DESCRIPTION
Closes #308 

Here I updated the reference that we use for mouse to use Ensembl 104 instead of 109. I changed the `version` in the tsv file and then re-ran the script to generate the `json` file. 

The final step was actually generating the index using `build-index.nf`. I did run into a few small issues that I had to fix along the way. The first was that the `generate_fasta` process was expecting the `fasta` outputs that were named with the index name and then appended with `.fa.gz` so I added that in. The second was that we were previously using `file("${meta.splici_index}").parent` to specify the publish directory, however whenever we used that it was grabbing the full path from my local directory and outputting the files in the S3 bucket with that organization rather than the correct parent directory from the json file. So I changed it to use the `meta.ref_dir/salmon_index` or the associated index folder name. If reviewers have other ideas I'm definitely open to them. 

I also had to remove outputting the `ref_fasta` and `ref_gtf` from the `generate_reference` process because otherwise it outputs those files to the main `ref_dir` which we don't need them to do. We also don't pass that output to anything else. 

Also, @jashapiro, I did look at the files in the bucket when I tested running this morning to see if they were set to public after being created, and they unfortunately were not. So the updated settings did not seem to work. They do make new folders within the existing subfolders so probably that's why.