### PR TITLE
Add CellAssign predictions to cell type annotation workflow

### DIFF
--- a/add-celltypes.nf
+++ b/add-celltypes.nf
@@ -52,10 +52,12 @@ workflow {
              || (it.submitter == params.project)
              || (it.project_id == params.project)
             }
-    // tuple of meta, processed rds file to use as input to cell type annotation
-    .map{meta -> tuple(meta,
-                       file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed.rds")
-                       )}
+      // tuple of meta, processed RDS file to use as input to singleR
+      .map{meta -> tuple(meta,
+                        file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed.rds"),
+                        file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed_rna.hdf5")
+                        )}
 
     annotate_celltypes(processed_sce_ch)
+
 }

--- a/add-celltypes.nf
+++ b/add-celltypes.nf
@@ -52,7 +52,7 @@ workflow {
              || (it.submitter == params.project)
              || (it.project_id == params.project)
             }
-      // tuple of meta, processed RDS file to use as input to singleR
+      // tuple of meta, processed RDS file, processed hdf5 file to use as input to classifying celltypes
       .map{meta -> tuple(meta,
                         file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed.rds"),
                         file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed_rna.hdf5")

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# This script takes an AnnData object and a reference marker gene matrix
+# where genes are rows and columns are cell types
+# CellAssign is run and the predictions matrix is returned
+
+
+import os
+import anndata as adata
+import scvi
+from scvi.external import CellAssign
+from scvi import settings
+import pandas as pd
+import numpy as np
+import argparse
+import re
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-i', '--input_anndata',
+                    dest = 'input_anndata',
+                    required = True,
+                    help = 'Path to HDF5 file with processed AnnData object to annotate')
+parser.add_argument('-o', '--output_predictions',
+                    dest = 'output_predictions',
+                    required = True,
+                    help = 'Path to directory to save the predictions, should end in tsv')
+parser.add_argument('-r', '--reference',
+                    dest = 'reference',
+                    required = True,
+                    help = 'Path to marker by cell type reference file')
+parser.add_argument('-s', '--seed',
+                    dest = 'seed',
+                    type=int,
+                    default = None,
+                    help = 'Random seed to set for scvi.')
+parser.add_argument('-t', '--threads',
+                    dest = 'threads',
+                    default = 1,
+                    type = int,
+                    help = 'Number of threads to use when training the CellAssign model')
+
+args = parser.parse_args()
+
+# set seed
+scvi.settings.seed = args.seed
+
+# define the number of threads to use
+settings.num_threads = args.threads
+
+# compile extension regex
+file_ext = re.compile(r"\.hdf5$|.h5$", re.IGNORECASE)
+
+# check that input file exists, if it does exist, make sure it's an h5 file
+if not os.path.exists(args.input_anndata):
+    raise FileExistsError("--input_anndata file not found.")
+elif not file_ext.search(args.input_anndata):
+    raise ValueError("--input_anndata must end in either .hdf5 or .h5 and contain a processed AnnData object.")
+
+# check that marker file exists and make sure its a csv
+if not os.path.exists(args.reference):
+    raise FileExistsError("--reference file not found.")
+elif not ".csv" in args.reference:
+    raise ValueError("--reference must be a csv file")
+
+# make sure output file path is tsv file
+if not ".tsv" in args.output_predictions:
+    raise ValueError("--output_predictions must provide a file path ending in tsv")
+
+# check that output file directory exists and create directory if doesn't exist
+predictions_dir = os.path.dirname(args.output_predictions)
+os.makedirs(predictions_dir, exist_ok = True)
+
+# read in references as marker gene tables
+ref_matrix = pd.read_csv(args.reference, sep = "\t", index_col='ensembl_id')
+
+# file path to annotated sce
+annotated_adata = adata.read_h5ad(args.input_anndata)
+
+# subset anndata to contain only genes in the reference file
+# note that the gene names must be the rownames of the reference matrix
+subset_adata = annotated_adata[:, ref_matrix.index].copy()
+subset_adata.X = subset_adata.X.tocsr()
+
+# add size factor to subset adata (calculated from full data)
+lib_size = annotated_adata.X.sum(1)
+subset_adata.obs["size_factor"] = lib_size / np.mean(lib_size)
+
+# train and assign cell types
+scvi.external.CellAssign.setup_anndata(subset_adata, size_factor_key="size_factor")
+model = CellAssign(subset_adata, ref_matrix)
+model.train()
+predictions = model.predict()
+predictions['barcode'] = subset_adata.obs_names
+
+# write out predictions as tsv
+predictions.to_csv(args.output_predictions, sep = "\t", index = False)

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -9,7 +9,6 @@ import os
 import anndata as adata
 import scvi
 from scvi.external import CellAssign
-from scvi import settings
 import pandas as pd
 import numpy as np
 import argparse
@@ -23,11 +22,11 @@ parser.add_argument('-i', '--input_hdf5_file',
 parser.add_argument('-o', '--output_predictions',
                     dest = 'output_predictions',
                     required = True,
-                    help = 'Path to directory to save the predictions, should end in tsv')
+                    help = 'Path to file to save the predictions, should end in tsv')
 parser.add_argument('-r', '--reference',
                     dest = 'reference',
                     required = True,
-                    help = 'Path to marker by cell type reference file')
+                    help = 'Path to marker by cell type reference file, should end in tsv')
 parser.add_argument('-s', '--seed',
                     dest = 'seed',
                     type=int,
@@ -56,7 +55,7 @@ if not os.path.exists(args.input_hdf5_file):
 elif not file_ext.search(args.input_hdf5_file):
     raise ValueError("--input_hdf5_file must end in either .hdf5 or .h5 and contain a processed AnnData object.")
 
-# check that marker file exists and make sure its a csv
+# check that marker file exists and make sure its a tsv
 if not os.path.exists(args.reference):
     raise FileExistsError("--reference file not found.")
 

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -61,7 +61,7 @@ if not os.path.exists(args.reference):
     raise FileExistsError("--reference file not found.")
 
 # make sure output file path is tsv file
-if not ".tsv" in args.output_predictions:
+if not args.output_predictions.endswith(".tsv"):
     raise ValueError("--output_predictions must provide a file path ending in tsv")
 
 # read in references as marker gene tables

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -16,8 +16,8 @@ import argparse
 import re
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-i', '--input_anndata',
-                    dest = 'input_anndata',
+parser.add_argument('-i', '--input_hdf5_file',
+                    dest = 'input_hdf5_file',
                     required = True,
                     help = 'Path to HDF5 file with processed AnnData object to annotate')
 parser.add_argument('-o', '--output_predictions',
@@ -51,30 +51,24 @@ settings.num_threads = args.threads
 file_ext = re.compile(r"\.hdf5$|.h5$", re.IGNORECASE)
 
 # check that input file exists, if it does exist, make sure it's an h5 file
-if not os.path.exists(args.input_anndata):
-    raise FileExistsError("--input_anndata file not found.")
-elif not file_ext.search(args.input_anndata):
-    raise ValueError("--input_anndata must end in either .hdf5 or .h5 and contain a processed AnnData object.")
+if not os.path.exists(args.input_hdf5_file):
+    raise FileExistsError("--input_hdf5_file file not found.")
+elif not file_ext.search(args.input_hdf5_file):
+    raise ValueError("--input_hdf5_file must end in either .hdf5 or .h5 and contain a processed AnnData object.")
 
 # check that marker file exists and make sure its a csv
 if not os.path.exists(args.reference):
     raise FileExistsError("--reference file not found.")
-elif not ".csv" in args.reference:
-    raise ValueError("--reference must be a csv file")
 
 # make sure output file path is tsv file
 if not ".tsv" in args.output_predictions:
     raise ValueError("--output_predictions must provide a file path ending in tsv")
 
-# check that output file directory exists and create directory if doesn't exist
-predictions_dir = os.path.dirname(args.output_predictions)
-os.makedirs(predictions_dir, exist_ok = True)
-
 # read in references as marker gene tables
 ref_matrix = pd.read_csv(args.reference, sep = "\t", index_col='ensembl_id')
 
 # file path to annotated sce
-annotated_adata = adata.read_h5ad(args.input_anndata)
+annotated_adata = adata.read_h5ad(args.input_hdf5_file)
 
 # subset anndata to contain only genes in the reference file
 # note that the gene names must be the rownames of the reference matrix

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -44,7 +44,7 @@ args = parser.parse_args()
 scvi.settings.seed = args.seed
 
 # define the number of threads to use
-settings.num_threads = args.threads
+scvi.settings.num_threads = args.threads
 
 # compile extension regex
 file_ext = re.compile(r"\.hdf5$|.h5$", re.IGNORECASE)

--- a/bin/classify_cellassign.py
+++ b/bin/classify_cellassign.py
@@ -72,7 +72,9 @@ annotated_adata = adata.read_h5ad(args.input_hdf5_file)
 
 # subset anndata to contain only genes in the reference file
 # note that the gene names must be the rownames of the reference matrix
-subset_adata = annotated_adata[:, ref_matrix.index].copy()
+# first get a list of shared genes
+shared_genes = list(set(ref_matrix.index) & set(annotated_adata.var_names))
+subset_adata = annotated_adata[:, shared_genes].copy()
 subset_adata.X = subset_adata.X.tocsr()
 
 # add size factor to subset adata (calculated from full data)

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -57,7 +57,7 @@ process train_singler_models {
 
 process generate_cellassign_refs {
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${params.celltype_ref_dir}/cellassign_references"
+  publishDir "${cellassign_ref_dir}"
   label 'mem_8'
   input:
     tuple val(ref_name), val(ref_source), val(organs)

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -12,6 +12,8 @@ celltype_ref_dir = "${params.ref_rootdir}/celltype"
 singler_references_dir = "${params.celltype_ref_dir}/singler_references"
 // output from train_singler_models() process
 singler_models_dir = "${params.celltype_ref_dir}/singler_models"
+// output from generating cell assign reference matrices
+cellassign_ref_dir = "${params.celltype_ref_dir}/cellassign_references"
 
 // cell type metadata
 celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -88,6 +88,8 @@ workflow annotate_celltypes {
 
       predict_cellassign(cellassign_input_ch)
 
-    emit: tuple(classify_singleR.out, predict_cellassign.out)
+    emit:
+      classify_singleR.out
+      predict_cellassign.out
 
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -28,8 +28,8 @@ process classify_singleR {
 
 process predict_cellassign {
   container params.SCPCATOOLS_CONTAINER
-  label 'mem_8'
-  label 'cpus_4'
+  label 'mem_32'
+  label 'cpus_12'
   input:
     tuple val(meta), path(processed_hdf5), path(cellassign_reference_mtx)
   output:
@@ -41,6 +41,7 @@ process predict_cellassign {
       --input_hdf5_file ${processed_hdf5} \
       --output_predictions ${cellassign_predictions} \
       --reference ${cellassign_reference_mtx} \
+      --seed ${params.seed} \
       --threads ${task.cpus}
     """
   stub:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -88,6 +88,6 @@ workflow annotate_celltypes {
 
       predict_cellassign(cellassign_input_ch)
 
-    emit: classify_singleR.out
+    emit: tuple(classify_singleR.out, predict_cellassign.out)
 
 }


### PR DESCRIPTION
Closes #303 

This PR adds a process for obtaining `CellAssign` predictions to the main cell type annotation workflow. 

- I added this process into the current `classify_celltypes.nf` process where we now get cell type annotations using both `SingleR` and `CellAssign`. Right now for `CellAssign` I only output the predictions and plan to add one more process to merge in the predictions from `CellAssign` to the annotated rds file with `SingleR` annotations. 
- This does rely on the assumption that every project will have both a `SingleR` reference and a `CellAssign` reference. I think that's okay, because I don't see any scenarios as of yet that we wouldn't have them. 
- I used the highest memory and cpu label that we have. During testing, this was immediately failing due to memory errors, but is running on the third retry. I'm using the max to try and eliminate the failing and re-submitting as much as possible.
- Also see [AlexsLemonade/ScPCA-admin#](https://github.com/AlexsLemonade/ScPCA-admin/pull/604) for the changes to the metadata file that I made. There I added columns for the `SingleR` ref file and `CellAssign` ref file and am directly using them in the workflow rather than creating the paths. 

~~**Note:** I am still running a test to make sure that this completes fully, but it's been running for some time so I think most of the errors have been accounted for. I'll request a review once I ensure this is able to run to completion.~~

Edit: The test completed successfully, but it did take ~16 hours as a warning for reviewers that would like to test it. 😬 