### PR TITLE
Normalize ADT counts

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -134,8 +134,15 @@ for (alt in alt_names) {
 }
 
 
-# calculate filtering QC from ADTs, if present
+# calculate filtering QC and scaling factors for later
+# normalization from ADTs, if present
 if (!is.null(ambient_profile)) {
+  
+  # Calculate median size factors from the ambient profile
+  altExp(filtered_sce, adt_exp) <- scuttle::computeMedianFactors(
+    altExp(filtered_sce, adt_exp),
+    reference = ambient_profile
+  )
   
   # Create data frame of ADTs and their target types
   # If `target_type` column is not present, assume all ADTs are targets

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -135,8 +135,7 @@ for (alt in alt_names) {
 }
 
 
-# calculate filtering QC and scaling factors for later
-# normalization from ADTs, if present
+# calculate filtering QC from ADTs, if present
 if (!is.null(ambient_profile)) {
 
   # Create data frame of ADTs and their target types

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -155,11 +155,15 @@ processed_sce <- scuttle::logNormCounts(processed_sce)
 
 # Try to normalize ADT counts, if present
 if (alt_exp %in% altExpNames(processed_sce)) {
-
-  # Calculate median size factors from the ambient profile
-  altExp(filtered_sce, adt_exp) <- scuttle::computeMedianFactors(
-    altExp(filtered_sce, adt_exp),
-    reference = metadata(altExp(filtered_sce, adt_exp))$ambient_profile
+  if( !is.na(metadata(altExp(filtered_sce, adt_exp))$ambient_profile)){
+    # Calculate median size factors from the ambient profile
+    altExp(filtered_sce, adt_exp) <- scuttle::computeMedianFactors(
+      altExp(filtered_sce, adt_exp),
+      reference = metadata(altExp(filtered_sce, adt_exp))$ambient_profile
+  } else {
+    # if ambient profile is not present, set sizeFactor to 0 for later warning.
+    altExp(processed_sce, alt_exp)$sizeFactor <- 0
+  }
   )
 
   # Only perform normalization if size factors are all positive

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -160,11 +160,11 @@ if (alt_exp %in% altExpNames(processed_sce)) {
     altExp(filtered_sce, adt_exp) <- scuttle::computeMedianFactors(
       altExp(filtered_sce, adt_exp),
       reference = metadata(altExp(filtered_sce, adt_exp))$ambient_profile
+    )
   } else {
     # if ambient profile is not present, set sizeFactor to 0 for later warning.
     altExp(processed_sce, alt_exp)$sizeFactor <- 0
   }
-  )
 
   # Only perform normalization if size factors are all positive
   if ( any( altExp(processed_sce, alt_exp)$sizeFactor <= 0 ) ) {

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -155,7 +155,7 @@ processed_sce <- scuttle::logNormCounts(processed_sce)
 
 # Try to normalize ADT counts, if present
 if (alt_exp %in% altExpNames(processed_sce)) {
-  # need `all()` since present this is an array
+  # need `all()` since,if present, this is an array
   if( !all(is.null(metadata(altExp(processed_sce, alt_exp))$ambient_profile))){
     # Calculate median size factors from the ambient profile
     altExp(processed_sce, alt_exp) <- scuttle::computeMedianFactors(

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -95,14 +95,12 @@ if(all(is.na(sce$miQC_pass))){
 # setup associated metadata string
 alt_exp <- opt$adt_name
 if (!(alt_exp %in% altExpNames(sce))) {
-  adt_discard_rows <- c()
   adt_filter_string <- ""
 } else {
   adt_discard_rows <- which(altExp(sce, alt_exp)$discard)
   sce$scpca_filter[adt_discard_rows] <- "Remove"
   adt_filter_string <- ";cleanTagCounts"
 }
-
 metadata(sce)$scpca_filter_method <- paste0(metadata(sce)$scpca_filter_method,
                                             adt_filter_string)
 

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -155,11 +155,12 @@ processed_sce <- scuttle::logNormCounts(processed_sce)
 
 # Try to normalize ADT counts, if present
 if (alt_exp %in% altExpNames(processed_sce)) {
-  if( !is.na(metadata(altExp(filtered_sce, adt_exp))$ambient_profile)){
+  # need `all()` since present this is an array
+  if( !all(is.null(metadata(altExp(processed_sce, alt_exp))$ambient_profile))){
     # Calculate median size factors from the ambient profile
-    altExp(filtered_sce, adt_exp) <- scuttle::computeMedianFactors(
-      altExp(filtered_sce, adt_exp),
-      reference = metadata(altExp(filtered_sce, adt_exp))$ambient_profile
+    altExp(processed_sce, alt_exp) <- scuttle::computeMedianFactors(
+      altExp(processed_sce, alt_exp),
+      reference = metadata(altExp(processed_sce, alt_exp))$ambient_profile
     )
   } else {
     # if ambient profile is not present, set sizeFactor to 0 for later warning.

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -157,13 +157,13 @@ if (is.null(qclust)) {
 }
 
 # Normalize and log transform RNA counts
-processed_sce <- scater::logNormCounts(processed_sce)
+processed_sce <- scuttle::logNormCounts(processed_sce)
 
 # Try to normalize ADT counts, if present
 if (alt_exp %in% altExpNames(processed_sce)) {
 
   # Only perform normalization if size factors are all > 0
-  if ( any( altExp(processed_sce, alt_exp)$sizeFactor == 0 ) ) {
+  if ( any( altExp(processed_sce, alt_exp)$sizeFactor <= 0 ) ) {
     warn("Failed to normalize ADT counts.")
   } else {
     # Apply normalization


### PR DESCRIPTION
Closes #294 

This PR adds ADT normalization, which only affects 2 R scripts:

- `filter_sce_rds.R` will now calculate size factors on the filtered SCE object. Size factors must be >0, but we don't really want to check that until we know which cells will make it into the _processed_ SCE object. So, in this script, we just store the size factors for later
- `post_process_sce.R` actually performs the normalization using these size factors, and gives a _warning_ if normalization can't be performed (which occurs when a size factor == 0). By this point, the object has been "fully" filtered so by performing the check here we have the most chance of success!
  - Any feedback on the specific warning string? More details?  

This has been tested with one ADT + RNA library (first two runs) and one RNA-only library (last run) and it all runs through to the end.
```
nextflow run main.nf -profile ccdl,batch --run_ids SCPCR000364,SCPCR000365,SCPCR000001 -resume
```