### PR TITLE
Check ADT type values

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -152,9 +152,16 @@ if (!is.null(ambient_profile)) {
   }
   # Check for valid target types and warn if invalid found
   allowed_adt_values <- c("target", "neg_control", "pos_control")
-  if (!all(adt_barcode_df$target_type) %in% allowed_adt_values) {
-    warn("Warning: Invalid target type values provided in the ADT barcode file.
-         These ADTs will be assumed to be targets.")
+  if (!all(adt_barcode_df$target_type %in% allowed_adt_values)) {
+    warning(
+      glue::glue(
+        "Warning: Invalid target type values provided in the ADT barcode file. Allowed values are:
+        - target
+        - neg_control
+        - pos_control
+       Incorrectly specified ADTs will be assumed to be targets."
+      )
+    )
 
     # Set all invalid values to "target" default
     adt_barcode_df <- adt_barcode_df |>

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -151,8 +151,8 @@ if (!is.null(ambient_profile)) {
     adt_barcode_df$target_type <- "target"
   }
   # Check for valid target types and warn if invalid found
-  allowed_adt_values <- c("target", "neg_control", "pos_control")
-  if (!all(adt_barcode_df$target_type %in% allowed_adt_values)) {
+  expected_adt_values <- c("target", "neg_control", "pos_control")
+  if (!all(adt_barcode_df$target_type %in% expected_adt_values)) {
     warning(
       glue::glue(
         "Warning: Invalid ADT type values provided in the ADT barcode file. Expected values are:

--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -155,21 +155,13 @@ if (!is.null(ambient_profile)) {
   if (!all(adt_barcode_df$target_type %in% allowed_adt_values)) {
     warning(
       glue::glue(
-        "Warning: Invalid target type values provided in the ADT barcode file. Allowed values are:
+        "Warning: Invalid ADT type values provided in the ADT barcode file. Expected values are:
         - target
         - neg_control
         - pos_control
-       Incorrectly specified ADTs will be assumed to be targets."
+      Unknown ADT types will be treated as targets."
       )
     )
-
-    # Set all invalid values to "target" default
-    adt_barcode_df <- adt_barcode_df |>
-      dplyr::mutate(target_type == ifelse(
-        target_type %in% allowed_adt_values,
-        target_type,
-        "target"
-      ))
   }
 
   # Check that barcode file ADTs match SCE ADTs


### PR DESCRIPTION
Closes #330 

This PR adds a quick check for ADT target type values, printing a nice warning if anything is invalid that it will default to `target`. I added a few comments that seemed helpful along the way.