### PR TITLE
Skip feature mapping

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -124,8 +124,7 @@ workflow map_quant_feature{
       .unique()
     index_feature(feature_barcodes_ch)
 
-    // create tuple of [metadata, [Read1 files], [Read2 files]]
-    // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
+    // add the publish directories to the channel and branch based on existing rad files
     feature_ch = feature_channel
       .map{it.feature_rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
            it.feature_rad_dir = "${it.feature_rad_publish_dir}/${it.run_id}-features";
@@ -137,6 +136,8 @@ workflow map_quant_feature{
 
     // pull out files that need to be repeated
     feature_reads_ch = feature_ch.make_rad
+      // create tuple of [metadata, [Read1 files], [Read2 files]]
+      // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
       .map{meta -> tuple(meta.feature_barcode_file,
                          meta,
                          file("${meta.files_directory}/*_R1_*.fastq.gz"),
@@ -145,6 +146,8 @@ workflow map_quant_feature{
       .combine(index_feature.out, by: 0) // combine by the feature_barcode_file (reused indices, so combine is needed)
       .map{it.drop(1)} // remove the first element (feature_barcode_file)
 
+    // // if the rad directory has been created and repeat_mapping is set to false
+    // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
     feature_rad_ch = feature_ch.has_rad
       .map{meta -> tuple(Utils.readMeta(file("${meta.feature_rad_dir}/scpca-meta.json")),
                          file(meta.feature_rad_dir)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -75,13 +75,9 @@ process fry_quant_feature{
   tag "${meta.run_id}-features"
   publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
   input:
-    tuple val(meta),
-          path(run_dir)
-    path barcode_file
+    tuple val(meta), path(run_dir), path(barcode_file)
   output:
-    tuple val(meta),
-          path(run_dir)
-
+    tuple val(meta), path(run_dir)
   script:
     // get meta to write as file
     meta_json = Utils.makeJson(meta)
@@ -159,7 +155,7 @@ workflow map_quant_feature{
 
     // combine output from running alevin step with channel containing libraries that skipped creating RAD file
     all_feature_rad_ch = alevin_feature.out.mix(feature_rad_ch)
-      .map{it.toList() + it[0].barcode_file}
+      .map{it.toList() + [file(it[0].barcode_file)]}
 
 
     // quantify feature reads


### PR DESCRIPTION
Closes #315 

Here I updated the `af-feature` module to publish the rad directories for feature libraries. I also added the ability to skip mapping for feature libraries similar to how we do it for other mapping steps. I did test this with both skipping mapping and running mapping and it worked as expected. 

Also noting that this is stacked on #316 because of [github actions not working right now](https://www.githubstatus.com/).