### PR TITLE
Remove cell typing from main workflow

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -136,7 +136,4 @@ workflow {
   cellranger_index(params.ref_fasta, params.ref_gtf, params.assembly)
   // create star index
   index_star(params.ref_fasta, params.ref_gtf, params.assembly)
-
-  // build celltype references
-  build_celltype_ref()
 }

--- a/main.nf
+++ b/main.nf
@@ -50,11 +50,6 @@ if (!file(params.run_metafile).exists()) {
   param_error = true
 }
 
-if (!file(params.project_celltype_metafile).exists()) {
-  log.error("The 'project_celltype_metafile' file '${params.project_celltype_metafile}' can not be found.")
-  param_error = true
-}
-
 resolution_strategies = ['cr-like', 'full', 'cr-like-em', 'parsimony', 'trivial']
 if (!resolution_strategies.contains(params.af_resolution)) {
   log.error("'af_resolution' must be one of the following: ${resolution_strategies}")
@@ -193,16 +188,6 @@ workflow {
   // Make channel for all library sce files & run QC report
   all_sce_ch = sce_ch.single.mix(genetic_demux_sce.out)
   post_process_sce(all_sce_ch)
-
-  // annotate cell types
-  // create a channel with just meta and processed rds file to use as input to cell type annotation
-  celltype_ch = post_process_sce.out
-    .map{[
-      it[0], // meta
-      it[3] // processed rds
-    ]}
-
-  annotate_celltypes(celltype_ch)
 
   // generate QC reports
   sce_qc_report(post_process_sce.out, report_template_tuple)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -29,7 +29,7 @@ process alevin_feature{
   label 'cpus_8'
   label 'mem_8'
   tag "${meta.run_id}-features"
-  publishDir "${params.checkpoints_dir}/rad/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
+  publishDir "${meta.feature_rad_publish_dir}", mode: 'copy'
   input:
     tuple val(meta),
           path(read1), path(read2),
@@ -75,13 +75,9 @@ process fry_quant_feature{
   tag "${meta.run_id}-features"
   publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
   input:
-    tuple val(meta),
-          path(run_dir)
-    path barcode_file
+    tuple val(meta), path(run_dir), path(barcode_file)
   output:
-    tuple val(meta),
-          path(run_dir)
-
+    tuple val(meta), path(run_dir)
   script:
     // get meta to write as file
     meta_json = Utils.makeJson(meta)
@@ -124,24 +120,46 @@ workflow map_quant_feature{
       .unique()
     index_feature(feature_barcodes_ch)
 
-    // create tuple of [metadata, [Read1 files], [Read2 files]]
-    // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
-    feature_reads_ch = feature_channel
+    // add the publish directories to the channel and branch based on existing rad files
+    feature_ch = feature_channel
+      .map{it.feature_rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
+           it.feature_rad_dir = "${it.feature_rad_publish_dir}/${it.run_id}-features";
+           it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
+           it}
+      .branch{
+          has_rad: !params.repeat_mapping && file(it.feature_rad_dir).exists()
+          make_rad: true
+       }
+
+    // pull out files that need to be repeated
+    feature_reads_ch = feature_ch.make_rad
+      // create tuple of [metadata, [Read1 files], [Read2 files]]
+      // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
       .map{meta -> tuple(meta.feature_barcode_file,
                          meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
                          file("${meta.files_directory}/*_R2_*.fastq.gz")
                         )}
       .combine(index_feature.out, by: 0) // combine by the feature_barcode_file (reused indices, so combine is needed)
-      .map{ it.drop(1)} // remove the first element (feature_barcode_file)
+      .map{it.drop(1)} // remove the first element (feature_barcode_file)
 
-    cellbarcode_ch = feature_channel
-      .map{file("${params.barcode_dir}/${params.cell_barcodes[it.technology]}")}
+    // // if the rad directory has been created and repeat_mapping is set to false
+    // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
+    feature_rad_ch = feature_ch.has_rad
+      .map{meta -> tuple(Utils.readMeta(file("${meta.feature_rad_dir}/scpca-meta.json")),
+                         file(meta.feature_rad_dir)
+                         )}
 
     // run Alevin on feature reads
     alevin_feature(feature_reads_ch)
+
+    // combine output from running alevin step with channel containing libraries that skipped creating RAD file
+    all_feature_rad_ch = alevin_feature.out.mix(feature_rad_ch)
+      .map{it.toList() + [file(it[0].barcode_file)]}
+
+
     // quantify feature reads
-    fry_quant_feature(alevin_feature.out, cellbarcode_ch)
+    fry_quant_feature(all_feature_rad_ch)
 
   emit: fry_quant_feature.out
   // a tuple of metadata map and the alevin-fry output directory


### PR DESCRIPTION
Closes #313 

This just removes the call to build celltype refs and to add cell types within the main workflow. These can both still be run independently and we will add them back in after we are confident in adding annotations to the workflow.