### PR TITLE
Add process to cluster cells

### DIFF
--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -16,8 +16,7 @@ option_list <- list(
   make_option(
     opt_str = c("-i", "--processed_sce_file"),
     type = "character",
-    default = "~/sce.rds",
-    help = "Path to RDS file that contains the processedsce SCE object to cluster."
+    help = "Path to RDS file that contains the processed sce SCE object to cluster."
   ),
   make_option(
     opt_str = c("--pca_name"),

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -28,9 +28,9 @@ option_list <- list(
   make_option(
     opt_str = c("--cluster_algorithm"),
     type = "character",
-    default = "leiden",
+    default = "louvain",
     help = "Clustering algorithm to use. Must be one of the options available in bluster.
-      Default is 'leiden'."
+      Default is 'louvain'."
   ),
   make_option(
     opt_str = c("--nearest_neighbors"),
@@ -52,10 +52,10 @@ opt <- parse_args(OptionParser(option_list = option_list))
 set.seed(opt$seed)
 
 # check and read in SCE file
-if (!file.exists(opt$processed_sce_file)) {
-  stop("Input `sce_file` is missing.")
+if (!file.exists(opt$input_sce_file)) {
+  stop("Input `input_sce_file` is missing.")
 }
-sce <- readr::read_rds(opt$processed_sce_file)
+sce <- readr::read_rds(opt$input_sce_file)
 
 
 # check pca_name is present
@@ -73,6 +73,7 @@ clusters <- bluster::clusterRows(
   pca_matrix,
   bluster::NNGraphParam(
     k = opt$nearest_neighbors,
+    type = "jaccard",
     cluster.fun = opt$cluster_algorithm
   )
 ) 
@@ -84,4 +85,5 @@ metadata(sce)$cluster_algorithm <- opt$cluster_algorithm
 metadata(sce)$cluster_nn <- opt$nearest_neighbors
 
 # export -------------------
-readr::write_rds(sce, opt$processed_sce_file)
+# we are overwriting the input file here:
+readr::write_rds(sce, opt$input_sce_file)

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -2,7 +2,7 @@
 
 # Script used to perform clustering on a given SCE object
 # 
-# This script reads in an RDS file containing an SCE, and performed
+# This script reads in an RDS file containing an SCE, and performs
 #  graph-based clustering using the specified algorithm. Cluster identities are 
 #  stored in the SCE's colData slot, and the SCE is written back out to the
 #  original RDS file.
@@ -14,7 +14,7 @@ library(SingleCellExperiment)
 # Set up optparse options
 option_list <- list(
   make_option(
-    opt_str = c("-i", "--processed_sce_file"),
+    opt_str = c("-i", "--input_sce_file"),
     type = "character",
     help = "Path to RDS file that contains the processed sce SCE object to cluster."
   ),

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+
+# Script used to perform clustering on a given SCE object
+# 
+# This script reads in an RDS file containing an SCE, and performed
+#  graph-based clustering using the specified algorithm. Cluster identities are 
+#  stored in the SCE's colData slot, and the SCE is written back out to the
+#  original RDS file.
+
+# import libraries
+library(optparse)
+library(SingleCellExperiment)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-i", "--sce_file"),
+    type = "character",
+    help = "Path to RDS file that contains the SCE object to cluster."
+  ),
+  make_option(
+    opt_str = c("--pca_name"),
+    type = "character",
+    default = "PCA",
+    help = "Name of the PCA reduced dimensionality representation to perform
+      clustering on."
+  ), 
+  make_option(
+    opt_str = c("--cluster_algorithm"),
+    type = "character",
+    default = "leiden",
+    help = "Clustering algorithm to use. Must be one of the options available in bluster.
+      Default is 'leiden'."
+  ),
+  make_option(
+    opt_str = c("--nn"),
+    type = "integer",
+    default = 15, 
+    help = "Nearest neighbors parameter to set for graph-based clustering."
+  ),
+  make_option(
+    opt_str = c("--seed"),
+    type = "integer",
+    help = "random seed to set during clustering."
+  )
+)
+
+# Setup ------------------------------
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+set.seed(opt$seed)
+
+# check and read in SCE file
+if (!file.exists(opt$sce_file)) {
+  stop("Input `sce_file` is missing.")
+}
+sce <- readr::read_rds(opt$sce_file)
+
+
+# check pca_name is present
+if (!opt$pca_name %in% reducedDimNames(sce)) {
+  stop("Provided `pca_name` is not present in the SCE object.")
+}
+
+# Perform clustering ----------------
+
+# extract the principal components matrix
+pca_matrix <- reducedDim(sce, opt$pca_name)
+
+# cluster with specified algorithm
+clusters <- bluster::clusterRows(
+  pca_matrix,
+  bluster::SNNGraphParam(
+    k = opt$nn,
+    cluster.fun = opt$cluster_algorithm
+  )
+)
+
+# add clusters and associated parameters to SCE object
+sce$clusters <- clusters
+metadata(sce)$cluster_algorithm <- opt$cluster_algorithm
+metadata(sce)$cluster_nn <- opt$nn
+
+
+# export -------------------
+readr::write_rds(sce, opt$sce_file)

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -16,7 +16,8 @@ option_list <- list(
   make_option(
     opt_str = c("-i", "--input_sce_file"),
     type = "character",
-    help = "Path to RDS file that contains the processed sce SCE object to cluster."
+    help = "Path to RDS file that contains the processed SCE object to cluster.
+      Must contain a PCA matrix to calculate clusters from."
   ),
   make_option(
     opt_str = c("--pca_name"),

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -74,18 +74,15 @@ if (!opt$pca_name %in% reducedDimNames(sce)) {
 # Perform clustering ----------------
 
 # extract the principal components matrix
-pca_matrix <- reducedDim(sce, opt$pca_name)
-
-# cluster with specified algorithm
-clusters <- bluster::clusterRows(
-  pca_matrix,
-  bluster::NNGraphParam(
+clusters <- scran::clusterCells(
+  sce, 
+  use.dimred = opt$pca_name, 
+  BLUSPARAM = bluster::NNGraphParam(
     k = opt$nearest_neighbors,
     type = opt$cluster_weighting,
     cluster.fun = opt$cluster_algorithm
   )
-) 
-# TODO: may wish to modify additional cluster parameters depending on cluster algorithm
+)
 
 # add clusters and associated parameters to SCE object
 sce$clusters <- clusters

--- a/main.nf
+++ b/main.nf
@@ -40,7 +40,7 @@ include { generate_sce; generate_merged_sce; cellhash_demux_sce; genetic_demux_s
 include { sce_to_anndata } from './modules/export-anndata.nf'
 include { annotate_celltypes } from './modules/classify-celltypes.nf'
 include { sce_qc_report } from './modules/qc-report.nf'
-
+include { cluster_sce } from './modules/cluster-sce.nf'
 
 
 // parameter checks
@@ -206,12 +206,15 @@ workflow {
 
   // **** Post processing and generate QC reports ****
   // combine all SCE outputs
-  // Make channel for all library sce files & run QC report
+  // Make channel for all library sce files
   all_sce_ch = sce_ch.no_genetic.mix(genetic_demux_sce.out)
   post_process_sce(all_sce_ch)
+  
+  // Cluster SCE and export RDS files to publishDir
+  cluster_sce(post_process_sce.out)
 
   // generate QC reports
-  sce_qc_report(post_process_sce.out, report_template_tuple)
+  sce_qc_report(cluster_sce.out, report_template_tuple)
 
   // convert RNA component of SCE object to anndata
   sce_to_anndata(post_process_sce.out)

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -1,0 +1,27 @@
+// perform graph-based clustering on a processed SCE object
+// this process also does the RDS file export to the publishDir
+
+
+process cluster_sce{
+    container params.SCPCATOOLS_CONTAINER
+    label 'mem_8'
+    tag "${meta.library_id}"
+    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
+    input:
+        tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
+    output:
+        tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
+    script:
+        """
+        cluster_sce.R \
+          --processed_sce_file ${processed_rds} \
+          --cluster_algorithm ${params.cluster_algorithm} \
+          --nearest_neighbors ${params.nearest_neighbors} \
+          ${params.seed ? "--random_seed ${params.seed}" : ""}
+        """
+    stub:
+        processed_rds = "${meta.library_id}_processed.rds"
+        """
+        touch ${processed_rds}
+        """
+}

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -14,7 +14,7 @@ process cluster_sce{
     script:
         """
         cluster_sce.R \
-          --processed_sce_file ${processed_rds} \
+          --input_sce_file ${processed_rds} \
           --cluster_algorithm ${params.cluster_algorithm} \
           --nearest_neighbors ${params.nearest_neighbors} \
           ${params.seed ? "--random_seed ${params.seed}" : ""}

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -14,8 +14,9 @@ process cluster_sce{
     script:
         """
         cluster_sce.R \
-          --input_sce_file ${processed_rds} \
+          --processed_sce_file ${processed_rds} \
           --cluster_algorithm ${params.cluster_algorithm} \
+          --cluster_weighting ${params.cluster_weighting} \
           --nearest_neighbors ${params.nearest_neighbors} \
           ${params.seed ? "--random_seed ${params.seed}" : ""}
         """

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -167,7 +167,6 @@ process post_process_sce{
     container params.SCPCATOOLS_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
-    publishDir "${params.checkpoints_dir}/post_processed/${meta.sample_id}", mode: 'copy'
     input:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -167,7 +167,7 @@ process post_process_sce{
     container params.SCPCATOOLS_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
-    publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
+    publishDir "${params.checkpoints_dir}/post_processed/${meta.sample_id}", mode: 'copy'
     input:
         tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,8 @@ params {
   
   // SCE clustering options
   cluster_algorithm = "louvain" // default graph-based clustering algorithm
-  nearest_neighbors = 15 // number of nearest neighbors parameter for graph-based clustering
+  cluster_weighting = "jaccard" // default weighting scheme for graph-based clustering
+  nearest_neighbors = 20 // default nearest neighbors parameter for graph-based clustering
 
   // Docker container images
   includeConfig 'config/containers.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,10 @@ params {
   gene_cutoff = 200 // minimum number of genes per cell cutoff used for filtering cells
   num_hvg = 2000 // number of high variance genes to use for dimension reduction
   num_pcs = 50 // number of principal components to retain in the returned SingleCellExperiment object
+  
+  // SCE clustering options
+  cluster_algorithm = "leiden" // default graph-based clustering algorithm
+  nearest_neighbors = 15 // number of nearest neighbors parameter for graph-based clustering
 
   // Docker container images
   includeConfig 'config/containers.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,7 +47,7 @@ params {
   num_pcs = 50 // number of principal components to retain in the returned SingleCellExperiment object
   
   // SCE clustering options
-  cluster_algorithm = "leiden" // default graph-based clustering algorithm
+  cluster_algorithm = "louvain" // default graph-based clustering algorithm
   nearest_neighbors = 15 // number of nearest neighbors parameter for graph-based clustering
 
   // Docker container images


### PR DESCRIPTION
Closes #404 

This PR adds a process to cluster SCEs to the main workflow. This has been successfully tested with `SCPCR000001`. Some notes on this implementation:

- Major caveat about the clustering code _itself_ given some of the discussion going on in #404 - we probably will want to circle back to the exact parameters used, but for now it will do graph-based clustering of some kind at least. (edit - worth noting I don't have `type = "jaccard"` in here, yet?)
- I have ended up using the following variable names, which can be tweaked!
  - Clusters are added to `colData(sce)$clusters`
  - Two metadata variables are added (this may change depending on the final clustering code): `metadata(sce)$cluster_algorithm` and `metadata(sce)$cluster_nn`. 
- While writing the clustering script, I nearly used but ended up not using the new `cluster_sce` function we added to `scpcaTools`, since the arguments for that function might be a tad involved for what we want to do here! That function seemed most suited for use by the integration metrics which it was written for, but we can use it here if that's really important just with some nextflow string wrangling.
- To add clustering to the workflow, I wrote a separate small module with one process to perform clustering. As of now, I have _this process_ sending final RDS files to `publishDir`, and I updated the `post_process_sce` process to instead save these files to a checkpoint directory. As a consequence, the processed sce files will now all have clusters in them. I did this because I didn't think a 4th SCE file with clusters made sense from a memory/storage perspective, but it is kind of a choice that all our processed SCEs now contain clusters. What feelings do we have?
