### PR TITLE
Update external docs to explain `feature_barcode_file` third column

### DIFF
--- a/external-instructions.md
+++ b/external-instructions.md
@@ -127,7 +127,7 @@ The following columns may be necessary for running other data modalities (CITE-s
 
 | column_id       | contents                                                       |
 |-----------------|----------------------------------------------------------------|
-| `feature_barcode_file` | path/uri to file containing the feature barcode sequences (only required for CITE-seq and cellhash samples)  |
+| `feature_barcode_file` | path/uri to file containing the feature barcode sequences (only required for CITE-seq and cellhash samples); for CITE-seq samples, this file can optionally indicate whether antibodies are targets or controls.  |
 | `feature_barcode_geom` | A salmon `--read-geometry` layout string. <br> See https://github.com/COMBINE-lab/salmon/releases/tag/v1.4.0 for details (only required for CITE-seq and cellhash samples) |
 | `slide_section`   | The slide section for spatial transcriptomics samples (only required for spatial transcriptomics) |
 | `slide_serial_number`| The slide serial number for spatial transcriptomics samples (only required for spatial transcriptomics)   |
@@ -313,6 +313,18 @@ For example:
 TAG01	CATGTGAGCT
 TAG02	TGTGAGGGTG
 ```
+
+For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate whether the given antibody is a true target (`target`) or a control, either a spike-in positive control (`pos_control`) or negative control (`neg_control`).
+
+For example, the following shows that two antibodies are targets and one is a negative control:
+
+```
+TAG01	CATGTGAGCT	target
+TAG02	TGTGAGGGTG	neg_control
+TAG03	GTAGCTCCAA	target
+```
+
+If negative control antibodies are indicated, this information will be considered during post-processing filtering and normalization.
 
 
 ### Multiplexed (cellhash) libraries

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -342,8 +342,8 @@ TAG02	TGTGAGGGTG	neg_control
 TAG03	GTAGCTCCAA	target
 ```
 
-If this third column is not provided, all antibodies will be assumed to be targets.
-Similarly, if information in this column is _not_ one of the allowed values, a warning will be printed, and the given antibody/ies will be assumed to be target(s).
+If this third column is not provided, all antibodies will be treated as targets.
+Similarly, if information in this column is _not_ one of the allowed values, a warning will be printed, and the given antibody/ies will be treated as target(s).
 
 If there are negative control antibodies, these will be taken into account during post-processing filtering and normalization.
 Positive controls are currently unused, but if provided, this label will be included in final output files.

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -328,7 +328,7 @@ TAG01	CATGTGAGCT
 TAG02	TGTGAGGGTG
 ```
 
-For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate the purpose of each antibody, which can take one of the following three allowed values:
+For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate the purpose of each antibody, which can take one of the following three values:
 
 - `target`:  antibody is a true target
 - `neg_control`: a negative control antibody

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -328,7 +328,8 @@ TAG02	TGTGAGGGTG	neg_control
 TAG03	GTAGCTCCAA	target
 ```
 
-If negative control antibodies are indicated, this information will be considered during post-processing filtering and normalization.
+If there are negative control antibodies, these will be taken into account during post-processing filtering and normalization.
+Positive controls are currently unused, but this label will be included in final output files.
 
 
 ### Multiplexed (cellhash) libraries

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -314,9 +314,9 @@ TAG01	CATGTGAGCT
 TAG02	TGTGAGGGTG
 ```
 
-For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate the purpose of each antibody, which can take one of the following three values:
+For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate the purpose of each antibody, which can take one of the following three allowed values:
 
-- `target`:  antibody is a true target 
+- `target`:  antibody is a true target
 - `neg_control`: a negative control antibody
 - `pos_control`: a spike-in positive control
 
@@ -328,8 +328,11 @@ TAG02	TGTGAGGGTG	neg_control
 TAG03	GTAGCTCCAA	target
 ```
 
+If this third column is not provided, all antibodies will be assumed to be targets.
+Similarly, if information in this column is _not_ one of the allowed values, a warning will be printed, and the given antibody/ies will be assumed to be target(s).
+
 If there are negative control antibodies, these will be taken into account during post-processing filtering and normalization.
-Positive controls are currently unused, but this label will be included in final output files.
+Positive controls are currently unused, but if provided, this label will be included in final output files.
 
 
 ### Multiplexed (cellhash) libraries

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -314,7 +314,11 @@ TAG01	CATGTGAGCT
 TAG02	TGTGAGGGTG
 ```
 
-For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate whether the given antibody is a true target (`target`) or a control, either a spike-in positive control (`pos_control`) or negative control (`neg_control`).
+For CITE-seq data, you can optionally include a third column in the `feature_barcode_file` to indicate the purpose of each antibody, which can take one of the following three values:
+
+- `target`:  antibody is a true target 
+- `neg_control`: a negative control antibody
+- `pos_control`: a spike-in positive control
 
 For example, the following shows that two antibodies are targets and one is a negative control:
 


### PR DESCRIPTION
Closes #299 

This PR adds documentation to explain that a third column can optionally be included in the `feature_barcode_file` to specify the ADT "target type," as I've been calling it.

Questions for reviewers..
- Did I miss anywhere else in these docs that need to be updated?
- Is it clear enough that the potential values are `target`, `neg_control`, and `pos_control` or would you suggest rephrasing there?
- Should we also say something like "at this time, positive controls are not considered in the pipeline"?