### PR TITLE
Fix metadata `has_citeseq` bug

### DIFF
--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -156,7 +156,7 @@ if (!is.null(sce_meta$library_id)){
 
 # check for alt experiments (CITE-seq, etc)
 alt_expts <- altExpNames(unfiltered_sce)
-has_citeseq <- "CITEseq" %in% alt_expts
+has_citeseq <- "adt" %in% alt_expts
 has_cellhash <- "cellhash" %in% alt_expts
 
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -88,6 +88,12 @@ option_list <- list(
     help = "workflow commit hash"
   ),
   make_option(
+    opt_str = c("--adt_name"),
+    type = "character",
+    default = "adt",
+    help = "Name for the alternative experiment, if present, that contains ADT features"
+  ),
+  make_option(
     opt_str = "--demux_method",
     type = "character",
     default = "vireo",
@@ -156,7 +162,7 @@ if (!is.null(sce_meta$library_id)){
 
 # check for alt experiments (CITE-seq, etc)
 alt_expts <- altExpNames(unfiltered_sce)
-has_citeseq <- "adt" %in% alt_expts
+has_citeseq <- opt$adt_name %in% alt_expts
 has_cellhash <- "cellhash" %in% alt_expts
 
 

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -31,7 +31,8 @@ process sce_qc_report{
           --genome_assembly "${meta.ref_assembly}" \
           --workflow_url "${workflow_url}" \
           --workflow_version "${workflow_version}" \
-          --workflow_commit "${workflow.commitId}"
+          --workflow_commit "${workflow.commitId}" \
+          --adt_name ${meta.feature_type}
         """
     stub:
         qc_report = "${meta.library_id}_qc.html"


### PR DESCRIPTION
Earlier today, I noticed that some samples were outputting `has_cite` to be False in the metadata TSV even though I knew cite-seq was there! I mentioned it to Ally, who pointed out that indeed it said `has_cite` was True, and she was right! Alas, I had confused myself - the portal is fine (metadata from which I sent her), but the pipeline is not. I have now gotten back on track to fix this.

In #348 we changed `"CITEseq"` --> `"adt"` for the altExp name, but we missed a spot, which was leading to wrong metadata outputs! Here, I've updated `bin/sce_qc_report.R` to take in the altexp name from an `optparse` argument, with `"adt"` as the default, as we have done previously, e.g. - 
https://github.com/AlexsLemonade/scpca-nf/blob/19722f43c8b5dd8ebacd0b3202ebee0b0a18ce90/bin/post_process_sce.R#L23-L28
https://github.com/AlexsLemonade/scpca-nf/blob/19722f43c8b5dd8ebacd0b3202ebee0b0a18ce90/modules/sce-processing.nf#L182

Note that the most recent commit says "untested" but it has now been tested and works as expected.