### PR TITLE
Add CPU & memory checks and stubs

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,25 +1,25 @@
 // Resource maximum settings
 params.max_cpus = 24
-params.max_memory = 128.GB
+params.max_memory = 96.GB
 
 process{
-  memory = { check_memory(4.GB * task.attempt) }
+  memory = {check_memory(4.GB * task.attempt)}
 
   errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 2
   maxErrors = '-1'
 
   withLabel: mem_8 {
-    memory = { check_memory(8.GB * task.attempt) }
+    memory = {check_memory(8.GB * task.attempt)}
   }
   withLabel: mem_16 {
-    memory = { check_memory(16.GB * task.attempt) }
+    memory = {check_memory(16.GB * task.attempt)}
   }
   withLabel: mem_24 {
-    memory = { check_memory(24.GB * task.attempt) }
+    memory = {check_memory(24.GB * task.attempt)}
   }
   withLabel: mem_32 {
-    memory = { check_memory(32.GB * task.attempt) }
+    memory = {check_memory(32.GB * task.attempt)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,24 +1,50 @@
+// Resource maximum settings
+params.max_cpus = 24
+params.max_memory = 128.GB
+
 process{
-  memory = { 4.GB * task.attempt }
-  
+  memory = { check_memory(4.GB * task.attempt) }
+
   errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 2
   maxErrors = '-1'
 
   withLabel: mem_8 {
-    memory = { 8.GB * task.attempt }
+    memory = { check_memory(8.GB * task.attempt) }
   }
   withLabel: mem_16 {
-    memory = { 16.GB * task.attempt }
+    memory = { check_memory(16.GB * task.attempt) }
   }
   withLabel: mem_24 {
-    memory = { 24.GB * task.attempt }
+    memory = { check_memory(24.GB * task.attempt) }
   }
   withLabel: mem_32 {
-    memory = { 32.GB * task.attempt }
+    memory = { check_memory(32.GB * task.attempt) }
   }
-  withLabel: cpus_2  { cpus = 2 }
-  withLabel: cpus_4  { cpus = 4 }
-  withLabel: cpus_8  { cpus = 8 }
-  withLabel: cpus_12 { cpus = 12 }
+  withLabel: cpus_2  {
+    cpus = {check_cpus(2)}
+  }
+  withLabel: cpus_4  {
+    cpus = {check_cpus(4)}
+  }
+  withLabel: cpus_8  {
+    cpus = {check_cpus(8)}
+  }
+  withLabel: cpus_12 {
+    cpus = {check_cpus(12)}
+  }
+}
+
+
+// Resource check functions
+def check_memory(memory){
+  memory = memory as nextflow.util.MemoryUnit
+  max_memory = params.max_memory as nextflow.util.MemoryUnit
+  memory < max_memory ? memory : max_memory
+}
+
+def check_cpus(cpus){
+  cpus = cpus as int
+  max_cpus = params.max_cpus as int
+  cpus < max_cpus ? cpus : max_cpus
 }

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -1,10 +1,10 @@
 // path to reference files
-ref_json            = "${projectDir}/references/scpca-refs.json"
-ref_metadata        = "${projectDir}/references/ref-metadata.tsv"
-ref_rootdir      = 's3://scpca-references'
+ref_json     = "${projectDir}/references/scpca-refs.json"
+ref_metadata = "${projectDir}/references/ref-metadata.tsv"
+ref_rootdir  = 's3://scpca-references'
 
 // barcode files
-barcode_dir      = "${params.ref_rootdir}/barcodes/10X"
+barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
 
 // cell type references
 celltype_ref_dir = "${params.ref_rootdir}/celltype/references"

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -22,6 +22,19 @@ Note: Although the name of this parameter is `run_ids`, any ids found in
   Optionally, `run_ids` can be set at the command line with `--run_ids SCPCR000003`
 */
 
+/*
+Available computational resources
+---------------------------------
+Adjust the following parameters to match the resources available on your system or cluster.
+  While most parts of scpca-nf will run with fewer resources than the defaults listed below,
+  be aware that some processes (notably spatial transcriptomics and genetic demultiplexing) may
+  fail if insufficient resources are available.
+*/
+params.max_cpus = 16 // Maximum number of cpus to use for a single process
+params.max_memory = 32.GB // Maximum memory to use for a single process
+
+
+
 // Spaceranger container, only required if using spatial transcriptomics workflow
 params.SPACERANGER_CONTAINER = ''
 
@@ -53,9 +66,9 @@ profiles{
     singularity {
       enabled = true
       autoMounts = true
-      // If you pre-pull container images (i.e., if nodes do not have internet access) 
+      // If you pre-pull container images (i.e., if nodes do not have internet access)
       // then the nextflow singularity cache directory should be specified.
-      // This setting is optional otherwise, though you may get a warning if it is not set, 
+      // This setting is optional otherwise, though you may get a warning if it is not set,
       // and a default location will be used.
       // cacheDir = "$HOME/nextflow/singularity"
     }

--- a/examples/user_template.config
+++ b/examples/user_template.config
@@ -30,8 +30,8 @@ Adjust the following parameters to match the resources available on your system 
   be aware that some processes (notably spatial transcriptomics and genetic demultiplexing) may
   fail if insufficient resources are available.
 */
-params.max_cpus = 16 // Maximum number of cpus to use for a single process
-params.max_memory = 32.GB // Maximum memory to use for a single process
+params.max_cpus = 24 // Maximum number of cpu cores to use for a single process
+params.max_memory = 96.GB // Maximum memory to use for a single process
 
 
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -25,7 +25,8 @@
 
  ## Overview
 
-Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can ideally accommodate up to 24 GB of RAM and 12 CPUs.
+Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accommodate up to 24 GB of RAM and 12 CPU cores.
+Some datasets and processes (genetic demultiplexing and spatial transcriptomics) may require additional resources, and our default configuration allows up to 96 GB of RAM and 24 CPU cores.
 While the workflow does support scaling down requirements in lower-resource environments, we have not tested extensively in those conditions, and some components may fail.
 After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process.
 Here we provide an overview of the steps you will need to complete:
@@ -150,7 +151,7 @@ Note that *workflow* parameters such as `--run_metafile` and `--outdir` are deno
 
 There are also a number of optional parameters that can be set, either at the command line or in a configuration file, including:
 
-- `max_cpus`: the maximum number of CPUs to use for a single process (default: 24)
+- `max_cpus`: the maximum number of CPU cores to use for a single process (default: 24)
 - `max_memory`: the maximum amount of memory to use for a single process (default: `96.GB`)
 
 Other customizable parameters can be found in the `nextflow.config` file in the repository.

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -25,7 +25,8 @@
 
  ## Overview
 
-Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can accomodate up to 24 GB of RAM and 12 CPUs.
+Using `scpca-nf` to process your own single-cell and single-nuclei RNA-seq data requires access to a high performance computing (HPC) environment that can ideally accommodate up to 24 GB of RAM and 12 CPUs.
+While the workflow does support scaling down requirements in lower-resource environments, we have not tested extensively in those conditions, and some components may fail.
 After identifying the system that you will use to execute the nextflow workflow, you will need to follow the steps outlined in this document to complete the set up process.
 Here we provide an overview of the steps you will need to complete:
 
@@ -147,6 +148,14 @@ These parameters can be set at the command line using `--run_metafile <path to r
 
 Note that *workflow* parameters such as `--run_metafile` and `--outdir` are denoted at the command line with double hyphen prefix, while options that affect Nextflow itself have only a single hyphen.
 
+There are also a number of optional parameters that can be set, either at the command line or in a configuration file, including:
+
+- `max_cpus`: the maximum number of CPUs to use for a single process (default: 24)
+- `max_memory`: the maximum amount of memory to use for a single process (default: `96.GB`)
+
+Other customizable parameters can be found in the `nextflow.config` file in the repository.
+Note that all parameters can be overridden with a user config file or at the command line; `nextflow.config` itself should not need modification.
+
 ### Configuration files
 
 Workflow parameters can also be set in a [configuration file](https://www.nextflow.io/docs/latest/config.html#configuration-file) by setting the values `params.run_metafile` and `params.outdir` as follows.
@@ -157,7 +166,11 @@ We could first create a file `my_config.config` (or a filename of your choice) w
 // my_config.config
 params.run_metafile = '<path to run_metafile>'
 params.outdir = '<path to output>'
+params.max_cpus = 12
+params.max_memory = 24.GB
 ```
+
+The `max_cpus` and `max_memory` parameters should reflect the maximum number of CPUs and memory available for a single process in your environment.
 
 This file is then used with the `-config` (or `-c`) argument at the command line:
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -167,8 +167,8 @@ We could first create a file `my_config.config` (or a filename of your choice) w
 // my_config.config
 params.run_metafile = '<path to run_metafile>'
 params.outdir = '<path to output>'
-params.max_cpus = 12
-params.max_memory = 24.GB
+params.max_cpus = 24
+params.max_memory = 96.GB
 ```
 
 The `max_cpus` and `max_memory` parameters should reflect the maximum number of CPUs and memory available for a single process in your environment.

--- a/main.nf
+++ b/main.nf
@@ -78,6 +78,7 @@ workflow {
 
   unfiltered_runs_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
+    .filter{it.sample_reference in ref_paths}
     // convert row data to a metadata map, keeping columns we will need (& some renaming) and reference paths
     .map{sample_refs = ref_paths[it.sample_reference]
     [

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -20,6 +20,10 @@ process index_feature{
 
     awk '{print \$1"\\t"\$1;}' ${feature_file} > feature_index/t2g.tsv
     """
+  stub:
+    """
+    mkdir -p feature_index
+    """
 }
 
 // generates RAD file for alevin feature matrix using alevin
@@ -65,6 +69,14 @@ process alevin_feature{
 
     echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
+  stub:
+    run_dir = "${meta.run_id}-features"
+    meta_json = Utils.makeJson(meta)
+    """
+    mkdir -p ${run_dir}
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
+    """
+
 }
 
 // quantify features from rad input
@@ -103,6 +115,11 @@ process fry_quant_feature{
     # remove large files
     rm ${run_dir}/*.rad ${run_dir}/*.bin
 
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
+    """
+  stub:
+    meta_json = Utils.makeJson(meta)
+    """
     echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
 }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -40,6 +40,12 @@ process alevin_rad{
 
     echo '${meta_json}' > ${rad_dir}/scpca-meta.json
     """
+  stub:
+    meta_json = Utils.makeJson(meta)
+    """
+    mkdir -p ${rad_dir}
+    echo '${meta_json}' > ${rad_dir}/scpca-meta.json
+    """
 }
 
 // quantify rna from RAD input
@@ -81,6 +87,11 @@ process fry_quant_rna{
     # remove large files
     rm ${run_dir}/*.rad ${run_dir}/*.bin
 
+    echo '${meta_json}' > ${run_dir}/scpca-meta.json
+    """
+  stub:
+    meta_json = Utils.makeJson(meta)
+    """
     echo '${meta_json}' > ${run_dir}/scpca-meta.json
     """
 }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -41,6 +41,7 @@ process alevin_rad{
     echo '${meta_json}' > ${rad_dir}/scpca-meta.json
     """
   stub:
+    rad_dir = file(meta.rad_dir).name
     meta_json = Utils.makeJson(meta)
     """
     mkdir -p ${rad_dir}

--- a/modules/bulk-pileup.nf
+++ b/modules/bulk-pileup.nf
@@ -23,6 +23,11 @@ process mpileup{
     | bcftools reheader -s samples.txt \
     > ${mpileup_file}
     """
+  stub:
+    mpileup_file = "${meta.multiplex_library_id}.vcf.gz"
+    """
+    touch ${mpileup_file}
+    """
 }
 
 workflow pileup_multibulk{

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -155,9 +155,9 @@ workflow bulk_quant_rna {
                 it[0],
                 it[1]]} // salmon directories
           .groupTuple(by: 0)
-          .map{it[1][0], // meta; relevant data should all be the same by project, so take the first
-               it[2], // salmon directories
-               file(it[1][0].t2g_bulk_path)}
+          .map{[it[1][0], // meta; relevant data should all be the same by project, so take the first
+                it[2], // salmon directories
+                file(it[1][0].t2g_bulk_path)]}
 
         // create tsv file and combined metadata for each project containing all libraries
         merge_bulk_quants(grouped_salmon_ch, params.run_metafile)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -20,7 +20,12 @@ process fastp{
         --length_required 20 \
         --thread ${task.cpus}
         """
-
+    stub:
+        trimmed_reads = "${meta.library_id}_trimmed"
+        fastp_report = "${meta.library_id}_fastp.html"
+        """
+        mkdir -p ${trimmed_reads}
+        """
 }
 
 process salmon{
@@ -49,6 +54,13 @@ process salmon{
         --seqBias \
         --threads ${task.cpus}
 
+        echo '${meta_json}' > ${salmon_dir}/scpca-meta.json
+        """
+    stub:
+        salmon_dir = file(meta.salmon_results_dir).name
+        meta_json = Utils.makeJson(meta)
+        """
+        mkdir -p ${salmon_dir}
         echo '${meta_json}' > ${salmon_dir}/scpca-meta.json
         """
 
@@ -87,6 +99,14 @@ process merge_bulk_quants {
          --workflow_version "${workflow.revision}" \
          --workflow_commit "${workflow.commitId}"
         """
+    stub:
+        tximport_file = "${meta.project_id}_bulk_quant.tsv"
+        bulk_metadata_file = "${meta.project_id}_bulk_metadata.tsv"
+        """
+        touch ${tximport_file}
+        touch ${bulk_metadata_file}
+        """
+
 }
 
 workflow bulk_quant_rna {

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -22,6 +22,11 @@ process bulkmap_star{
 
     mv Aligned.sortedByCoord.out.bam ${output_bam}
     """
+  stub:
+    output_bam = "${meta.run_id}.sorted.bam"
+    """
+    touch ${output_bam}
+    """
 }
 
 workflow star_bulk{

--- a/modules/cellsnp.nf
+++ b/modules/cellsnp.nf
@@ -27,6 +27,16 @@ process cellsnp{
       --minCOUNT=20 \
       --gzip
     """
+  stub:
+    meta = meta_star
+    meta.sample_ids = meta_mpileup.sample_ids
+    meta.bulk_run_ids = meta_mpileup.bulk_run_ids
+    quant_dir = meta_star.seq_unit == "nucleus" ? "GeneFull" : "Gene"
+    barcodes = "${star_quant}/Solo.out/${quant_dir}/filtered/barcodes.tsv"
+    outdir = "${meta.run_id}-cellSNP"
+    """
+    mkdir -p ${outdir}
+    """
 }
 
 process vireo{
@@ -49,6 +59,13 @@ process vireo{
       --outDir ${outdir} \
       --nproc ${task.cpus}
 
+    echo '${meta_json}' > ${outdir}/scpca-meta.json
+    """
+  stub:
+    outdir = file(meta.vireo_dir).name
+    meta_json = Utils.makeJson(meta)
+    """
+    mkdir -p ${outdir}
     echo '${meta_json}' > ${outdir}/scpca-meta.json
     """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -33,4 +33,11 @@ process sce_qc_report{
           --workflow_version "${workflow_version}" \
           --workflow_commit "${workflow.commitId}"
         """
+    stub:
+        qc_report = "${meta.library_id}_qc.html"
+        metadata_json = "${meta.library_id}_metadata.json"
+        """
+        touch ${qc_report}
+        echo '{}' > ${metadata_json}
+        """
 }

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -10,4 +10,8 @@ process index_bam{
     """
     samtools index ${bamfile} ${bamfile_index}
     """
+  stub:
+    """
+    touch ${bamfile_index}
+    """
 }

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -11,6 +11,7 @@ process index_bam{
     samtools index ${bamfile} ${bamfile_index}
     """
   stub:
+    bamfile_index = "${bamfile}.bai"
     """
     touch ${bamfile_index}
     """

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -33,6 +33,13 @@ process spaceranger{
     # remove bam and bai files
     rm ${out_id}/outs/*.bam*
     """
+  stub:
+    out_id = file(meta.spaceranger_results_dir).name
+    meta_json = Utils.makeJson(meta)
+    """
+    mkdir -p ${out_id}/outs
+    echo '${meta_json}' > ${out_id}/scpca-meta.json
+    """
 }
 
 process spaceranger_publish{
@@ -72,6 +79,13 @@ process spaceranger_publish{
       --workflow_url "${workflow_url}" \
       --workflow_version "${workflow.revision}" \
       --workflow_commit "${workflow.commitId}"
+    """
+  stub:
+    spatial_publish_dir = "${meta.library_id}_spatial"
+    metadata_json = "${spatial_publish_dir}/${meta.library_id}_metadata.json"
+    """
+    mkdir -p ${spatial_publish_dir}
+    echo '{}' > ${metadata_json}
     """
 }
 

--- a/modules/starsolo.nf
+++ b/modules/starsolo.nf
@@ -20,7 +20,6 @@ process starsolo{
     features_flag = meta.seq_unit == "nucleus" ? "--soloFeatures Gene GeneFull" : "--soloFeatures Gene"
     output_dir = "${meta.run_id}_star"
     output_bam = "${meta.run_id}.sorted.bam"
-
     """
     mkdir -p ${output_dir}/Solo.out/Gene/raw
     STAR \
@@ -48,6 +47,7 @@ process starsolo{
     """
     mkdir -p ${output_dir}
     touch ${output_bam}
+    sleep 10
     """
 }
 

--- a/modules/starsolo.nf
+++ b/modules/starsolo.nf
@@ -42,6 +42,13 @@ process starsolo{
 
     mv ${output_dir}/Aligned.sortedByCoord.out.bam ${output_bam}
     """
+  stub:
+    output_dir = "${meta.run_id}_star"
+    output_bam = "${meta.run_id}.sorted.bam"
+    """
+    mkdir -p ${output_dir}
+    touch ${output_bam}
+    """
 }
 
 

--- a/modules/starsolo.nf
+++ b/modules/starsolo.nf
@@ -47,7 +47,7 @@ process starsolo{
     """
     mkdir -p ${output_dir}
     touch ${output_bam}
-    sleep 10
+    sleep 5
     """
 }
 


### PR DESCRIPTION
The goal of the PR is to enable local running of the workflow, including basic checks of workflow logic using stubs.

Closes #290 
Closes #151 (though docs are needed here)

To do this, I added `stub:` blocks to all current processes, with the exception of the cell type classification process, which is not currently in the main workflow.

Unfortunately, adding stubs is insufficient for allowing local running, as the memory and cpu requirements are still used for the stub. So to fix that, I added some very simple functions inspired by nf-core to modify our memory and cpu settings, checking new `params` for the max memory and cpu and returning the lesser of the two values. 

So to run locally, you can now do something like:

```
nextflow main.nf -profile ccdl -stub --max_cpus 2 --max_memory 2.GB
```

I put this parameter in the `process_base.config` file, as that is where they are used, but it might make sense to move it to the main `nextflow.config` file to make it easier to users to find and set for their own configuration. On the other hand, we encourage people to make their own `config` file, and any value they put there will override anyway, so it may be more a documentation question. Opinions welcome.

If this is working for others, I will update the docs to include these parameters (and that you can run with less RAM, though performance may be affected and no guarantees for something like Cell Ranger).

I expect to leave the `-stub` functionality undocumented, except perhaps in development instructions, as I don't think that is something we should expect end users to use.


One other thing I noticed while doing this (since I was hitting almost every process) was that we have some inconsistency in the number of spaces for indentation; I might want to fix that in this PR, but I didn't want too many modified lines for the review!


