### PR TITLE
Be more flexible with fastq filenames

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -156,8 +156,8 @@ workflow map_quant_feature{
       // We start by including the feature_barcode file so we can combine with the indices, but that will be removed
       .map{meta -> tuple(meta.feature_barcode_file,
                          meta,
-                         file("${meta.files_directory}/*_R1_*.fastq.gz"),
-                         file("${meta.files_directory}/*_R2_*.fastq.gz")
+                         file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
+                         file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz")
                         )}
       .combine(index_feature.out, by: 0) // combine by the feature_barcode_file (reused indices, so combine is needed)
       .map{it.drop(1)} // remove the first element (feature_barcode_file)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -120,8 +120,8 @@ workflow map_quant_rna {
     // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
     rna_reads_ch = rna_channel.make_rad
       .map{meta -> tuple(meta,
-                         file("${meta.files_directory}/*_R1_*.fastq.gz"),
-                         file("${meta.files_directory}/*_R2_*.fastq.gz"),
+                         file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
+                         file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz"),
                          file("${meta.salmon_splici_index}")
                         )}
 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -139,8 +139,8 @@ workflow bulk_quant_rna {
         // If we need to run salmon, create tuple of (metadata map, [Read 1 files], [Read 2 files])
         bulk_reads_ch = bulk_channel.make_quants
           .map{meta -> tuple(meta,
-                             file("${meta.files_directory}/*_R1_*.fastq.gz"),
-                             file("${meta.files_directory}/*_R2_*.fastq.gz")
+                             file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
+                         file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz")
                              )}
 
         // run fastp and salmon for libraries that are not skipping salmon

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -37,8 +37,8 @@ workflow star_bulk{
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
     bulk_reads_ch = bulk_channel
         .map{meta -> tuple(meta,
-                           file("${meta.files_directory}/*_R1_*.fastq.gz"),
-                           file("${meta.files_directory}/*_R2_*.fastq.gz"),
+                           file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
+                         file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz"),
                            file("${meta.star_index}"))}
     // map and index
     bulkmap_star(bulk_reads_ch) \


### PR DESCRIPTION
Closes #392 

This PR updates all of the places we grab fastq files to accept either `_R1_` or `_R1.fastq.gz`. I tested it with one of our samples to make sure that it recognized our files and things worked as expected. 