### PR TITLE
Only use `label.ont` in SingleR workflow

### DIFF
--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -111,17 +111,13 @@ singler_model <- SingleR::trainSingleR(
 
 # If the label is `label.ont` (default), save corresponding cell label names
 if (label_col == "label.ont") {
-  cl_ont <- ontoProc::getCellOnto()
+  cl_ont <- ontoProc::getOnto("cellOnto")
 
-  # grab ontology ids from singler_model which are stored as
-  # `original.exprs` names (`original.exprs` itself is an empty list)
-  ontology_ids <- names(singler_model$original.exprs)
+  # grab ontology ids from singler_model
+  ontology_ids <- singler_model$labels$unique
 
   # grab corresponding cell names
-  cell_names <- purrr::map(
-    ontology_ids,
-    \(cl_id) cl_ont$name[cl_id]
-  ) |> unlist()
+  cell_names <- cl_ont$name[ontology_ids]
 
   # save data frame with _matching_ ontology ids and cell names to model object
   # use tibble to avoid rownames

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -2,6 +2,7 @@
 nextflow.enable.dsl=2
 
 params.t2g_3col_path = "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
+params.
 
 process train_singler_models {
   container params.SCPCATOOLS_CONTAINER
@@ -20,6 +21,7 @@ process train_singler_models {
       --ref_file ${celltype_ref} \
       --output_file ${celltype_model} \
       --fry_tx2gene ${tx2gene} \
+      --label_name ${params.label_name} \
       --seed ${params.seed} \
       --threads ${task.cpus}
     """

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -2,7 +2,6 @@
 nextflow.enable.dsl=2
 
 params.t2g_3col_path = "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
-params.
 
 process train_singler_models {
   container params.SCPCATOOLS_CONTAINER

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.2.2'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -15,6 +15,10 @@ params{
   // cell type references and SingleR label of interest
   celltype_refs_metafile = "s3://ccdl-scpca-data/sample_info/celltype_annotation/scpca-project-celltype-metadata.tsv"
   label_name = "label.ont"
+  
+  // output directory for cell type references
+  celltype_ref_dir = "s3://scpca-references/celltype/singler_models"
+  
 
   // Private CCDL containers
   CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -12,8 +12,9 @@ params{
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"
 
-  // cell type references
+  // cell type references and SingleR label of interest
   celltype_refs_metafile = "s3://ccdl-scpca-data/sample_info/celltype_annotation/scpca-project-celltype-metadata.tsv"
+  label_name = "label.ont"
 
   // Private CCDL containers
   CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -15,10 +15,7 @@ params{
   // cell type references and SingleR label of interest
   celltype_refs_metafile = "s3://ccdl-scpca-data/sample_info/celltype_annotation/scpca-project-celltype-metadata.tsv"
   label_name = "label.ont"
-  
-  // output directory for cell type references
-  celltype_ref_dir = "s3://scpca-references/celltype/singler_models"
-  
+
 
   // Private CCDL containers
   CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -7,5 +7,5 @@ ref_rootdir  = 's3://scpca-references'
 barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
 
 // cell type references
-celltype_ref_dir = "${params.ref_rootdir}/celltype/references"
-celltype_model_dir = "${params.ref_rootdir}/celltype/singler_models"
+celltype_ref_dir = "${params.ref_rootdir}/celltype/references" // original (generally celldex) files themselves
+celltype_model_dir = "${params.ref_rootdir}/celltype/singler_models" // models build from original (celldex) files


### PR DESCRIPTION
Closes #380

This PR updates the `build-celltype-ref.nf` workflow to only build a model from the given `params.label_name` (default `label.ont`).  Note at one point I kept getting confused b/w two directory params, so I added some comments into `config/reference_paths.config` for my 🧠 .

I have not yet run this through to update files on `S3`, but I've tested with local output directory and it's working for me fine there!
