### PR TITLE
Update version string in instructions and config

### DIFF
--- a/external-instructions.md
+++ b/external-instructions.md
@@ -65,7 +65,7 @@ nextflow run AlexsLemonade/scpca-nf \
 ```
 
 Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
-This command will pull the `scpca-nf` workflow directly from Github, using the `v0.5.1` version, and run it based on the settings in the configuration file that you have defined.
+This command will pull the `scpca-nf` workflow directly from Github, using the `v0.5.2` version, and run it based on the settings in the configuration file that you have defined.
 
 **Note:** `scpca-nf` is under active development.
 Using the above command will run the workflow from the `main` branch of the workflow repository.
@@ -76,7 +76,7 @@ Released versions can be found on the [`scpca-nf` repo releases page](https://gi
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.5.1 \
+  -r v0.5.2 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -280,7 +280,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.5.1`, then you will want to set `-r v0.5.1` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.5.2`, then you will want to set `-r v0.5.2` for `get_refs.py` as well to be sure you have the correct containers.
 Be default,  `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -33,7 +33,7 @@ nextflow run AlexsLemonade/scpca-nf -profile ccdl,batch
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.5.1 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.5.2 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest{
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.5.1'
+  version = 'v0.5.2'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
Towards #354 

This PR updates version strings in the places it needs to be updated.

Some `grep` confirmation - 
```
» grep -r "v0\.5\.1" .    # no output!

» grep -r "v0\.5\.2" .      
./internal-instructions.md:nextflow run AlexsLemonade/scpca-nf -r v0.5.2 -profile ccdl,batch --project SCPCP000000
./external-instructions.md:This command will pull the `scpca-nf` workflow directly from Github, using the `v0.5.2` version, and run it based on the settings in the configuration file that you have defined.
./external-instructions.md:  -r v0.5.2 \
./external-instructions.md:For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.5.2`, then you will want to set `-r v0.5.2` for `get_refs.py` as well to be sure you have the correct containers.
./nextflow.config:  version = 'v0.5.2'
```