### PR TITLE
Some QC report tweaks

### DIFF
--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -68,9 +68,9 @@ if (has_processed) {
     "Number of cells that pass filtering threshold"  = format(filtered_cell_count),
     "Percent of cells that pass filtering threshold" =
         paste0(round(filtered_cell_count/nrow(processed_sce) * 100, digits = 2), "%"), 
-    "Normalization method" = format(processed_meta$adt_normalization)
+    "Normalization method" = format(processed_meta$adt_normalization) 
     ) |>
-    mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
+    reformat_nulls() |>
     t()
   
   knitr::kable(basic_statistics, align = 'r') |>

--- a/templates/qc_report/multiplex_qc.rmd
+++ b/templates/qc_report/multiplex_qc.rmd
@@ -53,7 +53,7 @@ knitr::kable(hto_tags, digits = 2) |>
 
 ## Demultiplexing Sample Calls 
 
-Demultiplexing was performed using both [DropletUtils::hashedDrops](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [Seurat::HTOdemux](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
+Demultiplexing was performed using both [`DropletUtils::hashedDrops()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [`Seurat::HTOdemux()`](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
 
 For multiplex libraries where bulk RNA-seq data is available for the individual samples, we also performed demultiplexing analysis using genotype data following the methods described in [Weber _et al._ (2021)](https://doi.org/10.1093/gigascience/giab062). 
 The genetic demultiplexing results are reported under the `vireo` column in the below table.   

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -36,6 +36,13 @@ theme_set(
   theme(plot.margin = margin(rep(20, 4)), 
         strip.background = element_rect(fill = 'transparent'))
 )
+
+# Helper function to change NULL -> "N/A" in a data frame
+reformat_nulls <- function(df) {
+  df |>
+    mutate(across(everything(), 
+                  .fns = ~ifelse(.x == "NULL", "N/A", .x))) 
+}
 ```
 
 ```{r sce_setup}
@@ -177,7 +184,7 @@ if (has_cellhash) {
 }
 
 sample_information <- sample_information |>
-  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
+  reformat_nulls() |>
   t()
 
 # make table with sample information
@@ -205,7 +212,7 @@ processing_info <- tibble::tibble(
       transcript_type == "spliced" ~ "Spliced only",
       TRUE ~ transcript_type)
   ) |>
-  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |>
+  reformat_nulls() |>
   t()
 
 
@@ -251,7 +258,7 @@ if (has_processed) {
 }
 
 basic_statistics <- basic_statistics |>
-  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
+  reformat_nulls() |> # reformat nulls
   t()
 
 # make table with basic statistics
@@ -338,7 +345,7 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
   geom_point(mapping = aes(x = rank, y = sum, color = filter_pct),
              data = top_celldata,
              alpha = 0.5) +
-  geom_line(size = 2, lineend = "round", linejoin= "round") +
+  geom_line(linewidth = 2, lineend = "round", linejoin= "round") +
   scale_x_log10(labels = scales::label_number(accuracy = 1)) +
   scale_y_log10(labels = scales::label_number(accuracy = 1)) +
   scale_color_gradient2(low = "grey70",
@@ -352,7 +359,7 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
   ) +
   theme(legend.position = c(0, 0),
         legend.justification = c(0,0),
-        legend.background = element_rect(color = "grey20", size = 0.25),
+        legend.background = element_rect(color = "grey20", linewidth = 0.25),
         legend.box.margin = margin(rep(5, 4)))
 ```
 
@@ -379,11 +386,11 @@ ggplot(filtered_celldata,
        color = "Percent reads\nmitochondrial") +
   theme(legend.position = c(0, 1),
         legend.justification = c(0,1),
-        legend.background = element_rect(color = "grey20", size = 0.25),
+        legend.background = element_rect(color = "grey20", linewidth = 0.25),
         legend.box.margin = margin(rep(5, 4)))
 ```
 
-The above plot of cell metrics includes only droplets which have passed the `emptyDrops()` filter.
+The above plot of cell metrics includes only droplets which have passed the `emptyDropsCellRanger()` filter.
 The plot will usually display a strong (but curved) relationship between the total UMI count and the number of genes detected.
 Cells with low UMI counts and high mitochondrial percentages may require further filtering.
 
@@ -411,7 +418,7 @@ if (skip_miQC) {
          y = "Percent reads mitochondrial") +
     theme(legend.position = c(1, 1),
           legend.justification = c(1,1),
-          legend.background = element_rect(color = "grey20", size = 0.25),
+          legend.background = element_rect(color = "grey20", linewidth = 0.25),
           legend.box.margin = margin(rep(5, 4)))
 }
 ```
@@ -459,7 +466,7 @@ if (has_filtered & has_processed) {
     theme(plot.title = element_text(hjust = 0.5),
           legend.position = c(1, 1),
           legend.justification = c(1,1),
-          legend.background = element_rect(color = "grey20", size= 0.25),
+          legend.background = element_rect(color = "grey20", linewidth = 0.25),
           legend.title = element_text(hjust = 0.5))
 } else {
   glue::glue("

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -88,7 +88,7 @@ if (!is.null(processed_meta$highly_variable_genes)) {
     scale_y_continuous(labels = NULL, breaks = NULL) + 
     coord_fixed() + 
     theme(legend.position = "bottom", 
-          axis.title = element_text(size = 8, color = "black"),
+          axis.title = element_text(size = 9, color = "black"),
           strip.text = element_text(size = 8),
           legend.title = element_text(size = 9),
           legend.text = element_text(size = 8)) +


### PR DESCRIPTION
This PR cleans up some aspects of the QC report that I noticed (some choices I made are open for discussion!) - 

- I dealt with deprecation warnings. (did I deprecate the deprecation warnings? you decide!)
  - There are two warnings we get from `tidyverse` - use of `dplyr::across` now needs a `.cols` argument, and in `ggplot2` the `size` aesthetic is being deprecated in favor of `linewidth`. 
  - Rather than turning warnings off, I just went ahead and updated the code. 
  - As part of this, I wrote a little helper function `reformat_nulls()`, which uses `across()`, to make code a bit easier to maintain and work with. I did some testing and it works fine as expected.
- I added some backticks where they were missing around function names written in the text in the multiplex rmd
- I rephrased `emptyDrops()` -> `emptyDropsCellRanger()` as that is what we use
- One plot size tweak for fun.

Here's the current QC report for a multiplex library. Have a look also at the plot rendered for UMAPs, where we can see an example of UMAPs where the overall plot ends up very vertical as consequence of `coord_fixed()`, which doesn't seem like a problem to me since the coordinates are what the coordinates are! Just wanted to make sure folks have a sense of how `coord_fixed()` is ending up for a different dataset.
[qc_report.html.txt](https://github.com/AlexsLemonade/scpca-nf/files/11917679/qc_report.html.txt)
