### PR TITLE
Generate marker gene references for CellAssign

### DIFF
--- a/bin/generate_cellassign_refs.R
+++ b/bin/generate_cellassign_refs.R
@@ -15,7 +15,7 @@ option_list <- list(
     opt_str = c("--marker_gene_file"),
     type = "character",
     help = "File containing a list of marker genes for all cell types and all organs. 
-      Must contain the `organ`, `cell_type_column` and `gene_id_column` columns. "
+      Must contain the `organ` column, `--cell_type_column` and `--gene_id_column`. "
   ),
   make_option(
     opt_str = c("--cell_type_column"),
@@ -28,17 +28,20 @@ option_list <- list(
     default = "official gene symbol"
   ),
   make_option(
-    opt_str = c("--gtf"),
+    opt_str = c("--gtf_file"),
     type = "character",
     help = "reference gtf to use"
   ),
   make_option(
-    opt_str = c("--ref_file"),
+    opt_str = c("--ref_mtx_file"),
     type = "character",
     help = "path to save reference file"
   )
 )
 
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Set up -----------------------------------------------------------------------
 
 if(!file.exists(opt$marker_gene_file)){
   stop("Provided `marker_gene_file` does not exist.")
@@ -65,23 +68,53 @@ if(!(gene_id_column %in% colnames(marker_gene_df))){
   stop("Specified `gene_id_column` does not exist as a column in `marker_gene_file`")
 }
 
+# Create marker gene matrix ----------------------------------------------------
+
+# grab marker genes for specified organs from marker gene reference
 organ_gene_df <- marker_gene_df |>
   dplyr::filter(organ %in% organs) |>
-  dplyr::select(cell_type_column, gene_id_column)
-
-# combine with ensembl gene id 
+  dplyr::select({{cell_type_column}}, {{gene_id_column}})
 
 # create a binary matrix of genes by cell type markers 
 binary_mtx <- organ_gene_df |>
-  tidyr::pivot_wider(id_cols = ensembl_id,
-                     names_from = celltype_column,
-                     values_from = celltype_column,
+  tidyr::pivot_wider(id_cols = gene_id_column,
+                     names_from = cell_type_column,
+                     values_from = cell_type_column,
                      values_fn = length,
                      values_fill = 0) |> 
-  tibble::column_to_rownames(ensembl_id) |>
+  tibble::column_to_rownames(gene_id_column) |>
   # add a column with no marker genes 
   # cell assign will assign cells to "other" when no other cell types are appropriate 
   dplyr::mutate(other = 0)
 
 # replace length with 1
 binary_mtx[binary_mtx > 1] <- 1
+
+# Add ensembl ids --------------------------------------------------------------
+
+# combine with ensembl gene id 
+# read in gtf file (genes only for speed)
+gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
+
+# create a data frame with ensembl id and gene symbol 
+gene_id_map <- gtf |>
+  as.data.frame() |>
+  dplyr::select(
+    "ensembl_id" = "gene_id",
+    "gene_symbol" = "gene_name"
+  ) |>
+  dplyr::filter(.data$gene_symbol != "NA") |>
+  dplyr::distinct() |>
+  ## in case there are any duplicate gene_ids (there shouldn't be!)
+  dplyr::group_by(.data$ensembl_id) |>
+  dplyr::summarise(gene_symbol = paste(.data$gene_symbol, collapse = ";"))
+
+# replace gene symbols with ensembl id
+binary_mtx <- binary_mtx |>
+  tibble::rownames_to_column("gene_symbol") |>
+  dplyr::left_join(gene_id_map, by = "gene_symbol") |>
+  # drop any rows where there is no ensembl id
+  tidyr::drop_na(ensembl_id) |>
+  dplyr::select(ensembl_id, everything(), -gene_symbol)
+
+readr::write_tsv(binary_mtx, opt$ref_mtx_file)

--- a/bin/generate_cellassign_refs.R
+++ b/bin/generate_cellassign_refs.R
@@ -20,12 +20,14 @@ option_list <- list(
   make_option(
     opt_str = c("--cell_type_column"),
     type = "character",
-    default = "cell type"
+    default = "cell type",
+    help = "Column name in `marker_gene_file` containing cell types."
   ),
   make_option(
     opt_str = c("--gene_id_column"),
     type = "character",
-    default = "official gene symbol"
+    default = "official gene symbol",
+    help = "Column name in `marker_gene_file` containing the gene symbols."
   ),
   make_option(
     opt_str = c("--gtf_file"),

--- a/bin/generate_cellassign_refs.R
+++ b/bin/generate_cellassign_refs.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+
+# this script is used to create binary gene x cell marker genes matrices 
+# for use as references with CellAssign
+
+library(optparse)
+
+option_list <- list(
+  make_option(
+    opt_str = c("--organs"),
+    type = "character",
+    help = "Comma separated list of organs to include in gene x cell matrix"
+  ),
+  make_option(
+    opt_str = c("--marker_gene_file"),
+    type = "character",
+    help = "File containing a list of marker genes for all cell types and all organs. 
+      Must contain the `organ`, `cell_type_column` and `gene_id_column` columns. "
+  ),
+  make_option(
+    opt_str = c("--cell_type_column"),
+    type = "character",
+    default = "cell type"
+  ),
+  make_option(
+    opt_str = c("--gene_id_column"),
+    type = "character",
+    default = "official gene symbol"
+  ),
+  make_option(
+    opt_str = c("--gtf"),
+    type = "character",
+    help = "reference gtf to use"
+  ),
+  make_option(
+    opt_str = c("--ref_file"),
+    type = "character",
+    help = "path to save reference file"
+  )
+)
+
+
+if(!file.exists(opt$marker_gene_file)){
+  stop("Provided `marker_gene_file` does not exist.")
+}
+
+marker_gene_df <- readr::read_tsv(opt$marker_gene_file)
+
+organs <- stringr::str_split(opt$organs, ",") |>
+  unlist() |>
+  stringr::str_trim()
+
+if(!all(organs %in% marker_gene_df$organ)){
+  stop("`organs` must be present in `organ` column of `marker_gene_file`.")
+}
+
+cell_type_column <- opt$cell_type_column
+gene_id_column <- opt$gene_id_column
+
+if(!(cell_type_column %in% colnames(marker_gene_df))){
+  stop("Specified `cell_type_column` does not exist as a column in `marker_gene_file`")
+}
+
+if(!(gene_id_column %in% colnames(marker_gene_df))){
+  stop("Specified `gene_id_column` does not exist as a column in `marker_gene_file`")
+}
+
+organ_gene_df <- marker_gene_df |>
+  dplyr::filter(organ %in% organs) |>
+  dplyr::select(cell_type_column, gene_id_column)
+
+# combine with ensembl gene id 
+
+# create a binary matrix of genes by cell type markers 
+binary_mtx <- organ_gene_df |>
+  tidyr::pivot_wider(id_cols = ensembl_id,
+                     names_from = celltype_column,
+                     values_from = celltype_column,
+                     values_fn = length,
+                     values_fill = 0) |> 
+  tibble::column_to_rownames(ensembl_id) |>
+  # add a column with no marker genes 
+  # cell assign will assign cells to "other" when no other cell types are appropriate 
+  dplyr::mutate(other = 0)
+
+# replace length with 1
+binary_mtx[binary_mtx > 1] <- 1

--- a/bin/generate_cellassign_refs.R
+++ b/bin/generate_cellassign_refs.R
@@ -35,7 +35,7 @@ option_list <- list(
   make_option(
     opt_str = c("--ref_mtx_file"),
     type = "character",
-    help = "path to save reference file"
+    help = "path to save reference binary matrix file"
   )
 )
 
@@ -103,11 +103,11 @@ gene_id_map <- gtf |>
     "ensembl_id" = "gene_id",
     "gene_symbol" = "gene_name"
   ) |>
-  dplyr::filter(.data$gene_symbol != "NA") |>
+  dplyr::filter(gene_symbol != "NA") |>
   dplyr::distinct() |>
   ## in case there are any duplicate gene_ids (there shouldn't be!)
-  dplyr::group_by(.data$ensembl_id) |>
-  dplyr::summarise(gene_symbol = paste(.data$gene_symbol, collapse = ";"))
+  dplyr::group_by(ensembl_id) |>
+  dplyr::summarize(gene_symbol = paste(gene_symbol, collapse = ";"))
 
 # replace gene symbols with ensembl id
 binary_mtx <- binary_mtx |>

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -60,13 +60,13 @@ process generate_cellassign_refs {
   publishDir "${params.celltype_ref_dir}/cellassign_references"
   label 'mem_8'
   input:
-    tuple val(ref_name), val(ref_database), val(organs)
+    tuple val(ref_name), val(ref_source), val(organs)
     path(marker_gene_file)
     path(ref_gtf)
   output:
     path ref_file
   script:
-    ref_file="${ref_database}-${ref_name}.tsv"
+    ref_file="${ref_source}-${ref_name}.tsv"
     """
     generate_cellassign_refs.R \
       --organs "${organs}" \
@@ -75,7 +75,7 @@ process generate_cellassign_refs {
       --ref_mtx_file ${ref_file}
     """
   stub:
-    ref_file="${ref_database}-${ref_name}.tsv"
+    ref_file="${ref_source}-${ref_name}.tsv"
     """
     touch ${ref_file}
     """

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -54,6 +54,30 @@ process train_singler_models {
     """
 }
 
+process generate_cellassign_refs {
+  container params.SCPCATOOLS_CONTAINER
+  publishDir "${params.celltype_ref_dir}/cellassign_references"
+  label 'mem_8'
+  input:
+    tuple val(ref_name), val(ref_database), val(organs)
+    path(marker_gene_file)
+  output:
+    path ref_file
+  script:
+    ref_file="${ref_database}-${ref_name}.tsv"
+    """
+    generate_cellassign_refs.R \
+      --organs "${organs}" \
+      --marker_gene_file ${marker_gene_file} \
+      --ref_file ${ref_file}
+    """
+  stub:
+    ref_file="${ref_database}-${ref_name}.tsv"
+    """
+    touch ${ref_file}
+    """
+}
+
 workflow build_celltype_ref {
 
   // create channel of cell type ref files and names

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -2,6 +2,7 @@
 nextflow.enable.dsl=2
 
 params.t2g_3col_path = "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv"
+params.ref_gtf = "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz"
 
 process save_singler_refs {
   container params.SCPCATOOLS_CONTAINER
@@ -61,6 +62,7 @@ process generate_cellassign_refs {
   input:
     tuple val(ref_name), val(ref_database), val(organs)
     path(marker_gene_file)
+    path(ref_gtf)
   output:
     path ref_file
   script:
@@ -69,7 +71,8 @@ process generate_cellassign_refs {
     generate_cellassign_refs.R \
       --organs "${organs}" \
       --marker_gene_file ${marker_gene_file} \
-      --ref_file ${ref_file}
+      --gtf_file ${ref_gtf} \
+      --ref_mtx_file ${ref_file}
     """
   stub:
     ref_file="${ref_database}-${ref_name}.tsv"
@@ -109,6 +112,9 @@ workflow build_celltype_ref {
       ref_source: it.celltype_ref_source,
       organs: it.organs
     ]}
+
+  generate_cellassign_refs(cellassign_refs_ch, params.panglao_marker_genes_file, params.ref_gtf)
+
 }
 
 workflow {


### PR DESCRIPTION
Closes #384 

This PR builds on the additions from #388 and adds in a process for creating the marker gene x cell type matrices need for `CellAssign`. 

- I created a script that takes as input a marker gene list, a list of organs, and a gtf file and outputs a binary gene x cell type matrix with ensembl ID's. I used the same method as our data integration process to create the matrix. First, I filtered the larger marker gene table by organs and then converted the resulting gene list into a binary matrix.
- I did add options to the script for the columns that contain the cell type and the gene id. In case we ever want to use a different marker table as the reference we could still use this script but change those arguments. The only thing that I don't make optional is the `organs`, because we are specifying that in the metadata table. 
- I wanted the output to contain the genes as ensembl IDs and not as human gene symbols, which is how PanglaoDB shows them. Previously, we were grabbing the ensembl IDs from the rownames of the SCE object we are annotating. Here, we want to create a single reference that can be used on all SCE objects, so I imported the `gtf` file that we use to build our reference and grab the ids from there. 
- I tested this and the new marker gene matrices are in `s3://scpca-references/celltype/cellassign_references`