### PR TITLE
Add CITEseq postprocessing to QC report

### DIFF
--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -203,6 +203,12 @@ if (alt_exp %in% altExpNames(processed_sce)) {
 
     # Add result_matrix back into correct SCE as logcounts assay
     logcounts(altExp(processed_sce, alt_exp)) <- result_matrix
+    
+    # Also, calculate & save most variable ADTs from `adt_sce` 
+    top_adts <- adt_sce |>
+      scran::modelGeneVar() |>
+      scran::getTopHVGs()
+    metadata(processed_sce)$highly_variable_adts <- top_adts
   }
 }
 

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -86,7 +86,7 @@ process filter_sce{
         filtered_rds = "${meta.library_id}_filtered.rds"
 
         // Three checks for whether we have ADT data:
-        // - technology should be adt
+        // - feature_type should be adt
         // - barcode file should exist
         // - barcode file should _not_ be the empty file NO_FILE.txt
         adt_present = meta.feature_type == 'adt' &

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -40,7 +40,8 @@ antibody_tags <- as.data.frame(rowData(cite_exp)) |>
   arrange(desc(mean)) |>
   select("Antibody",
          "Mean UMI count per cell" = mean,
-         "Percent of cells detected" = detected)
+         "Percent of cells detected" = detected, 
+         "ADT target type" =  target_type)
 
 knitr::kable(antibody_tags, digits = 2) |>
   kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -56,12 +56,12 @@ knitr::kable(antibody_tags, digits = 2) |>
 
 ```{r}
 
-filtered_cell_count <- sum(filtered_sce$adt_scpca_filter == "Remove")
+filtered_cell_count <- sum(filtered_sce$adt_scpca_filter == "Keep")
 
 basic_statistics <- tibble::tibble(
     "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method),
-    "Number of cells targeted for filtering"  = format(filtered_cell_count),
-    "Percent of cells targeted for filtering" =
+    "Number of cells that pass filtering thresholds"  = format(filtered_cell_count),
+    "Percent of cells that pass filtering thresholds" =
       paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
   ) |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -2,7 +2,7 @@
 
 This section details quality control statistics from the ADT (antibody-derived tag) component of CITE-seq experiments.
 
-## CITE-seq Statistics
+## CITE-seq Experiment Statistics
 
 ```{r}
 # add rowData if missing
@@ -13,17 +13,17 @@ if (is.null(rowData(adt_exp)$detected)){
 cell_adt_counts <- Matrix::colSums(counts(adt_exp))
 
 adt_information <- tibble::tibble(
-  "Number of ADTs assayed" = 
+  "Number of ADTs assayed" =
     format(nrow(adt_exp), big.mark = ',', scientific = FALSE),
-  "Number of reads sequenced" = 
+  "Number of reads sequenced" =
     format(adt_meta$total_reads, big.mark = ',', scientific = FALSE),
-  "Percent reads mapped to ADTs" = 
+  "Percent reads mapped to ADTs" =
     paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%"),
-  "Percent of ADTs in cells" = 
+  "Percent of ADTs in cells" =
     paste0(round(sum(cell_adt_counts)/adt_meta$mapped_reads * 100, digits = 2), "%"),
-  "Percent of cells with ADTs" = 
+  "Percent of cells with ADTs" =
     paste0(round(sum(cell_adt_counts > 0)/length(cell_adt_counts) * 100, digits = 2), "%"),
-  "Median ADT UMIs per cell" = 
+  "Median ADT UMIs per cell" =
     format(median(cell_adt_counts), big.mark = ',', scientific = FALSE)
   )|>
   t()
@@ -35,14 +35,14 @@ knitr::kable(adt_information, align = 'r') |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-## Antibody-Derived Tag Statistics 
+## ADT Statistics
 ```{r}
 antibody_tags <- as.data.frame(rowData(adt_exp)) |>
   tibble::rownames_to_column("Antibody") |>
   arrange(desc(mean)) |>
   select("Antibody",
          "Mean UMI count per cell" = mean,
-         "Percent of cells detected" = detected, 
+         "Percent of cells detected" = detected,
          "ADT target type" =  target_type)
 
 knitr::kable(antibody_tags, digits = 2) |>
@@ -50,5 +50,27 @@ knitr::kable(antibody_tags, digits = 2) |>
                             full_width = FALSE,
                             position = "left",
                             ) |>
-  kableExtra::column_spec(2:3, monospace = TRUE) 
+  kableExtra::column_spec(2:3, monospace = TRUE)
+```
+
+## ADT Post-processing Statistics
+
+```{r}
+
+filtered_cell_count <- sum(processed_sce$adt_scpca_filter_method == "Remove")
+
+basic_statistics <- basic_statistics |>
+  mutate(
+    "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method)
+    "Number of cells targeted for filtering"  = format(filtered_cell_count),
+    "Percent of cells targeted for filtering" =
+      paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
+  )
+
+  # TODO: check rendering here & tweak kable settings
+  knitr::kable(basic_statistics, align = 'r') |>
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left") |>
+  kableExtra::column_spec(2, monospace = TRUE)
 ```

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -193,8 +193,8 @@ if (has_processed) {
 
   # grab expression for top ADTs from counts
   var_adt_exp_df <- logcounts(altExp(processed_sce))[top_adts,] |>
-    as.matrix() |>
     t() |>
+    as.matrix() |>
     as.data.frame() |>
     tibble::rownames_to_column("barcode") |>
     # combine all ADTs into a single column for  faceting 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -49,28 +49,100 @@ knitr::kable(antibody_tags, digits = 2) |>
   kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
                             full_width = FALSE,
                             position = "left",
-                            ) |>
-  kableExtra::column_spec(2:3, monospace = TRUE)
+                            ) 
 ```
 
 ## ADT Post-processing Statistics
 
 ```{r}
 
-filtered_cell_count <- sum(processed_sce$adt_scpca_filter_method == "Remove")
+filtered_cell_count <- sum(filtered_sce$adt_scpca_filter_method == "Remove")
 
-basic_statistics <- basic_statistics |>
-  mutate(
-    "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method)
+basic_statistics <- tibble::tibble(
+    "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method),
     "Number of cells targeted for filtering"  = format(filtered_cell_count),
     "Percent of cells targeted for filtering" =
       paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
-  )
+  ) |>
+  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
+  t()
 
-  # TODO: check rendering here & tweak kable settings
-  knitr::kable(basic_statistics, align = 'r') |>
+knitr::kable(basic_statistics, align = 'r') |>
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
                             position = "left") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
+
+
+## Expression of highly variable ADTs
+
+The plots below show UMAP embeddings calculated from RNA expression where each cell is colored by the expression level of the labeled 
+ADT. 
+The ADTs chosen for plotting are the top 4 most variable ADTs in the library.
+
+
+```{r message=FALSE, results='asis'}
+# only create plot if variable ADTs are present
+if (!is.null(processed_meta$highly_variable_adts)) {
+  
+  # select top ADTs to plot 
+  top_adts <- processed_meta$highly_variable_adts |>
+    head(n = 4)
+  
+  # grab expression for top ADTs from counts
+  var_adt_exp <- logcounts(adt_exp[top_adts,]) |>
+    as.matrix() |>
+    t() |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode")
+  
+  # extract umap embeddings as a dataframe
+  umap_df <- reducedDim(processed_sce, "UMAP") |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    rename("UMAP1" = "V1",
+           "UMAP2" = "V2") 
+  
+  # combine ADT expression with coldata, umap embeddings, and create data frame to use for plotting
+  coldata_df <- colData(processed_sce) |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    # TODO: FILTER TO ONLY ADTS WHOSE KEEP==TRUE???
+    # combine with gene expression
+    left_join(var_adt_exp, by = "barcode") |>
+    # combine with umap embeddings 
+    left_join(umap_df, by = "barcode") |>
+    # combine all ADTs into a single column for easy faceting 
+    tidyr::pivot_longer(cols = starts_with("CD"),
+                        names_to = "ADT",
+                        values_to = "adt_expression")
+  
+  
+  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
+    geom_point(alpha = 0.1, size = 0.001) + 
+    facet_wrap(vars(ADT)) +
+    scale_color_viridis_c() +
+    labs(
+      color = "Log-normalized ADT expression"
+    ) +
+    theme(legend.position = "bottom", 
+          axis.text = element_text(size = 8, color = "black"),
+          axis.title = element_text(size = 8, color = "black"),
+          strip.text = element_text(size = 8),
+          strip.background = element_rect(fill = 'transparent'),
+          legend.title = element_text(size = 8),
+          legend.text = element_text(size = 8)) + 
+    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
+  
+} else {
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    This library does not contain a set of highly variable ADTs. 
+    
+    </div>
+  ")
+}
+```
+

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -165,7 +165,6 @@ if (has_processed) {
   # Calculate variance for each ADT
   adt_var <- altExp(processed_sce) |>
     logcounts() |>
-    as.matrix() |> 
     apply(1, var, na.rm=TRUE) 
   
   # Get the top 4
@@ -188,7 +187,7 @@ if (has_processed) {
 The plot below displays UMAP embeddings calculated from RNA expression, where each cell is colored by the expression level of the given ADT. 
 
 
-```{r fig.alt="UMAP colored by expression of highly variable ADTs", warning = FALSE}
+```{r fig.alt="Density plot showing normalized expression of highly variable ADTs", warning = FALSE}
 if (has_processed) {
 
   # grab expression for top ADTs from counts
@@ -212,7 +211,7 @@ if (has_processed) {
 ```
 
 
-```{r fig.alt="UMAP colored by expression of highly variable ADTs"}
+```{r fig.alt="UMAP calculated from RNA expression but colored by normalized expression of highly variable ADTs", fig.height = 6}
 if (has_processed) {
   # create data frame of UMAPs and expression 
    umap_df <- scuttle::makePerCellDF(processed_sce) |>
@@ -233,8 +232,13 @@ if (has_processed) {
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) + 
     scale_y_continuous(labels = NULL, breaks = NULL) + 
-    theme(legend.position = "bottom")  + 
-    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5)) 
+    coord_fixed() +
+    theme(legend.position = "bottom",
+          axis.title = element_text(size = 8, color = "black"),
+          strip.text = element_text(size = 8),
+          legend.title = element_text(size = 9),
+          legend.text = element_text(size = 8)) +
+    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
 }
 ```
 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -62,7 +62,7 @@ if (has_processed) {
   filtered_cell_count <- sum(processed_sce$adt_scpca_filter == "Keep")
   
   basic_statistics <- tibble::tibble(
-    # Note that the `adt_scpca_filter_method` column is only present in the `processed_sce` object
+    # Note that the adt_scpca_filter_method column is only present in the processed_sce object
     "Method used to identify cells to filter" = format(processed_meta$adt_scpca_filter_method),
     "Number of cells that pass filtering threshold"  = format(filtered_cell_count),
     "Percent of cells that pass filtering threshold" =
@@ -88,14 +88,16 @@ if (has_processed) {
 
 ```
 
+
 ## Expression of highly variable ADTs
 
-The plots below show UMAP embeddings calculated from RNA expression where each cell is colored by the expression level of the labeled 
-ADT. 
-The ADTs chosen for plotting are the top 4 most variable ADTs in the library.
+The plots below show visualizations of the top 4 most variable ADTS in the library.
+
+First, ridgeplots showing normalized expression of these 4 ADTs are shown.
+Second, UMAP embeddings calculated from RNA expression are shown, where each cell is colored by the expression level of the given ADT. 
 
 
-```{r fig.height=5, fig.width=6, message=FALSE, results='asis'}
+```{r fig.height=10, fig.width=8, message=FALSE, warning=FALSE, results='asis'}
 if (has_processed) {
   
   # only create plot if variable ADTs are present
@@ -108,13 +110,26 @@ if (has_processed) {
       head(n = 4)
     
     # grab expression for top ADTs from counts
-    var_adt_exp <- logcounts(adt_exp_processed[top_adts,]) |>
+    var_adt_exp_df <- logcounts(adt_exp_processed[top_adts,]) |>
       as.matrix() |>
       t() |>
       as.data.frame() |>
-      tibble::rownames_to_column("barcode")
+      tibble::rownames_to_column("barcode") |>
+      # combine all ADTs into a single column for easy faceting 
+      tidyr::pivot_longer(cols = starts_with("CD"),
+                            names_to = "ADT",
+                            values_to = "adt_expression")
     
-    # extract umap embeddings as a dataframe
+    # First, expression ridgeplot ridgeplots
+    adt_ridgeplot <- ggplot(var_adt_exp_df, 
+           aes(y = ADT, x = adt_expression, fill = ADT)) + 
+      ggridges::geom_density_ridges(alpha = 0.5) + 
+      scale_fill_viridis_d() + 
+      labs(x = "Log-normalized ADT expression") +
+      theme(legend.position = "none") 
+    
+    
+    # Next, extract umap embeddings as a dataframe
     umap_df <- reducedDim(processed_sce, "UMAP") |>
       as.data.frame() |>
       tibble::rownames_to_column("barcode") |>
@@ -125,19 +140,14 @@ if (has_processed) {
     coldata_df <- colData(processed_sce) |>
       as.data.frame() |>
       tibble::rownames_to_column("barcode") |>
-      # TODO: FILTER TO ONLY ADTS WHOSE KEEP==TRUE???
       # combine with gene expression
-      left_join(var_adt_exp, by = "barcode") |>
+      left_join(var_adt_exp_df, by = "barcode") |>
       # combine with umap embeddings 
-      left_join(umap_df, by = "barcode") |>
-      # combine all ADTs into a single column for easy faceting 
-      tidyr::pivot_longer(cols = starts_with("CD"),
-                          names_to = "ADT",
-                          values_to = "adt_expression")
+      left_join(umap_df, by = "barcode")
     
     
-    ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
-      geom_point(alpha = 0.1, size = 0.075) + 
+    adt_umap <- ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
+      geom_point(alpha = 0.1, size = 0.1) + 
       facet_wrap(vars(ADT)) +
       scale_color_viridis_c() +
       labs(
@@ -150,7 +160,10 @@ if (has_processed) {
             strip.background = element_rect(fill = 'transparent'),
             legend.title = element_text(size = 8),
             legend.text = element_text(size = 8)) + 
-      guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
+      guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5)) 
+    
+    # Combine with patchwork so that both plots are reliably printed
+    adt_ridgeplot / adt_umap
     
   } else {
     glue::glue("

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -58,6 +58,7 @@ Note that low-quality cells as identified by ADT counts are not actually filtere
 Instead, cells that passed the filter threshold are labeled as `"Keep"` within the SCE object, and conversely cells that failed to pass the filtered are labeled as `"Remove"`.
 
 ```{r}
+
 if (has_processed) {
   filtered_cell_count <- sum(processed_sce$adt_scpca_filter == "Keep")
   
@@ -66,7 +67,8 @@ if (has_processed) {
     "Method used to identify cells to filter" = format(processed_meta$adt_scpca_filter_method),
     "Number of cells that pass filtering threshold"  = format(filtered_cell_count),
     "Percent of cells that pass filtering threshold" =
-        paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
+        paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%"), 
+    "Normalization method" = format(processed_meta$adt_normalization)
     ) |>
     mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
     t()
@@ -90,26 +92,22 @@ if (has_processed) {
 
 ## Removing low quality cells based on ADT counts
 
-```{r results='asis'}
 
-glue::glue("
-  This glue is OUTSIDE the if and it prints just fine. 
-  Where are my glues INSIDE the ifs? :( 
-  ")
-
-
-if (has_filtered & has_processed) { 
+```{r fig.alt="Cell filtering based on both ADT and RNA counts", results='asis'}
+if (has_processed) { 
   
+  # DO NOT TAB TEXT IN, for formatting reasons
   glue::glue("
-    The plot below displays an overall view of cell filtering based on both ADT and RNA counts. Cells are labeled as one of the following:
-    - 'Keep': This cell is retained based on both RNA and ADT counts.
-    - 'Filter (RNA & ADT)': This cell is filtered based on both RNA and ADT counts.
-    - 'Filter (RNA only) ': This cell is filtered based on only RNA counts.
-    - 'Filter (ADT only)': This cell is filtered based on only ADT counts.
-    
-    Each panel is labeled with the given category of cells as well as the total number of cells in that category.
-  ")
+The plot below displays an overall view of cell filtering based on both ADT and RNA counts. Cells are labeled as one of the following:\n\n
 
+- 'Keep': This cell is retained based on both RNA and ADT counts.\n
+- 'Filter (RNA only) ': This cell is filtered based on only RNA counts.\n
+- 'Filter (ADT only)': This cell is filtered based on only ADT counts.\n\n
+- 'Filter (RNA & ADT)': This cell is filtered based on both RNA and ADT counts.\n
+
+Each panel is labeled with the given category of cells as well as the total number of cells in that category.
+  ")  |> print()
+  
   filter_levels <- c("Keep", "Filter (RNA & ADT)", "Filter (RNA only)", "Filter (ADT only)")
   filtered_coldata_df <- filtered_coldata_df |>
     # add column to represent filtering on both RNA and ADT counts
@@ -121,9 +119,15 @@ if (has_filtered & has_processed) {
       TRUE ~ "Error"
     ))  |>
     # now, add a count to each label and factor in count order
+    # add `keep_column` for use in plotting for colors
     add_count(filter_summary) |>
     mutate(filter_summary = glue::glue("{filter_summary}\nN={n}"), 
-           filter_summary = forcats::fct_infreq(filter_summary)) |>
+           filter_summary = forcats::fct_infreq(filter_summary), 
+           keep_column = ifelse(
+             stringr::str_starts(filter_summary, "Keep"), 
+             "Keep", 
+             "Remove"
+           )) |>
     select(-n)
 
   if (sum(stringr::str_detect(filtered_coldata_df$filter_summary, "Error")) != 0) {
@@ -131,15 +135,14 @@ if (has_filtered & has_processed) {
   }
 
   
-  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = filter_summary)) +
+  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = keep_column)) +
     geom_point(alpha = 0.5, size = 1) +
     geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
     labs(x = "Number of genes detected",
          y = "Mitochondrial percentage",
          title = "Combined RNA and ADT filters") +
-    scale_color_viridis_d(direction = -1) +
     facet_wrap(vars(filter_summary)) +
-    theme(plot.title = element_text(hjust = 0.5),
+    theme(plot.title = element_text(hjust = 0.5), 
           legend.position = "none")
 }
 ```
@@ -148,90 +151,29 @@ if (has_filtered & has_processed) {
 
 ## Expression of highly variable ADTs
 
-The plots below show visualizations of the top 4 most variable ADTS in the library.
+The plots in this section visualize the top four most variable ADTS in the library.
 
-First, ridgeplots showing normalized expression of these 4 ADTs are shown.
-Second, UMAP embeddings calculated from RNA expression are shown, where each cell is colored by the expression level of the given ADT. 
+The plot below displays normalized expression of these four ADTs, with one ADT shown per panel.
 
 
-```{r fig.height=10, fig.width=8, message=FALSE, warning=FALSE, results='asis'}
+```{r}
+# Calculate ADT variance
 if (has_processed) {
   
-  # only create plot if variable ADTs are present
-  if (!is.null(processed_meta$highly_variable_adts)) {
-    
-    adt_exp_processed <- altExp(processed_sce)
-    
-    # select top ADTs to plot 
-    top_adts <- processed_meta$highly_variable_adts |>
-      head(n = 4)
-    
-    # grab expression for top ADTs from counts
-    var_adt_exp_df <- logcounts(adt_exp_processed[top_adts,]) |>
-      as.matrix() |>
-      t() |>
-      as.data.frame() |>
-      tibble::rownames_to_column("barcode") |>
-      # combine all ADTs into a single column for easy faceting 
-      tidyr::pivot_longer(cols = starts_with("CD"),
-                            names_to = "ADT",
-                            values_to = "adt_expression")
-    
-    # First, expression ridgeplot ridgeplots
-    adt_ridgeplot <- ggplot(var_adt_exp_df, 
-           aes(y = ADT, x = adt_expression, fill = ADT)) + 
-      ggridges::geom_density_ridges(alpha = 0.5) + 
-      scale_fill_viridis_d() + 
-      labs(x = "Log-normalized ADT expression") +
-      theme(legend.position = "none") 
-    
-    
-    # Next, extract umap embeddings as a dataframe
-    umap_df <- reducedDim(processed_sce, "UMAP") |>
-      as.data.frame() |>
-      tibble::rownames_to_column("barcode") |>
-      rename("UMAP1" = "V1",
-             "UMAP2" = "V2") 
-    
-    # combine ADT expression with coldata, umap embeddings, and create data frame to use for plotting
-    coldata_df <- colData(processed_sce) |>
-      as.data.frame() |>
-      tibble::rownames_to_column("barcode") |>
-      # combine with gene expression
-      left_join(var_adt_exp_df, by = "barcode") |>
-      # combine with umap embeddings 
-      left_join(umap_df, by = "barcode")
-    
-    
-    adt_umap <- ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
-      geom_point(alpha = 0.1, size = 0.1) + 
-      facet_wrap(vars(ADT)) +
-      scale_color_viridis_c() +
-      labs(
-        color = "Log-normalized ADT expression"
-      ) +
-      theme(legend.position = "bottom", 
-            axis.text = element_text(size = 8, color = "black"),
-            axis.title = element_text(size = 8, color = "black"),
-            strip.text = element_text(size = 8),
-            strip.background = element_rect(fill = 'transparent'),
-            legend.title = element_text(size = 8),
-            legend.text = element_text(size = 8)) + 
-      guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5)) 
-    
-    # Combine with patchwork so that both plots are reliably printed
-    adt_ridgeplot / adt_umap
-    
-  } else {
-    glue::glue("
-      <div class=\"alert alert-warning\">
-      
-      This library does not contain a set of highly variable ADTs. 
-      
-      </div>
-    ")
-  }
+  top_n <- 4 # we want the top 4 ADTs
+
+  # Calculate variance for each ADT
+  adt_var <- altExp(processed_sce) |>
+    logcounts() |>
+    as.matrix() |> 
+    apply(1, var, na.rm=TRUE) 
+  
+  # Get the top 4
+  top_adts <- adt_var[ order(adt_var, decreasing=TRUE)[1:top_n] ] |>
+    names()
+
 } else {
+  # This warning also handles "else" conditions for the next two chunks
   glue::glue("
     <div class=\"alert alert-warning\">
 
@@ -239,6 +181,60 @@ if (has_processed) {
 
     </div>
   ")
+}
+```
+
+
+The plot below displays UMAP embeddings calculated from RNA expression, where each cell is colored by the expression level of the given ADT. 
+
+
+```{r fig.alt="UMAP colored by expression of highly variable ADTs", warning = FALSE}
+if (has_processed) {
+
+  # grab expression for top ADTs from counts
+  var_adt_exp_df <- logcounts(altExp(processed_sce))[top_adts,] |>
+    as.matrix() |>
+    t() |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    # combine all ADTs into a single column for  faceting 
+    tidyr::pivot_longer(!barcode,
+                        names_to = "ADT",
+                        values_to = "adt_expression")
+  
+  # expression density plots
+  ggplot(var_adt_exp_df, aes(x = adt_expression, fill = ADT)) + 
+    geom_density() + 
+    facet_wrap(vars(ADT), nrow = 2) +
+    labs(x = "Log-normalized ADT expression") +
+    theme(legend.position = "none") 
+} 
+```
+
+
+```{r fig.alt="UMAP colored by expression of highly variable ADTs"}
+if (has_processed) {
+  # create data frame of UMAPs and expression 
+   umap_df <- scuttle::makePerCellDF(processed_sce) |>
+      tibble::rownames_to_column("barcode") |>
+      select(barcode, 
+             UMAP1 = UMAP.1, 
+             UMAP2 = UMAP.2) |> 
+    # combine with gene expression
+    left_join(var_adt_exp_df, by = "barcode")
+  
+  ggplot(umap_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
+    geom_point(alpha = 0.1, size = 0.1) + 
+    facet_wrap(vars(ADT)) +
+    scale_color_viridis_c() +
+    labs(
+      color = "Log-normalized ADT expression"
+    ) +
+    # remove axis numbers and background grid
+    scale_x_continuous(labels = NULL, breaks = NULL) + 
+    scale_y_continuous(labels = NULL, breaks = NULL) + 
+    theme(legend.position = "bottom")  + 
+    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5)) 
 }
 ```
 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -88,6 +88,63 @@ if (has_processed) {
 
 ```
 
+## Removing low quality cells based on ADT counts
+
+```{r results='asis'}
+
+glue::glue("
+  This glue is OUTSIDE the if and it prints just fine. 
+  Where are my glues INSIDE the ifs? :( 
+  ")
+
+
+if (has_filtered & has_processed) { 
+  
+  glue::glue("
+    The plot below displays an overall view of cell filtering based on both ADT and RNA counts. Cells are labeled as one of the following:
+    - 'Keep': This cell is retained based on both RNA and ADT counts.
+    - 'Filter (RNA & ADT)': This cell is filtered based on both RNA and ADT counts.
+    - 'Filter (RNA only) ': This cell is filtered based on only RNA counts.
+    - 'Filter (ADT only)': This cell is filtered based on only ADT counts.
+    
+    Each panel is labeled with the given category of cells as well as the total number of cells in that category.
+  ")
+
+  filter_levels <- c("Keep", "Filter (RNA & ADT)", "Filter (RNA only)", "Filter (ADT only)")
+  filtered_coldata_df <- filtered_coldata_df |>
+    # add column to represent filtering on both RNA and ADT counts
+    mutate(filter_summary = case_when(
+      scpca_filter == "Keep"   & adt_scpca_filter == "Keep"   ~ filter_levels[1],
+      scpca_filter == "Remove" & adt_scpca_filter == "Remove" ~ filter_levels[2],
+      scpca_filter == "Remove" & adt_scpca_filter == "Keep"   ~ filter_levels[3],
+      scpca_filter == "Keep"   & adt_scpca_filter == "Remove" ~ filter_levels[4],
+      TRUE ~ "Error"
+    ))  |>
+    # now, add a count to each label and factor in count order
+    add_count(filter_summary) |>
+    mutate(filter_summary = glue::glue("{filter_summary}\nN={n}"), 
+           filter_summary = forcats::fct_infreq(filter_summary)) |>
+    select(-n)
+
+  if (sum(stringr::str_detect(filtered_coldata_df$filter_summary, "Error")) != 0) {
+    stop("Processing error when evaluating CITE-seq filtering.")
+  }
+
+  
+  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = filter_summary)) +
+    geom_point(alpha = 0.5, size = 1) +
+    geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
+    labs(x = "Number of genes detected",
+         y = "Mitochondrial percentage",
+         title = "Combined RNA and ADT filters") +
+    scale_color_viridis_d(direction = -1) +
+    facet_wrap(vars(filter_summary)) +
+    theme(plot.title = element_text(hjust = 0.5),
+          legend.position = "none")
+}
+```
+
+
 
 ## Expression of highly variable ADTs
 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -153,8 +153,6 @@ Each panel is labeled with the given category of cells as well as the total numb
 
 The plots in this section visualize the top four most variable ADTS in the library.
 
-The plot below displays normalized expression of these four ADTs, with one ADT shown per panel.
-
 
 ```{r}
 # Calculate ADT variance
@@ -184,7 +182,7 @@ if (has_processed) {
 ```
 
 
-The plot below displays UMAP embeddings calculated from RNA expression, where each cell is colored by the expression level of the given ADT. 
+The plot below displays normalized expression of these four ADTs, with one ADT shown per panel.
 
 
 ```{r fig.alt="Density plot showing normalized expression of highly variable ADTs", warning = FALSE}
@@ -209,6 +207,8 @@ if (has_processed) {
     theme(legend.position = "none") 
 } 
 ```
+
+The plot below displays UMAP embeddings calculated from RNA expression, where each cell is colored by the expression level of the given ADT. 
 
 
 ```{r fig.alt="UMAP calculated from RNA expression but colored by normalized expression of highly variable ADTs", fig.height = 6}

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -56,7 +56,7 @@ knitr::kable(antibody_tags, digits = 2) |>
 
 ```{r}
 
-filtered_cell_count <- sum(filtered_sce$adt_scpca_filter_method == "Remove")
+filtered_cell_count <- sum(filtered_sce$adt_scpca_filter == "Remove")
 
 basic_statistics <- tibble::tibble(
     "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method),
@@ -82,7 +82,7 @@ ADT.
 The ADTs chosen for plotting are the top 4 most variable ADTs in the library.
 
 
-```{r message=FALSE, results='asis'}
+```{r fig.height=5, fig.width=6, message=FALSE, results='asis'}
 # only create plot if variable ADTs are present
 if (!is.null(processed_meta$highly_variable_adts)) {
   
@@ -120,7 +120,7 @@ if (!is.null(processed_meta$highly_variable_adts)) {
   
   
   ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
-    geom_point(alpha = 0.1, size = 0.001) + 
+    geom_point(alpha = 0.1, size = 0.075) + 
     facet_wrap(vars(ADT)) +
     scale_color_viridis_c() +
     labs(

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -54,26 +54,39 @@ knitr::kable(antibody_tags, digits = 2) |>
 
 ## ADT Post-processing Statistics
 
+Note that low-quality cells as identified by ADT counts are not actually filtered from the SCE object.
+Instead, cells that passed the filter threshold are labeled as `"Keep"` within the SCE object, and conversely cells that failed to pass the filtered are labeled as `"Remove"`.
+
 ```{r}
+if (has_processed) {
+  filtered_cell_count <- sum(processed_sce$adt_scpca_filter == "Keep")
+  
+  basic_statistics <- tibble::tibble(
+    # Note that the `adt_scpca_filter_method` column is only present in the `processed_sce` object
+    "Method used to identify cells to filter" = format(processed_meta$adt_scpca_filter_method),
+    "Number of cells that pass filtering threshold"  = format(filtered_cell_count),
+    "Percent of cells that pass filtering threshold" =
+        paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
+    ) |>
+    mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
+    t()
+  
+  knitr::kable(basic_statistics, align = 'r') |>
+    kableExtra::kable_styling(bootstrap_options = "striped",
+                              full_width = FALSE,
+                              position = "left") |>
+    kableExtra::column_spec(2, monospace = TRUE)
+} else {
+    glue::glue("
+    <div class=\"alert alert-warning\">
 
-filtered_cell_count <- sum(filtered_sce$adt_scpca_filter == "Keep")
+    No ADT post-processing was performed on this library.
 
-basic_statistics <- tibble::tibble(
-    "Method used to identify cells targeted for filtering" = format(processed_meta$adt_scpca_filter_method),
-    "Number of cells that pass filtering thresholds"  = format(filtered_cell_count),
-    "Percent of cells that pass filtering thresholds" =
-      paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%")
-  ) |>
-  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
-  t()
+    </div>
+  ")
+}
 
-knitr::kable(basic_statistics, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
-  kableExtra::column_spec(2, monospace = TRUE)
 ```
-
 
 ## Expression of highly variable ADTs
 
@@ -83,64 +96,77 @@ The ADTs chosen for plotting are the top 4 most variable ADTs in the library.
 
 
 ```{r fig.height=5, fig.width=6, message=FALSE, results='asis'}
-# only create plot if variable ADTs are present
-if (!is.null(processed_meta$highly_variable_adts)) {
+if (has_processed) {
   
-  # select top ADTs to plot 
-  top_adts <- processed_meta$highly_variable_adts |>
-    head(n = 4)
-  
-  # grab expression for top ADTs from counts
-  var_adt_exp <- logcounts(adt_exp[top_adts,]) |>
-    as.matrix() |>
-    t() |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode")
-  
-  # extract umap embeddings as a dataframe
-  umap_df <- reducedDim(processed_sce, "UMAP") |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode") |>
-    rename("UMAP1" = "V1",
-           "UMAP2" = "V2") 
-  
-  # combine ADT expression with coldata, umap embeddings, and create data frame to use for plotting
-  coldata_df <- colData(processed_sce) |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode") |>
-    # TODO: FILTER TO ONLY ADTS WHOSE KEEP==TRUE???
-    # combine with gene expression
-    left_join(var_adt_exp, by = "barcode") |>
-    # combine with umap embeddings 
-    left_join(umap_df, by = "barcode") |>
-    # combine all ADTs into a single column for easy faceting 
-    tidyr::pivot_longer(cols = starts_with("CD"),
-                        names_to = "ADT",
-                        values_to = "adt_expression")
-  
-  
-  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
-    geom_point(alpha = 0.1, size = 0.075) + 
-    facet_wrap(vars(ADT)) +
-    scale_color_viridis_c() +
-    labs(
-      color = "Log-normalized ADT expression"
-    ) +
-    theme(legend.position = "bottom", 
-          axis.text = element_text(size = 8, color = "black"),
-          axis.title = element_text(size = 8, color = "black"),
-          strip.text = element_text(size = 8),
-          strip.background = element_rect(fill = 'transparent'),
-          legend.title = element_text(size = 8),
-          legend.text = element_text(size = 8)) + 
-    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
-  
+  # only create plot if variable ADTs are present
+  if (!is.null(processed_meta$highly_variable_adts)) {
+    
+    adt_exp_processed <- altExp(processed_sce)
+    
+    # select top ADTs to plot 
+    top_adts <- processed_meta$highly_variable_adts |>
+      head(n = 4)
+    
+    # grab expression for top ADTs from counts
+    var_adt_exp <- logcounts(adt_exp_processed[top_adts,]) |>
+      as.matrix() |>
+      t() |>
+      as.data.frame() |>
+      tibble::rownames_to_column("barcode")
+    
+    # extract umap embeddings as a dataframe
+    umap_df <- reducedDim(processed_sce, "UMAP") |>
+      as.data.frame() |>
+      tibble::rownames_to_column("barcode") |>
+      rename("UMAP1" = "V1",
+             "UMAP2" = "V2") 
+    
+    # combine ADT expression with coldata, umap embeddings, and create data frame to use for plotting
+    coldata_df <- colData(processed_sce) |>
+      as.data.frame() |>
+      tibble::rownames_to_column("barcode") |>
+      # TODO: FILTER TO ONLY ADTS WHOSE KEEP==TRUE???
+      # combine with gene expression
+      left_join(var_adt_exp, by = "barcode") |>
+      # combine with umap embeddings 
+      left_join(umap_df, by = "barcode") |>
+      # combine all ADTs into a single column for easy faceting 
+      tidyr::pivot_longer(cols = starts_with("CD"),
+                          names_to = "ADT",
+                          values_to = "adt_expression")
+    
+    
+    ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = adt_expression)) + 
+      geom_point(alpha = 0.1, size = 0.075) + 
+      facet_wrap(vars(ADT)) +
+      scale_color_viridis_c() +
+      labs(
+        color = "Log-normalized ADT expression"
+      ) +
+      theme(legend.position = "bottom", 
+            axis.text = element_text(size = 8, color = "black"),
+            axis.title = element_text(size = 8, color = "black"),
+            strip.text = element_text(size = 8),
+            strip.background = element_rect(fill = 'transparent'),
+            legend.title = element_text(size = 8),
+            legend.text = element_text(size = 8)) + 
+      guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
+    
+  } else {
+    glue::glue("
+      <div class=\"alert alert-warning\">
+      
+      This library does not contain a set of highly variable ADTs. 
+      
+      </div>
+    ")
+  }
 } else {
   glue::glue("
     <div class=\"alert alert-warning\">
-    
-    This library does not contain a set of highly variable ADTs. 
-    
+
+    No ADT post-processing was performed on this library.
+
     </div>
   ")
 }

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -143,7 +143,7 @@ sample_information <- tibble::tibble(
 )
 
 if (has_adt) {
-  adt_exp <- altExp(processed_sce, "adt")
+  adt_exp <- altExp(filtered_sce, "adt") # must be filtered_sce in case has_processed is FALSE
   adt_meta <- metadata(adt_exp)
 
   sample_information <- sample_information |>
@@ -468,7 +468,65 @@ if (has_filtered & has_processed) {
 }
 ```
 
-The raw counts from all cells that remain after filtering low quality cells are then normalized prior to selection of highly variable genes and dimensionality reduction.
+```{r results='asis'}
+
+glue::glue("
+  This glue is OUTSIDE the if and it prints just fine. 
+  Where are my glues INSIDE the ifs? :( 
+  ")
+
+
+if (has_adt & has_filtered & has_processed) { 
+  
+  glue::glue("
+
+    The below plot is the same as above, but cells are colored based on both RNA count and ADT count filtering.
+    Specifically, cells are labeled as one of the following:
+    - 'Keep': This cell is retained based on both RNA and ADT counts.
+    - 'Filter (RNA & ADT)': This cell is filtered based on both RNA and ADT counts.
+    - 'Filter (RNA only) ': This cell is filtered based on only RNA counts.
+    - 'Filter (ADT only)': This cell is filtered based on only ADT counts.
+    
+    Each panel is labeled with the given category of cells as well as the total number of cells in that category.
+  ")
+
+  filter_levels <- c("Keep", "Filter (RNA & ADT)", "Filter (RNA only)", "Filter (ADT only)")
+  filtered_coldata_df <- filtered_coldata_df |>
+    # add column to represent filtering on both RNA and ADT counts
+    mutate(filter_summary = case_when(
+      scpca_filter == "Keep"   & adt_scpca_filter == "Keep"   ~ filter_levels[1],
+      scpca_filter == "Remove" & adt_scpca_filter == "Remove" ~ filter_levels[2],
+      scpca_filter == "Remove" & adt_scpca_filter == "Keep"   ~ filter_levels[3],
+      scpca_filter == "Keep"   & adt_scpca_filter == "Remove" ~ filter_levels[4],
+      TRUE ~ "Error"
+    ))  |>
+    # now, add a count to each label and factor in count order
+    add_count(filter_summary) |>
+    mutate(filter_summary = glue::glue("{filter_summary}\nN={n}"), 
+           filter_summary = forcats::fct_infreq(filter_summary)) |>
+    select(-n)
+
+  if (sum(stringr::str_detect(filtered_coldata_df$filter_summary, "Error")) != 0) {
+    stop("Processing error when evaluating CITE-seq filtering.")
+  }
+
+  
+  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = filter_summary)) +
+    geom_point(alpha = 0.5, size = 1) +
+    geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
+    labs(x = "Number of genes detected",
+         y = "Mitochondrial percentage",
+         title = "Combined RNA and ADT filters") +
+    scale_color_viridis_d(direction = -1) +
+    facet_wrap(vars(filter_summary)) +
+    theme(plot.title = element_text(hjust = 0.5),
+          legend.position = "none")
+}
+```
+
+The raw counts from all cells that remain after filtering low quality cells (RNA only) are then normalized prior to selection of highly variable genes and dimensionality reduction.
+
+
 
 <!-- Next section include only if UMAP is present -->
 ```{r, child='umap_qc.rmd', eval = has_umap}

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -449,7 +449,8 @@ The dotted vertical line indicates the minimum gene cutoff used for filtering.
 
 ```{r eval = has_cite, results='asis'}
 glue::glue(
-"Next, additional low quality cells were removed based on ADT counts (<code>cleanTagCounts</code>), such that cells with high levels of ambient contamination and/or isotype control tags (if present) were removed."
+"Next, additional low quality cells were removed based on ADT counts ([`DropletUtils::cleanTagCounts()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html)).
+Cells with high levels of ambient contamination and/or isotype control tags (if present) were removed."
 )
 ```
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -79,18 +79,18 @@ if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
 modalities <- c("RNA-seq")
 
 has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
-if (has_cite){
+if (has_cite) {
   modalities <- c(modalities, "CITE-seq")
 }
 
 # check for cellhash to add to list of modalities
 has_cellhash <- "cellhash" %in% altExpNames(filtered_sce)
-if(has_cellhash){
+if (has_cellhash) {
   modalities <- c(modalities, "Multiplex")
 }
 
 # check for umap, need to be sure that processed_sce exists first
-if(has_processed){
+if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
 } else {
   has_umap <- FALSE
@@ -104,7 +104,7 @@ if(has_processed){
 # only print out multiplexed warning if more than one sample is present
 has_multiplex <- length(sample_id) > 1
 
-if(has_multiplex){
+if (has_multiplex) {
   # convert sample id to bullet separated list 
   multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
   glue::glue("
@@ -141,7 +141,7 @@ sample_information <- tibble::tibble(
   "Percent RNA-seq reads mapped to transcripts" = 
     paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%")
 )
-if (has_cite){
+if (has_cite) {
   cite_exp <- altExp(filtered_sce, "CITEseq")
   cite_meta <- metadata(cite_exp)
   
@@ -155,7 +155,7 @@ if (has_cite){
         paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%")
     )
 }
-if (has_cellhash){
+if (has_cellhash) {
   multiplex_exp <- altExp(filtered_sce, "cellhash")
   multiplex_meta <- metadata(multiplex_exp)
   
@@ -227,18 +227,33 @@ basic_statistics <- tibble::tibble(
   )
 
 # if processed sce exists add filtering and normalization table
-if(has_processed){
+if (has_processed) {
   processed_meta <- metadata(processed_sce)
+  
+  # TODO: Do we want to separate RNA and ADT rows? ADT is always the same, so may not be needed, but 
+  # might be a good indicator that filtering was also performed based on ADTs.
+  # Other approach is just to split out the first string in `scpca_filter_method`, which won't need an `if` here. 
+  if (has_cite) {
+    split_methods <- stringr::str_split(processed_meta$scpca_filter_method, ";")[[1]]
+    basic_statistics <- basic_statistics |>
+    mutate(
+      "Method used to filter low quality cells (RNA)" = format(split_methods[1]),
+      "Method used to filter low quality cells (ADT)" = format(split_methods[2]),
+    )
+  } else {
+    basic_statistics <- basic_statistics |>
+    mutate(
+      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method)
+    )
+  }
   
   basic_statistics <- basic_statistics |>
     mutate(
-      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method),
       "Cells after filtering low quality cells" = format(dim(processed_sce)[2], big.mark = ',', scientific = FALSE),
       "Normalization method"                    = format(processed_meta$normalization),
       "Minimum genes per cell cutoff"           = format(processed_meta$min_gene_cutoff)
-    
     )
-  if(processed_meta$scpca_filter_method == "miQC") {
+  if (processed_meta$scpca_filter_method == "miQC") {
     basic_statistics <- basic_statistics |>
       mutate(
         "Probability of compromised cell cutoff" = format(processed_meta$prob_compromised_cutoff, big.mark = ",", scientific = FALSE)
@@ -261,8 +276,8 @@ knitr::kable(basic_statistics, align = 'r') |>
 ```
 
 ```{r, results='asis'}
-if(has_filtered &&
-   (metadata(filtered_sce)$filtering_method == "UMI cutoff")){
+if (has_filtered &&
+   (metadata(filtered_sce)$filtering_method == "UMI cutoff")) {
   glue::glue("
     <div class=\"alert alert-warning\">
     
@@ -426,26 +441,31 @@ In such situations, the calculated probability of compromise may not be valid (s
 ## Removing low quality cells
 
 The below plot highlights cells that were removed prior to normalization and dimensionality reduction.
-Cells that should be removed are those that are identified to be low quality cells, such as cells with high probability of being compromised, calculated by `miQC`.
+Cells that should be removed based on RNA counts are those that are identified to be low quality cells, such as cells with high probability of being compromised.
 The method of filtering is indicated above the plot as either `miQC` or `Minimum gene cutoff`. 
 If `miQC`, cells below the specified probability compromised cutoff and above the minimum number of unique genes identified are kept for downstream analyses. 
 If only a `Minimum gene cutoff` is used, then `miQC` is not used and only those cells that pass the minimum number of unique genes identified threshold are retained. 
 The dotted vertical line indicates the minimum gene cutoff used for filtering. 
 
+```{r eval = has_cite, results='asis'}
+glue::glue(
+"Next, additional low quality cells were removed based on ADT counts (<code>cleanTagCounts</code>), such that cells with high levels of ambient contamination and/or isotype control tags (if present) were removed."
+)
+```
+
 ```{r results='asis'}
-if(has_filtered & has_processed){
+if (has_filtered & has_processed) {
   
   # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
-  filter_method <- processed_meta$scpca_filter_method
+  
+  # clean string to indicate RNA and ADT filtering (if no ADT, string will be unaffected)
+  filter_method <- stringr::str_replace(processed_meta$scpca_filter_method, ";", " and ")
   
   # add column to coldata labeling cells to keep/remove based on filtering method
   filtered_coldata_df <- colData(filtered_sce) |>
     as.data.frame() |>
-    tibble::rownames_to_column("barcode") |>
-    dplyr::mutate(scpca_filter = ifelse(barcode %in%  colnames(processed_sce), 
-                                       "Keep", 
-                                       "Remove")) 
+    tibble::rownames_to_column("barcode")
   
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = scpca_filter)) + 
     geom_point(alpha = 0.5, size = 1) +

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -79,7 +79,7 @@ if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
 modalities <- c("RNA-seq")
 
 has_adt <- "adt" %in% altExpNames(filtered_sce)
-if (has_adt){
+if (has_adt) {
   modalities <- c(modalities, "ADT")
 }
 
@@ -141,8 +141,9 @@ sample_information <- tibble::tibble(
   "Percent of RNA-seq reads mapped to transcripts" =
     paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%")
 )
-if (has_adt){
-  adt_exp <- altExp(filtered_sce, "adt")
+
+if (has_adt) {
+  adt_exp <- altExp(processed_sce, "adt")
   adt_meta <- metadata(adt_exp)
 
   sample_information <- sample_information |>
@@ -155,6 +156,7 @@ if (has_adt){
         paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%")
     )
 }
+
 if (has_cellhash) {
   multiplex_exp <- altExp(filtered_sce, "cellhash")
   multiplex_meta <- metadata(multiplex_exp)
@@ -169,7 +171,6 @@ if (has_cellhash) {
         paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%")
     )
 }
-
 
 sample_information <- sample_information |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
@@ -385,7 +386,7 @@ Cells with low UMI counts and high mitochondrial percentages may require further
 ## miQC Model Diagnostics
 
 ```{r, fig.alt="miQC model diagnostics plot", results='asis', warning=FALSE}
-if(skip_miQC){
+if (skip_miQC) {
   cat("miQC model not created, skipping miQC plot. Usually this is because mitochondrial gene data was not available.")
 }else{
   # remove prob_compromised if it exists, as this will cause errors with plotModel

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -232,7 +232,7 @@ if (has_processed) {
 
   basic_statistics <- basic_statistics |>
     mutate(
-      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method)
+      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method),
       "Cells after filtering low quality cells" = format(dim(processed_sce)[2], big.mark = ',', scientific = FALSE),
       "Normalization method"                    = format(processed_meta$normalization),
       "Minimum genes per cell cutoff"           = format(processed_meta$min_gene_cutoff)
@@ -430,18 +430,14 @@ If `miQC`, cells below the specified probability compromised cutoff and above th
 If only a `Minimum gene cutoff` is used, then `miQC` is not used and only those cells that pass the minimum number of unique genes identified threshold are retained.
 The dotted vertical line indicates the minimum gene cutoff used for filtering.
 
-```{r eval = has_adt, results='asis'}
-glue::glue(
-"Next, additional low quality cells were removed based on ADT counts ([`DropletUtils::cleanTagCounts()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html)).
-Cells with high levels of ambient contamination and/or isotype control tags (if present) were removed."
-)
-```
 
 ```{r results='asis'}
 if (has_filtered & has_processed) {
 
   # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
+
+  filter_method <- processed_meta$scpca_filter_method
 
   # add column to coldata labeling cells to keep/remove based on filtering method
   filtered_coldata_df <- colData(filtered_sce) |>
@@ -454,7 +450,7 @@ if (has_filtered & has_processed) {
     labs(x = "Number of genes detected",
          y = "Mitochondrial percentage",
          color = "Filter",
-         title = stringr::str_replace(processed_meta$scpca_filter_method, "_", " ")) +
+         title = stringr::str_replace(filter_method, "_", " ")) +
     theme(plot.title = element_text(hjust = 0.5),
           legend.position = c(1, 1),
           legend.justification = c(1,1),

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -32,8 +32,9 @@ library(patchwork)
 
 # Set default ggplot theme
 theme_set(
-  theme_bw() +theme(plot.margin = margin(rep(20, 4)), 
-                    strip.background = element_rect(fill = 'transparent'))
+  theme_bw() +
+  theme(plot.margin = margin(rep(20, 4)), 
+        strip.background = element_rect(fill = 'transparent'))
 )
 ```
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -469,62 +469,6 @@ if (has_filtered & has_processed) {
 }
 ```
 
-```{r results='asis'}
-
-glue::glue("
-  This glue is OUTSIDE the if and it prints just fine. 
-  Where are my glues INSIDE the ifs? :( 
-  ")
-
-
-if ((has_adt & has_filtered) & has_processed) { 
-  
-  glue::glue("
-
-    The below plot is the same as above, but cells are colored based on both RNA count and ADT count filtering.
-    Specifically, cells are labeled as one of the following:
-    - 'Keep': This cell is retained based on both RNA and ADT counts.
-    - 'Filter (RNA & ADT)': This cell is filtered based on both RNA and ADT counts.
-    - 'Filter (RNA only) ': This cell is filtered based on only RNA counts.
-    - 'Filter (ADT only)': This cell is filtered based on only ADT counts.
-    
-    Each panel is labeled with the given category of cells as well as the total number of cells in that category.
-  ")
-
-  filter_levels <- c("Keep", "Filter (RNA & ADT)", "Filter (RNA only)", "Filter (ADT only)")
-  filtered_coldata_df <- filtered_coldata_df |>
-    # add column to represent filtering on both RNA and ADT counts
-    mutate(filter_summary = case_when(
-      scpca_filter == "Keep"   & adt_scpca_filter == "Keep"   ~ filter_levels[1],
-      scpca_filter == "Remove" & adt_scpca_filter == "Remove" ~ filter_levels[2],
-      scpca_filter == "Remove" & adt_scpca_filter == "Keep"   ~ filter_levels[3],
-      scpca_filter == "Keep"   & adt_scpca_filter == "Remove" ~ filter_levels[4],
-      TRUE ~ "Error"
-    ))  |>
-    # now, add a count to each label and factor in count order
-    add_count(filter_summary) |>
-    mutate(filter_summary = glue::glue("{filter_summary}\nN={n}"), 
-           filter_summary = forcats::fct_infreq(filter_summary)) |>
-    select(-n)
-
-  if (sum(stringr::str_detect(filtered_coldata_df$filter_summary, "Error")) != 0) {
-    stop("Processing error when evaluating CITE-seq filtering.")
-  }
-
-  
-  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = filter_summary)) +
-    geom_point(alpha = 0.5, size = 1) +
-    geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
-    labs(x = "Number of genes detected",
-         y = "Mitochondrial percentage",
-         title = "Combined RNA and ADT filters") +
-    scale_color_viridis_d(direction = -1) +
-    facet_wrap(vars(filter_summary)) +
-    theme(plot.title = element_text(hjust = 0.5),
-          legend.position = "none")
-}
-```
-
 The raw counts from all cells that remain after filtering low quality cells (RNA only) are then normalized prior to selection of highly variable genes and dimensionality reduction.
 
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -28,6 +28,7 @@ knitr::opts_chunk$set(
 library(SingleCellExperiment)
 library(dplyr)
 library(ggplot2)
+library(patchwork)
 
 # Set default ggplot theme
 theme_set(theme_bw() +
@@ -476,7 +477,7 @@ glue::glue("
   ")
 
 
-if (has_adt & has_filtered & has_processed) { 
+if ((has_adt & has_filtered) & has_processed) { 
   
   glue::glue("
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -31,8 +31,10 @@ library(ggplot2)
 library(patchwork)
 
 # Set default ggplot theme
-theme_set(theme_bw() +
-          theme(plot.margin = margin(rep(20, 4))))
+theme_set(
+  theme_bw() +theme(plot.margin = margin(rep(20, 4)), 
+                    strip.background = element_rect(fill = 'transparent'))
+)
 ```
 
 ```{r sce_setup}
@@ -389,15 +391,15 @@ Cells with low UMI counts and high mitochondrial percentages may require further
 ```{r, fig.alt="miQC model diagnostics plot", results='asis', warning=FALSE}
 if (skip_miQC) {
   cat("miQC model not created, skipping miQC plot. Usually this is because mitochondrial gene data was not available.")
-}else{
+} else {
   # remove prob_compromised if it exists, as this will cause errors with plotModel
   filtered_sce$prob_compromised <- NULL
   miQC_model <- metadata(filtered_sce)$miQC_model
 
-  if (is.null(miQC_model) || length(miQC_model@components) < 2){
+  if (is.null(miQC_model) || length(miQC_model@components) < 2) {
     # model didn't fit, just plot metrics
     miQC_plot <- miQC::plotMetrics(filtered_sce)
-  }else{
+  } else {
     miQC_plot <- miQC::plotModel(filtered_sce, model = miQC_model)
   }
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -233,7 +233,7 @@ if (has_processed) {
   # TODO: Do we want to separate RNA and ADT rows? ADT is always the same, so may not be needed, but
   # might be a good indicator that filtering was also performed based on ADTs.
   # Other approach is just to split out the first string in `scpca_filter_method`, which won't need an `if` here.
-  if (has_cite) {
+  if (has_adt) {
     split_methods <- stringr::str_split(processed_meta$scpca_filter_method, ";")[[1]]
     basic_statistics <- basic_statistics |>
     mutate(
@@ -447,7 +447,7 @@ If `miQC`, cells below the specified probability compromised cutoff and above th
 If only a `Minimum gene cutoff` is used, then `miQC` is not used and only those cells that pass the minimum number of unique genes identified threshold are retained.
 The dotted vertical line indicates the minimum gene cutoff used for filtering.
 
-```{r eval = has_cite, results='asis'}
+```{r eval = has_adt, results='asis'}
 glue::glue(
 "Next, additional low quality cells were removed based on ADT counts ([`DropletUtils::cleanTagCounts()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html)).
 Cells with high levels of ambient contamination and/or isotype control tags (if present) were removed."

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -230,25 +230,9 @@ basic_statistics <- tibble::tibble(
 if (has_processed) {
   processed_meta <- metadata(processed_sce)
 
-  # TODO: Do we want to separate RNA and ADT rows? ADT is always the same, so may not be needed, but
-  # might be a good indicator that filtering was also performed based on ADTs.
-  # Other approach is just to split out the first string in `scpca_filter_method`, which won't need an `if` here.
-  if (has_adt) {
-    split_methods <- stringr::str_split(processed_meta$scpca_filter_method, ";")[[1]]
-    basic_statistics <- basic_statistics |>
-    mutate(
-      "Method used to filter low quality cells (RNA)" = format(split_methods[1]),
-      "Method used to filter low quality cells (ADT)" = format(split_methods[2]),
-    )
-  } else {
-    basic_statistics <- basic_statistics |>
-    mutate(
-      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method)
-    )
-  }
-
   basic_statistics <- basic_statistics |>
     mutate(
+      "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method)
       "Cells after filtering low quality cells" = format(dim(processed_sce)[2], big.mark = ',', scientific = FALSE),
       "Normalization method"                    = format(processed_meta$normalization),
       "Minimum genes per cell cutoff"           = format(processed_meta$min_gene_cutoff)
@@ -260,7 +244,6 @@ if (has_processed) {
       )
   }
 }
-
 
 basic_statistics <- basic_statistics |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
@@ -460,9 +443,6 @@ if (has_filtered & has_processed) {
   # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
 
-  # clean string to indicate RNA and ADT filtering (if no ADT, string will be unaffected)
-  filter_method <- stringr::str_replace(processed_meta$scpca_filter_method, ";", " and ")
-
   # add column to coldata labeling cells to keep/remove based on filtering method
   filtered_coldata_df <- colData(filtered_sce) |>
     as.data.frame() |>
@@ -474,7 +454,7 @@ if (has_filtered & has_processed) {
     labs(x = "Number of genes detected",
          y = "Mitochondrial percentage",
          color = "Filter",
-         title = stringr::str_replace(filter_method, "_", " ")) +
+         title = stringr::str_replace(processed_meta$scpca_filter_method, "_", " ")) +
     theme(plot.title = element_text(hjust = 0.5),
           legend.position = c(1, 1),
           legend.justification = c(1,1),

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -24,11 +24,11 @@ If gene symbols are not available, the Ensembl id will be shown.
 
 ```{r message=FALSE, results='asis'}
 # only create plot if variable genes are present
-if(!is.null(processed_meta$highly_variable_genes)){
+if (!is.null(processed_meta$highly_variable_genes)) {
   
   # select top genes to plot 
   top_genes <- processed_meta$highly_variable_genes |>
-    head(n=12)
+    head( n = 12)
   
   # grab expression for top genes from counts
   var_gene_exp <- logcounts(processed_sce[top_genes,]) |>
@@ -75,7 +75,7 @@ if(!is.null(processed_meta$highly_variable_genes)){
   
   ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) + 
     geom_point(alpha = 0.1, size = 0.001) + 
-    facet_wrap(~ gene_symbol) +
+    facet_wrap(vars(gene_symbol)) +
     scale_color_viridis_c() +
     labs(
       color = "Log-normalized gene expression"

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -8,8 +8,10 @@ scater::plotUMAP(processed_sce,
                  point_size = 0.3,
                  point_alpha = 0.5,
                  colour_by = "detected") +
-  scale_color_viridis_c()+
-  theme_bw() + 
+  scale_color_viridis_c() +
+  # remove axis numbers and background grid
+  scale_x_continuous(labels = NULL, breaks = NULL) + 
+  scale_y_continuous(labels = NULL, breaks = NULL) + 
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
   )
@@ -80,13 +82,15 @@ if (!is.null(processed_meta$highly_variable_genes)) {
     labs(
       color = "Log-normalized gene expression"
     ) +
+    # remove axis numbers and background grid
+    scale_x_continuous(labels = NULL, breaks = NULL) + 
+    scale_y_continuous(labels = NULL, breaks = NULL) + 
     theme(legend.position = "bottom", 
           axis.text = element_text(size = 8, color = "black"),
           axis.title = element_text(size = 8, color = "black"),
           strip.text = element_text(size = 8),
-          strip.background = element_rect(fill = 'transparent'),
           legend.title = element_text(size = 8),
-          legend.text = element_text(size = 8)) + 
+          legend.text = element_text(size = 8)) +
     guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
   
 } else {

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -12,6 +12,7 @@ scater::plotUMAP(processed_sce,
   # remove axis numbers and background grid
   scale_x_continuous(labels = NULL, breaks = NULL) + 
   scale_y_continuous(labels = NULL, breaks = NULL) + 
+  coord_fixed() + 
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
   )
@@ -24,7 +25,7 @@ The genes chosen for plotting are the 12 most variable genes identified in the l
 Gene symbols are used when available to label the UMAP plots.
 If gene symbols are not available, the Ensembl id will be shown.
 
-```{r message=FALSE, results='asis'}
+```{r message=FALSE, results='asis', fig.height = 8}
 # only create plot if variable genes are present
 if (!is.null(processed_meta$highly_variable_genes)) {
   
@@ -85,11 +86,11 @@ if (!is.null(processed_meta$highly_variable_genes)) {
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) + 
     scale_y_continuous(labels = NULL, breaks = NULL) + 
+    coord_fixed() + 
     theme(legend.position = "bottom", 
-          axis.text = element_text(size = 8, color = "black"),
           axis.title = element_text(size = 8, color = "black"),
           strip.text = element_text(size = 8),
-          legend.title = element_text(size = 8),
+          legend.title = element_text(size = 9),
           legend.text = element_text(size = 8)) +
     guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
   


### PR DESCRIPTION
Closes #336 

This PR updates the QC report to have a bit more information about CITEseq post-processing. There wasn't much that really needed to be done it seemed in the end? I've done where what I think is the minimum we need (note one `TODO` comment in the `qc_report.rmd` file which is a question for reviewers!), but we could add more details, for example, maybe the number of cells removed based on RNA info vs. ADT info. Any recommendations for other stats to include would be helpful! Tagging a couple people for review to crowd source any other ideas for info to include.

While I was here, I also fixed a couple things..
- The `scpca_filter` column is present in both `_filtered` and `_processed` RDS files, so we remove a bit of wrangling
- I cleaned up a couple spacing around parentheses for styling 
- I tweaked, in line 444 of `qc_report.rmd`, a phrase that I think should not be there - I deleted the bit "calculated by `miQC`", since we then proceed to explain that maybe it wasn't calculated by miQC! Was this a good move on my part?

When testing this, I found that running `nextflow` with `-resume` did not want to use the updated rmds (is the `template` directory not copied over fresh, I wonder? any insights as to why `nextflow` didn't want to use? i wasn't pulling anything fresh from git, just running `main.nf`...). So, I just locally knitted with whatever package versions I have, which is maybe why we have the warning on top, unless we do need to update the `mutate()` code there. Local knitting is definitely responsible for the title though! Here's the report now:  
[qc_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/11618036/qc_report.html.zip)
