### PR TITLE
Use single model for celltype annotation

### DIFF
--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -23,15 +23,7 @@ option_list <- list(
   make_option(
     opt_str = c("--singler_model_file"),
     type = "character",
-    help = "path to file containing model generated for use with SingleR containing labels
-      for the given `label_name`."
-  ),
-  # TODO: do we even need this? We could check that the label is correct, but maybe unnecessary since only 1 is expected anyways
-  make_option(
-    opt_str = c("--label_name"),
-    type = "character",
-    default = "label.ont",
-    help = "name of cell type label to use for annotation in the reference dataset."
+    help = "path to file containing a single model generated for SingleR annotation"
   ),
   make_option(
     opt_str = c("--seed"),

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -80,14 +80,14 @@ singler_model <- readr::read_rds(singler_model_file)
 # SingleR classify and annotate SCE-------------------------------------------------------------
 
 singler_results <- SingleR::classifySingleR(
-  ref = singler_model,
+  trained = singler_model,
   test = sce,
   fine.tune = TRUE,
   BPPARAM = bp_param
 )
 
 # add annotations to SCE colData, simply
-sce$singler_results$pruned.labels
+sce$pruned.labels <- singler_results$pruned.labels
 
 # store full SingleR results in metadata
 metadata(sce)$singler_results <- singler_results

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -97,7 +97,8 @@ if (opt$label_name == "label.ont") {
     ) |>
     # this is the new column that was joined in with the cell names
     dplyr::rename(singler_celltype_annotation = ontology_cell_names) |>
-    DataFrame()
+    # make sure we keep rownames
+    DataFrame(row.names = colData(sce)$barcodes)
 
 
 } else {

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -128,7 +128,7 @@ if (label_col == "label.ont") {
 }
 
 # Save reference name and label to model object
-singler_model$reference_name <- stringr::str_replace(opt$ref_file, "_model.rds$", "")
+singler_model$reference_name <- stringr::str_replace(opt$output_file, "_model.rds$", "")
 singler_model$reference_label <- label_col
 
 # export models

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -123,8 +123,13 @@ if (label_col == "label.ont") {
   # use tibble to avoid rownames
   singler_model$cell_ontology_df <- tibble::tibble(
     ontology_id = names(cell_names),
-    ontology_cell_names = cell_names
+    ontology_cell_names = unname(cell_names)
   )
 }
+
+# Save reference name and label to model object
+singler_model$reference_name <- stringr::str_replace(opt$ref_file, "_model.rds$", "")
+singler_model$reference_label <- label_col
+
 # export models
 readr::write_rds(singler_model, opt$output_file)

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -15,6 +15,7 @@ process classify_singleR {
         --input_sce_file ${processed_rds} \
         --output_sce_file ${annotated_rds} \
         --singler_model_file ${singler_model_file} \
+        --label_name ${params.label_name} \
         --seed ${params.seed} \
         --threads ${task.cpus}
       """

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -36,16 +36,14 @@ workflow annotate_celltypes {
           singler_model_file = "${params.celltype_model_dir}/${it.celltype_ref_name}_model.rds"
         ]}
 
-      // create channel with grouped meta, processed sce object, and all references to use
+      // create channel grouped_celltype_ch as: [meta, processed sce object, SingleR reference model]
+      // input processed_sce_channel is [meta, unfiltered, filtered, processed]
       grouped_celltype_ch = processed_sce_channel
         .map{[it[0]["project_id"]] + it}
         .combine(celltype_ch, by: 0)
         .map{it.drop(1)} // remove extra project ID
-        .map{[
-          it[0], // meta
-          it[1], // processed rds
-          it[2] // reference model file
-        ]}
+        // creates [meta, processed, SingleR reference model]
+        .map{ it[0..2] }
 
       classify_singleR(grouped_celltype_ch)
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -18,6 +18,11 @@ process classify_singleR {
         --seed ${params.seed} \
         --threads ${task.cpus}
       """
+    stub:
+      annotated_rds = "${meta.library_id}_annotated.rds"
+      """
+      touch "${annotated_rds}"
+      """
 }
 
 workflow annotate_celltypes {

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -5,23 +5,19 @@ process classify_singleR {
     label 'cpus_4'
     publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
     input:
-        tuple val(meta), path(processed_rds), path(singler_models)
+        tuple val(meta), path(processed_rds), path(singler_model_file)
     output:
         tuple val(meta), path(annotated_rds)
     script:
       annotated_rds = "${meta.library_id}_annotated.rds"
-      singler_list = singler_models in List ? singler_models.join(',') : singler_models
       """
       classify_SingleR.R \
         --input_sce_file ${processed_rds} \
         --output_sce_file ${annotated_rds} \
-        --singler_models ${singler_list} \
+        --singler_model_file ${singler_model_file} \
         --seed ${params.seed} \
         --threads ${task.cpus}
-
       """
-
-
 }
 
 workflow annotate_celltypes {
@@ -32,9 +28,8 @@ workflow annotate_celltypes {
         .splitCsv(header: true, sep: '\t')
         .map{[
           project_id = it.scpca_project_id,
-          singler_model = "${params.celltype_model_dir}/${it.celltype_ref_name}_model.rds"
+          singler_model_file = "${params.celltype_model_dir}/${it.celltype_ref_name}_model.rds"
         ]}
-        .groupTuple(by: 0) // group by project id
 
       // create channel with grouped meta, processed sce object, and all references to use
       grouped_celltype_ch = processed_sce_channel
@@ -44,7 +39,7 @@ workflow annotate_celltypes {
         .map{[
           it[0], // meta
           it[1], // processed rds
-          it[2] // tuple of reference models
+          it[2] // reference model file
         ]}
 
       classify_singleR(grouped_celltype_ch)

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -25,7 +25,7 @@ process make_unfiltered_sce{
     stub:
         unfiltered_rds = "${meta.library_id}_unfiltered.rds"
         """
-        touch "${meta.library_id}_unfiltered.rds"
+        touch ${unfiltered_rds}
         """
 
 }
@@ -46,7 +46,7 @@ process make_merged_unfiltered_sce{
         // add feature metadata as an element of the main meta object
         meta['feature_type'] = feature_meta.technology.split('_')[0]
         meta['feature_meta'] = feature_meta
-        
+
         // If feature_type is "CITEseq", make it "adt"
         if (meta['feature_type'] == "CITEseq") {
           meta['feature_type'] = "adt"

--- a/test-celltype-metadata.tsv
+++ b/test-celltype-metadata.tsv
@@ -1,2 +1,0 @@
-scpca_project_id	celltype_ref_name	celltype_singler_file
-SCPCP000007	test-BlueprintEncodeData	celldex-BlueprintEncodeData.rds

--- a/test-celltype-metadata.tsv
+++ b/test-celltype-metadata.tsv
@@ -1,0 +1,2 @@
+scpca_project_id	celltype_ref_name	celltype_singler_file
+SCPCP000007	test-BlueprintEncodeData	celldex-BlueprintEncodeData.rds


### PR DESCRIPTION
**⚠️ Stacked on #380**
Closes #381 

This PR updates the celltype annotation workflow to only expect a single model per flow. Mostly this involved some code simplification and variable renaming for consistency with the current approach.

To run this...
- I made a dummy metadata file `test-celltype-metadata.tsv`, which I've committed here just for testing - it will need to be removed before merge!
- I copied a reference, named as described in ☝️,  that only contains `label.ont` (aka, a single set of labels generated by #380 changes) to `s3://scpca-reference/celltype/singler_models/test-BlueprintEncodeData_model.rds` for use by workflow

I ran as:
```
op run --nextflow run add-celltypes.nf -profile ccdl,batch \
  --celltype_refs_metafile /full/path/to/test-celltype-metadata.tsv \  # update your path to test!
  --run_ids SCPCL000341  # an SCPCP000007 project
```

You can see the resulting annotated RDS in `s3://scpca/processed/results/SCPCP000007/SCPCS000244/SCPCL000341_annotated.rds`, and as expected it contains the `pruned.labels` column in `colData` and the full `SingleR` output in `metadata(sce)$singler_results`.

