### PR TITLE
Add documentation for celltype refs files

### DIFF
--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -69,8 +69,8 @@ This file is required as input to `scpca-nf`.
 
 3. `celltype-reference-metadata.tsv`: Each row of this TSV file corresponds to a supported cell type reference available for cell type assignment using `add-celltypes.nf`.
 For all references, the following columns will be populated: `celltype_ref_name`, `celltype_ref_source` (e.g., `celldex`), supported `celltype_method` (e.g., `SingleR`).
-For all references obtained from the `PanglaoDB` source also require an `organs` column containing the list of supported `PanglaoDB` organs to include when building the reference.
-This should be a comma separated list of all organs to include.
+All references obtained from the `PanglaoDB` source also require an `organs` column containing the list of supported `PanglaoDB` organs to include when building the reference.
+This should be a comma-separated list of all organs to include.
 To find all possible organs, see the `organs` column of `PanglaoDB_markers_27_Mar_2020.tsv`.
 This file is required as input to the `build-celltype-ref.nf` workflow, which will create all required cell type references for `add-celltypes.nf`.
 

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -103,7 +103,8 @@ homo_sapiens
 
 ## Adding additional cell type references
 
-Follow the below steps to add suppor for additional cell type references:
+Follow the below steps to add support for additional cell type references.
+We currently only support `celldex` and `PanglaoDB` for reference sources.
 
 1. Add the `celltype_ref_name`, `celltype_ref_source`, `celltype_method`, and `organs` (if applicable) for the new reference to `celltype-reference-metadata.tsv`.
 2. Generate the new cell type references using `nextflow run build-celltype-ref.nf -profile ccdl,batch` from the root directory of this repository.

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -73,6 +73,7 @@ All references obtained from the `PanglaoDB` source also require an `organs` col
 This should be a comma-separated list of all organs to include.
 To find all possible organs, see the `organs` column of `PanglaoDB_markers_27_Mar_2020.tsv`.
 This file is required as input to the `build-celltype-ref.nf` workflow, which will create all required cell type references for `add-celltypes.nf`.
+See [instructions for adding additional cell type references](#adding-additional-cell-type-references) for more details.
 
 4. `PanglaoDB_markers_27_Mar_2020.tsv`: This file is used to build the cell type references from `PanglaoDB`.
 This file was obtained from clicking the `get tsv file` button on the [PanglaoDB Dataset page](https://panglaodb.se/markers.html?cell_type=%27choose%27).
@@ -99,3 +100,11 @@ homo_sapiens
 3. Generate an updated `scpca-refs.json` by running the script, `create-reference-json.R`, located in the `scripts` directory.
 4. Generate the index files using `nextflow run build-index.nf -profile ccdl,batch` from the root directory of this repository.
 5. Ensure that the new reference files are public and in the correct location on S3 (`s3://scpca-references`).
+
+## Adding additional cell type references
+
+Follow the below steps to add suppor for additional cell type references:
+
+1. Add the `celltype_ref_name`, `celltype_ref_source`, `celltype_method`, and `organs` (if applicable) for the new reference to `celltype-reference-metadata.tsv`.
+2. Generate the new cell type references using `nextflow run build-celltype-ref.nf -profile ccdl,batch` from the root directory of this repository.
+3. Ensure that the new reference files are public and in the correct location on S3 (`s3://scpca-references/celltype`).

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -67,6 +67,17 @@ See [instructions for adding additional organisms](#adding-additional-organisms)
 For each supported reference, a list of all the reference files that are needed to run `scpca-nf` will be included.
 This file is required as input to `scpca-nf`.
 
+3. `celltype-reference-metadata.tsv`: Each row of this TSV file corresponds to a supported cell type reference available for cell type assignment using `add-celltypes.nf`.
+For all references, the following columns will be populated: `celltype_ref_name`, `celltype_ref_source` (e.g., `celldex`), supported `celltype_method` (e.g., `SingleR`).
+For all references obtained from the `PanglaoDB` source also require an `organs` column containing the list of supported `PanglaoDB` organs to include when building the reference.
+This should be a comma separated list of all organs to include.
+To find all possible organs, see the `organs` column of `PanglaoDB_markers_27_Mar_2020.tsv`.
+This file is required as input to the `build-celltype-ref.nf` workflow, which will create all required cell type references for `add-celltypes.nf`.
+
+4. `PanglaoDB_markers_27_Mar_2020.tsv`: This file is used to build the cell type references from `PanglaoDB`.
+This file was obtained from clicking the `get tsv file` button on the [PanglaoDB Dataset page](https://panglaodb.se/markers.html?cell_type=%27choose%27).
+This file is required as input to the `build-celltype-ref.nf` workflow, which will create all required cell type references for `add-celltypes.nf`.
+
 ### Adding additional organisms
 
 Follow the below steps to add support for additional references:


### PR DESCRIPTION
Closes #389 

So I went to document the `references` folder per #389 and was pleasantly surprised that I had already documented the files related to references for the main `scpca-nf`. So I just had to add in some context about the two new files related to building cell type references. 

I added on to the section that I already had in our internal documentation describing the two files. Generally this was pretty straight forward but let me know if I need to expand on anything! 