### PR TITLE
Use reference json file to define paths in building celltype refs

### DIFF
--- a/add-celltypes.nf
+++ b/add-celltypes.nf
@@ -30,8 +30,6 @@ workflow {
     log.info("Executing workflow for all runs in the run metafile.")
   }
 
-  celltype_ref_paths = Utils.readMeta(file(params.celltype_ref_json))
-
   // read in metadata file and filter to libraries/ projects of interest
   processed_sce_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')

--- a/add-celltypes.nf
+++ b/add-celltypes.nf
@@ -30,6 +30,8 @@ workflow {
     log.info("Executing workflow for all runs in the run metafile.")
   }
 
+  celltype_ref_paths = Utils.readMeta(file(params.celltype_ref_json))
+
   // read in metadata file and filter to libraries/ projects of interest
   processed_sce_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -53,7 +53,7 @@ process train_singler_models {
 
 process generate_cellassign_refs {
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${cellassign_ref_dir}"
+  publishDir "${params.cellassign_ref_dir}"
   label 'mem_8'
   input:
     tuple val(ref_name), val(ref_source), val(organs), path(ref_gtf)

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -79,7 +79,7 @@ process generate_cellassign_refs {
 workflow build_celltype_ref {
 
   // read in json file with all reference paths
-  ref_paths = Utils.getMetaVal(file(params.ref_json), "Homo_sapiens.GRCh38.104")
+  ref_paths = Utils.getMetaVal(file(params.ref_json), params.celltype_organism)
 
   // create channel of cell type ref files and names
   celltype_refs_ch = Channel.fromPath(params.celltype_ref_metadata)

--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -30,7 +30,7 @@ process train_singler_models {
   label 'cpus_4'
   label 'mem_16'
   input:
-    tuple val(ref_name), path(ref_file), path(tx2gene)
+    tuple val(ref_name), path(ref_file), path(t2g_3col_path)
   output:
     path celltype_model
   script:
@@ -39,7 +39,7 @@ process train_singler_models {
     train_SingleR.R \
       --ref_file ${ref_file} \
       --output_file ${celltype_model} \
-      --fry_tx2gene ${tx2gene} \
+      --fry_tx2gene ${t2g_3col_path} \
       --label_name ${params.label_name} \
       --seed ${params.seed} \
       --threads ${task.cpus}

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -7,6 +7,7 @@ ref_rootdir  = 's3://scpca-references'
 barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
 
 // cell type references directories
+celltype_organism = "Homo_sapiens.GRCh38.104"
 celltype_ref_dir = "${params.ref_rootdir}/celltype"
 // output from save_singler_refs() process
 singler_references_dir = "${params.celltype_ref_dir}/singler_references"

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -6,8 +6,11 @@ ref_rootdir  = 's3://scpca-references'
 // barcode files
 barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
 
-// cell type references directories
+// organism name to use for cell type annotation
+// name must match one of the keys in ref_json
 celltype_organism = "Homo_sapiens.GRCh38.104"
+
+// cell type references directories
 celltype_ref_dir = "${params.ref_rootdir}/celltype"
 // output from save_singler_refs() process
 singler_references_dir = "${params.celltype_ref_dir}/singler_references"


### PR DESCRIPTION
Closes #390 
Stacked on #396 

This PR updates the `build-celltype-refs.nf` workflow to use the paths defined in `scpca-refs.json` rather than re-defining them at the top of the script. Originally in #390 I was thinking I would also add a cell type specific json file, but as I worked on it that seemed less helpful. We only have a few parameters that are mostly used to define publish directories and then the other ones are paths to reference files we don't want to store in S3. So in conclusion, I didn't fully make a new cell type specific json file, but instead updated this to remove hard coding paths. 
