### PR TITLE
Use reference json file for downloading references

### DIFF
--- a/get_refs.py
+++ b/get_refs.py
@@ -212,7 +212,7 @@ ref_paths += [barcode_dir / f for f in barcode_files]
 
 ## download all the files and put them in the correct locations ##
 print("Downloading reference files... (This might take a while)")
-for path in ref_paths[2:3]:
+for path in ref_paths:
     outfile = args.refdir / path
     if outfile.exists() and not args.overwrite_refs:
         continue


### PR DESCRIPTION
Closes #309 

Here I updated the `get_refs.py` script to explicitly grab the file paths for references from `scpca_refs.json` rather than using the config file for references. I still had to keep quite a lot of it the same, because we still need to get the root directory from the config file and the barcode directory, but other than that all the other file paths are coming from the json file. 

I pretty much just put the building of the list of reference paths into one chunk where I extracted all the file paths from the json file for the references we specifically want. I also added in the individual salmon files and then cellranger and star index files if those flags are used. I'm sure there is a more efficient way to do this. 

Also right now for testing I'm using the file that's available on the branch in #289, but we will want to change that to use a tagged release. I believe this should be the last update related to multiple organisms, so once this is approved I'll merge this and #289 in. 