### PR TITLE
Really use the QC report template

### DIFF
--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -161,7 +161,6 @@ has_cellhash <- "cellhash" %in% alt_expts
 
 
 metadata_list <- list(
-  report_template = opt$report_template,
   library_id = opt$library_id,
   sample_id = opt$sample_id,
   technology = opt$technology,
@@ -220,6 +219,7 @@ if (multiplexed) {
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE, pretty = TRUE)
 
 scpcaTools::generate_qc_report(
+  report_template = opt$report_template,
   library_id = metadata_list$library_id,
   unfiltered_sce = unfiltered_sce,
   filtered_sce = filtered_sce,

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.2.1'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'


### PR DESCRIPTION
Apparently the last time I said I was adding the QC template, I added a line to the wrong place. This moves it to what should be the right place (and changes `scpcaTools` to `edge` for testing).