### PR TITLE
Rename CITEseq to adt

### DIFF
--- a/bin/filter_sce_rds.R
+++ b/bin/filter_sce_rds.R
@@ -42,7 +42,7 @@ option_list <- list(
   make_option(
     opt_str = c("--adt_name"),
     type = "character",
-    default = "CITEseq",
+    default = "adt",
     help = "Name for the alternative experiment, if present, that contains ADT features"
   ),
   make_option(

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -23,7 +23,7 @@ option_list <- list(
   make_option(
     opt_str = c("--adt_name"),
     type = "character",
-    default = "CITEseq",
+    default = "adt",
     help = "Name for the alternative experiment, if present, that contains ADT features"
   ),
   make_option(

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -46,7 +46,9 @@ process make_merged_unfiltered_sce{
         // add feature metadata as an element of the main meta object
         meta['feature_type'] = feature_meta.technology.split('_')[0]
         meta['feature_meta'] = feature_meta
-
+        
+        // If feature_type is "CITEseq", make it "adt"
+        meta['feature_type'] = meta['feature_type'] == "CITEseq" ? "adt":meta['feature_type']
 
         """
         generate_unfiltered_sce.R \
@@ -82,10 +84,10 @@ process filter_sce{
         filtered_rds = "${meta.library_id}_filtered.rds"
 
         // Three checks for whether we have ADT data:
-        // - technology should be CITEseq
+        // - technology should be adt
         // - barcode file should exist
         // - barcode file should _not_ be the empty file NO_FILE.txt
-        adt_present = meta.feature_type == 'CITEseq' &
+        adt_present = meta.feature_type == 'adt' &
           feature_barcode_file.exists() &
           feature_barcode_file.name != "NO_FILE.txt"
 
@@ -217,6 +219,7 @@ workflow generate_merged_sce {
     feature_sce_ch = feature_quant_channel
       // RNA meta is in the third slot here
       .map{it.toList() + [file(it[2].mito_file), file(it[2].ref_gtf)]}
+
 
     make_merged_unfiltered_sce(feature_sce_ch)
 

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -220,7 +220,6 @@ workflow generate_merged_sce {
       // RNA meta is in the third slot here
       .map{it.toList() + [file(it[2].mito_file), file(it[2].ref_gtf)]}
 
-
     make_merged_unfiltered_sce(feature_sce_ch)
 
     // append the feature barcode file

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -48,7 +48,9 @@ process make_merged_unfiltered_sce{
         meta['feature_meta'] = feature_meta
         
         // If feature_type is "CITEseq", make it "adt"
-        meta['feature_type'] = meta['feature_type'] == "CITEseq" ? "adt":meta['feature_type']
+        if (meta['feature_type'] == "CITEseq") {
+          meta['feature_type'] = "adt"
+        }
 
         """
         generate_unfiltered_sce.R \

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -1,5 +1,7 @@
 # CITE-seq Experiment Summary
 
+This section details quality control statistics from the ADT (antibody-derived tag) component of CITE-seq experiments.
+
 ## CITE-seq Statistics
 
 ```{r}
@@ -13,9 +15,9 @@ cell_adt_counts <- Matrix::colSums(counts(cite_exp))
 cite_information <- tibble::tibble(
   "Number of ADTs assayed" = 
     format(nrow(cite_exp), big.mark = ',', scientific = FALSE),
-  "CITE-seq reads sequenced" = 
+  "Number of reads sequenced" = 
     format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
-  "Percent CITE-seq reads mapped to ADTs" = 
+  "Percent reads mapped to ADTs" = 
     paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%"),
   "Percent of ADTs in cells" = 
     paste0(round(sum(cell_adt_counts)/cite_meta$mapped_reads * 100, digits = 2), "%"),
@@ -33,7 +35,7 @@ knitr::kable(cite_information, align = 'r') |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-## Antibody Derived Tag Statistics 
+## Antibody-Derived Tag Statistics 
 ```{r}
 antibody_tags <- as.data.frame(rowData(cite_exp)) |>
   tibble::rownames_to_column("Antibody") |>
@@ -48,6 +50,4 @@ knitr::kable(antibody_tags, digits = 2) |>
                             position = "left",
                             ) |>
   kableExtra::column_spec(2:3, monospace = TRUE) 
-  
 ```
-

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -6,21 +6,21 @@ This section details quality control statistics from the ADT (antibody-derived t
 
 ```{r}
 # add rowData if missing
-if (is.null(rowData(cite_exp)$detected)){
-  cite_exp <- scuttle::addPerFeatureQCMetrics(cite_exp)
+if (is.null(rowData(adt_exp)$detected)){
+  adt_exp <- scuttle::addPerFeatureQCMetrics(adt_exp)
 }
 
-cell_adt_counts <- Matrix::colSums(counts(cite_exp))
+cell_adt_counts <- Matrix::colSums(counts(adt_exp))
 
-cite_information <- tibble::tibble(
+adt_information <- tibble::tibble(
   "Number of ADTs assayed" = 
-    format(nrow(cite_exp), big.mark = ',', scientific = FALSE),
+    format(nrow(adt_exp), big.mark = ',', scientific = FALSE),
   "Number of reads sequenced" = 
-    format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
+    format(adt_meta$total_reads, big.mark = ',', scientific = FALSE),
   "Percent reads mapped to ADTs" = 
-    paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%"),
+    paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%"),
   "Percent of ADTs in cells" = 
-    paste0(round(sum(cell_adt_counts)/cite_meta$mapped_reads * 100, digits = 2), "%"),
+    paste0(round(sum(cell_adt_counts)/adt_meta$mapped_reads * 100, digits = 2), "%"),
   "Percent of cells with ADTs" = 
     paste0(round(sum(cell_adt_counts > 0)/length(cell_adt_counts) * 100, digits = 2), "%"),
   "Median ADT UMIs per cell" = 
@@ -28,7 +28,7 @@ cite_information <- tibble::tibble(
   )|>
   t()
 
-knitr::kable(cite_information, align = 'r') |>
+knitr::kable(adt_information, align = 'r') |>
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
                             position = "left") |>
@@ -37,7 +37,7 @@ knitr::kable(cite_information, align = 'r') |>
 
 ## Antibody-Derived Tag Statistics 
 ```{r}
-antibody_tags <- as.data.frame(rowData(cite_exp)) |>
+antibody_tags <- as.data.frame(rowData(adt_exp)) |>
   tibble::rownames_to_column("Antibody") |>
   arrange(desc(mean)) |>
   select("Antibody",

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -78,8 +78,8 @@ if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
 ## Check for additional modalities
 modalities <- c("RNA-seq")
 
-has_cite <- "adt" %in% altExpNames(filtered_sce)
-if (has_cite){
+has_adt <- "adt" %in% altExpNames(filtered_sce)
+if (has_adt){
   modalities <- c(modalities, "ADT")
 }
 
@@ -136,23 +136,23 @@ sample_information <- tibble::tibble(
     format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE),
   "Number of genes assayed" = 
     format(nrow(unfiltered_sce), big.mark = ',', scientific = FALSE),
-  "RNA-seq reads sequenced" = 
+  "Number of RNA-seq reads sequenced" = 
     format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
-  "Percent RNA-seq reads mapped to transcripts" = 
+  "Percent of RNA-seq reads mapped to transcripts" = 
     paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%")
 )
-if (has_cite){
-  cite_exp <- altExp(filtered_sce, "adt")
-  cite_meta <- metadata(cite_exp)
+if (has_adt){
+  adt_exp <- altExp(filtered_sce, "adt")
+  adt_meta <- metadata(adt_exp)
   
   sample_information <- sample_information |>
     mutate(
-      "Number of ADTs assayed" = 
-        format(nrow(cite_exp), big.mark = ',', scientific = FALSE),
-      "ADT reads sequenced" = 
-        format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
-      "Percent reads mapped to ADTs" = 
-        paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%")
+      "Number of antibodies assayed" = 
+        format(nrow(adt_exp), big.mark = ',', scientific = FALSE),
+      "Number of ADT reads sequenced" = 
+        format(adt_meta$total_reads, big.mark = ',', scientific = FALSE),
+      "Percent of ADT reads mapped to ADTs" = 
+        paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%")
     )
 }
 if (has_cellhash){
@@ -163,7 +163,7 @@ if (has_cellhash){
     mutate(
       "Number of HTOs assayed" = 
         format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
-      "Multiplex reads sequenced" = 
+      "Number of multiplex reads sequenced" = 
         format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
       "Percent of multiplex reads mapped to HTOs" = 
         paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%")
@@ -478,7 +478,7 @@ The raw counts from all cells that remain after filtering low quality cells are 
 ```
 
 <!-- Next section included only if CITE-seq data is present -->
-```{r, child='cite_qc.rmd', eval = has_cite}
+```{r, child='cite_qc.rmd', eval = has_adt}
 ```
 
 <!-- Next section only included if multiplex data is present --> 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -78,9 +78,9 @@ if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
 ## Check for additional modalities
 modalities <- c("RNA-seq")
 
-has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
+has_cite <- "adt" %in% altExpNames(filtered_sce)
 if (has_cite){
-  modalities <- c(modalities, "CITE-seq")
+  modalities <- c(modalities, "ADT")
 }
 
 # check for cellhash to add to list of modalities
@@ -142,16 +142,16 @@ sample_information <- tibble::tibble(
     paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%")
 )
 if (has_cite){
-  cite_exp <- altExp(filtered_sce, "CITEseq")
+  cite_exp <- altExp(filtered_sce, "adt")
   cite_meta <- metadata(cite_exp)
   
   sample_information <- sample_information |>
     mutate(
       "Number of ADTs assayed" = 
         format(nrow(cite_exp), big.mark = ',', scientific = FALSE),
-      "CITE-seq reads sequenced" = 
+      "ADT reads sequenced" = 
         format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
-      "Percent CITE-seq reads mapped to ADTs" = 
+      "Percent reads mapped to ADTs" = 
         paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%")
     )
 }
@@ -443,7 +443,7 @@ if(has_filtered & has_processed){
   filtered_coldata_df <- colData(filtered_sce) |>
     as.data.frame() |>
     tibble::rownames_to_column("barcode") |>
-    dplyr::mutate(scpca_filter = ifelse(barcode %in%  colnames(processed_sce), 
+    dplyr::mutate(scpca_filter = ifelse(barcode %in% colnames(processed_sce), 
                                        "Keep", 
                                        "Remove")) 
   

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -163,9 +163,9 @@ if (has_cellhash){
     mutate(
       "Number of HTOs assayed" = 
         format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
-      "Number of multiplex reads sequenced" = 
+      "Number of cellhash reads sequenced" = 
         format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
-      "Percent of multiplex reads mapped to HTOs" = 
+      "Percent of cellhash reads mapped to HTOs" = 
         paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%")
     )
 }


### PR DESCRIPTION
**Stacked on #345**

This PR updates the workflow to use `adt` as the CITEseq name, not `CITEseq`, which involved a bit of R and a bit of groovy (....gRoovy? sorry.). I decided to change the `feature_type` variable we have floating around in the meta list/dictionary/whatever it technically is called, and this information will just flow forward with updated R option defaults. 

All tested and runs through with final `_filtered.rds` & `_processed.rds` looking as expected!
