### PR TITLE
Check index paths match when skipping mapping for all mapping steps

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -144,7 +144,7 @@ workflow map_quant_feature{
            it}
       .branch{
           has_rad: (!params.repeat_mapping
-                    && file("${it.feature_rad_dir}/map.rad").exists()
+                    && file(it.feature_rad_dir).exists()
                     && Utils.getMetaVal(file("${it.feature_rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                     )
           make_rad: true

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -143,7 +143,10 @@ workflow map_quant_feature{
            it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
            it}
       .branch{
-          has_rad: !params.repeat_mapping && file(it.feature_rad_dir).exists()
+          has_rad: (!params.repeat_mapping
+                    && file(it.feature_rad_dir).exists()
+                    && Utils.getMetaVal(file("${it.feature_rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                    )
           make_rad: true
        }
 

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -144,7 +144,7 @@ workflow map_quant_feature{
            it}
       .branch{
           has_rad: (!params.repeat_mapping
-                    && file(it.feature_rad_dir).exists()
+                    && file("${it.feature_rad_dir}/map.rad").exists()
                     && Utils.getMetaVal(file("${it.feature_rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                     )
           make_rad: true

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -112,8 +112,7 @@ workflow map_quant_rna {
       .branch{
           has_rad: (!params.repeat_mapping
                     && file(it.rad_dir).exists()
-                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
-                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "t2g_3col_path") == "${it.t2g_3col_path}"
+                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "salmon_splici_index") == "${it.salmon_splici_index}"
                     )
           make_rad: true
        }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -111,7 +111,7 @@ workflow map_quant_rna {
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_rad: (!params.repeat_mapping
-                    && file(it.rad_dir).exists()
+                    && file("${it.rad_dir}/map.rad").exists()
                     && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                     )
           make_rad: true

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -111,7 +111,7 @@ workflow map_quant_rna {
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_rad: (!params.repeat_mapping
-                    && file("${it.rad_dir}/map.rad").exists()
+                    && file(it.rad_dir).exists()
                     && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                     )
           make_rad: true

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -110,7 +110,11 @@ workflow map_quant_rna {
            it}
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
-          has_rad: !params.repeat_mapping && file(it.rad_dir).exists()
+          has_rad: (!params.repeat_mapping
+                    && file(it.rad_dir).exists()
+                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "t2g_3col_path") == "${it.t2g_3col_path}"
+                    )
           make_rad: true
        }
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -112,7 +112,8 @@ workflow map_quant_rna {
       .branch{
           has_rad: (!params.repeat_mapping
                     && file(it.rad_dir).exists()
-                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "salmon_splici_index") == "${it.salmon_splici_index}"
+                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "t2g_3col_path") == "${it.t2g_3col_path}"
                     )
           make_rad: true
        }

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -113,7 +113,6 @@ workflow map_quant_rna {
           has_rad: (!params.repeat_mapping
                     && file(it.rad_dir).exists()
                     && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
-                    && Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "t2g_3col_path") == "${it.t2g_3col_path}"
                     )
           make_rad: true
        }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -123,7 +123,8 @@ workflow bulk_quant_rna {
           .branch{
               has_quants: (!params.repeat_mapping
                            && file(it.salmon_results_dir).exists()
-                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "salmon_bulk_index") == "${it.salmon_bulk_index}"
+                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "t2g_bulk_path") == "${it.t2g_bulk_path}"
                           )
               make_quants: true
           }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -123,8 +123,7 @@ workflow bulk_quant_rna {
           .branch{
               has_quants: (!params.repeat_mapping
                            && file(it.salmon_results_dir).exists()
-                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
-                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "t2g_bulk_path") == "${it.t2g_bulk_path}"
+                           && Utils.getMetaVal(file("${it.salmon_results_dir}/scpca-meta.json"), "salmon_bulk_index") == "${it.salmon_bulk_index}"
                           )
               make_quants: true
           }

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -20,7 +20,7 @@ workflow genetic_demux_vireo{
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_demux: (!params.repeat_genetic_demux
-                      && file("${it.vireo_dir}/donor_ids.tsv").exists()
+                      && file(it.vireo_dir).exists()
                       && Utils.getMetaVal(file("${it.vireo_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                      )
           make_demux: true

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -21,7 +21,7 @@ workflow genetic_demux_vireo{
       .branch{
           has_demux: (!params.repeat_genetic_demux
                       && file(it.vireo_dir).exists()
-                      && Utils.getMetaVal(file("${it.vireo_dir}/scpca-meta.json"), "star_index") == "${it.star_index}"
+                      && Utils.getMetaVal(file("${it.vireo_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                      )
           make_demux: true
        }

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -20,7 +20,7 @@ workflow genetic_demux_vireo{
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_demux: (!params.repeat_genetic_demux
-                      && file(it.vireo_dir).exists()
+                      && file("${it.vireo_dir}/donor_ids.tsv").exists()
                       && Utils.getMetaVal(file("${it.vireo_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                      )
           make_demux: true

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -19,7 +19,10 @@ workflow genetic_demux_vireo{
            it}
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
-          has_demux: !params.repeat_genetic_demux && file(it.vireo_dir).exists()
+          has_demux: (!params.repeat_genetic_demux
+                      && file(it.vireo_dir).exists()
+                      && Utils.getMetaVal(file("${it.vireo_dir}/scpca-meta.json"), "star_index") == "${it.star_index}"
+                     )
           make_demux: true
        }
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -118,7 +118,7 @@ workflow spaceranger_quant{
                it}
           .branch{
             has_spatial: (!params.repeat_mapping
-                          && file(it.spaceranger_results_dir).exists()
+                          && file("${it.spaceranger_results_dir}/outs").exists()
                           && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                          )
             make_spatial: true

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -119,7 +119,7 @@ workflow spaceranger_quant{
           .branch{
             has_spatial: (!params.repeat_mapping
                           && file(it.spaceranger_results_dir).exists()
-                          && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "cellranger_index") == "${it.cellranger_index}"
+                          && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                          )
             make_spatial: true
            }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -117,7 +117,10 @@ workflow spaceranger_quant{
                it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
                it}
           .branch{
-            has_spatial: !params.repeat_mapping & file(it.spaceranger_results_dir).exists()
+            has_spatial: (!params.repeat_mapping
+                          && file(it.spaceranger_results_dir).exists()
+                          && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                         )
             make_spatial: true
            }
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -119,7 +119,7 @@ workflow spaceranger_quant{
           .branch{
             has_spatial: (!params.repeat_mapping
                           && file(it.spaceranger_results_dir).exists()
-                          && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
+                          && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "cellranger_index") == "${it.cellranger_index}"
                          )
             make_spatial: true
            }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -118,7 +118,7 @@ workflow spaceranger_quant{
                it}
           .branch{
             has_spatial: (!params.repeat_mapping
-                          && file("${it.spaceranger_results_dir}/outs").exists()
+                          && file(it.spaceranger_results_dir).exists()
                           && Utils.getMetaVal(file("${it.spaceranger_results_dir}/scpca-meta.json"), "ref_assembly") == "${it.ref_assembly}"
                          )
             make_spatial: true


### PR DESCRIPTION
Closes #302 

This adds a check to all places where we skip mapping for the path of the reference to be the same as what's present in the `scpca-meta.json` file. I added this to the af-rna, af-feature, genetic demux workflow, and spaceranger. I also modified what was in the bulk workflow to look specifically for the index path rather than the assembly name and tx2gene file path. 

The only one that still checks for the reference name is the `af-feature`, since we create the index uniquely for each of those and the path to the index is not written out as part of `scpca-meta.json`. 