### PR TITLE
Sample metadata to cell-level metadata for AnnData 

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -113,7 +113,6 @@ unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
                               library_id = opt$library_id,
                               sample_id = sample_ids)
 
-
 # read and merge feature counts if present
 if (opt$feature_dir != ""){
   feature_sce <- read_alevin(quant_dir = opt$feature_dir,
@@ -128,22 +127,25 @@ if (opt$feature_dir != ""){
   altExp(unfiltered_sce, opt$feature_name) <- scuttle::addPerFeatureQCMetrics(altExp(unfiltered_sce, opt$feature_name))
 }
 
+
+# read in sample metadata and filter to sample ids
+sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
+  # rename sample id column
+  dplyr::rename("sample_id" = "scpca_sample_id") |>
+  # add library ID as column in sample metadata
+  # we need this so we are able to merge sample metadata with colData later
+  dplyr::mutate(library_id = opt$library_id) |>
+  # remove upload date as we don't provide this on the portal
+  dplyr::select(-upload_date)
+
 # add per cell and per gene statistics to colData and rowData
 unfiltered_sce <- unfiltered_sce |>
   add_cell_mito_qc(mito = mito_genes) |>
  # add gene symbols to rowData
   add_gene_symbols(gene_info = gtf) |>
-  scuttle::addPerFeatureQCMetrics()
-
-# read in sample metadata and filter to sample ids
-sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
-  # rename sample id column
-  dplyr::rename("sample_id" = "scpca_sample_id",
-                "library_id" = "scpca_library_id")
-
-# add dataframe with sample metadata to sce metadata
-unfiltered_sce <- add_sample_metadata(sce = unfiltered_sce,
-                                      metadata_df = sample_metadata_df)
+  scuttle::addPerFeatureQCMetrics() |>
+  # add dataframe with sample metadata to sce metadata
+  add_sample_metadata(metadata_df = sample_metadata_df)
 
 # write to rds
 readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -136,9 +136,10 @@ unfiltered_sce <- unfiltered_sce |>
   scuttle::addPerFeatureQCMetrics()
 
 # read in sample metadata and filter to sample ids
-sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |> 
+sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
   # rename sample id column
-  dplyr::rename("sample_id" = "scpca_sample_id")
+  dplyr::rename("sample_id" = "scpca_sample_id",
+                "library_id" = "scpca_library_id")
 
 # add dataframe with sample metadata to sce metadata
 unfiltered_sce <- add_sample_metadata(sce = unfiltered_sce,

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -61,7 +61,7 @@ sce$library_id <- metadata(sce)$library_id
 # add sample metadata to colData sce
 sce <- scpcaTools::metadata_to_coldata(sce,
                                        join_columns = "library_id")
-# remove sample metadata from metadata, otherwise conflicts with converting object
+# remove sample metadata from sce metadata, otherwise conflicts with converting object
 metadata(sce) <- metadata(sce)[names(metadata(sce)) != "sample_metadata"]
 
 # export sce as anndata object

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -28,7 +28,7 @@ option_list <- list(
   make_option(
     opt_str = c("--output_feature_h5"),
     type = "character",
-    help = "path to output hdf5 file to store feature counts as AnnData object. 
+    help = "path to output hdf5 file to store feature counts as AnnData object.
     Only used if the input SCE contains an altExp. Must end in .hdf5 or .h5"
   )
 )
@@ -52,32 +52,41 @@ if(!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))){
 # read in sce
 sce <- readr::read_rds(opt$input_sce_file)
 
+# add library id as a column to the sce object
+sce$library_id <- metadata(sce)$library_id
+
+# add sample metadata to sce
+sce <- scpcaTools::metadata_to_coldata(sce,
+                                       batch_column = "library_id")
+# remove sample metadata from metadata, otherwise conflicts with converting object
+metadata(sce) <- metadata(sce)[!names(metadata(sce)) %in% "sample_metadata"]
+
 # export sce as anndata object
 scpcaTools::sce_to_anndata(
   sce,
   anndata_file = opt$output_rna_h5
 )
 
-# if feature data exists, grab it and export to AnnData 
+# if feature data exists, grab it and export to AnnData
 if(!is.null(opt$feature_name)){
-  
-  # make sure the feature data is present 
+
+  # make sure the feature data is present
   if(!(opt$feature_name %in% altExpNames(sce))){
     stop("feature_name must match name of altExp in provided SCE object.")
   }
-  
-  # check for output file 
+
+  # check for output file
   if(!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))){
     stop("output feature file name must end in .hdf5 or .h5")
   }
-  
-  # extract altExp 
+
+  # extract altExp
   alt_sce <- altExp(sce, opt$feature_name)
-  
+
   # export altExp sce as anndata object
   scpcaTools::sce_to_anndata(
     alt_sce,
     anndata_file = opt$output_feature_h5
   )
-  
+
 }

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -52,14 +52,17 @@ if(!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))){
 # read in sce
 sce <- readr::read_rds(opt$input_sce_file)
 
+# grab sample metadata
+sample_metadata <- metadata(sce)$sample_metadata
+
 # add library id as a column to the sce object
 sce$library_id <- metadata(sce)$library_id
 
-# add sample metadata to sce
+# add sample metadata to colData sce
 sce <- scpcaTools::metadata_to_coldata(sce,
-                                       batch_column = "library_id")
+                                       join_columns = "library_id")
 # remove sample metadata from metadata, otherwise conflicts with converting object
-metadata(sce) <- metadata(sce)[!names(metadata(sce)) %in% "sample_metadata"]
+metadata(sce) <- metadata(sce)[!metadata(sce) %in% sample_metadata]
 
 # export sce as anndata object
 scpcaTools::sce_to_anndata(
@@ -82,6 +85,19 @@ if(!is.null(opt$feature_name)){
 
   # extract altExp
   alt_sce <- altExp(sce, opt$feature_name)
+
+  # add library ID to colData
+  metadata(alt_sce)$library_id <- metadata(sce)$library_id
+
+  # add sample metadata to alt sce metadata
+  metadata(alt_sce)$sample_metadata <- sample_metadata
+
+  # add sample metadata to alt sce coldata
+  alt_sce <- scpcaTools::metadata_to_coldata(alt_sce,
+                                             join_columns = "library_id")
+
+  # remove sample metadata from metadata, otherwise conflicts with converting object
+  metadata(sce) <- metadata(sce)[!metadata(sce) %in% sample_metadata]
 
   # export altExp sce as anndata object
   scpcaTools::sce_to_anndata(

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -97,7 +97,7 @@ if(!is.null(opt$feature_name)){
                                              join_columns = "library_id")
 
   # remove sample metadata from metadata, otherwise conflicts with converting object
-  metadata(sce) <- metadata(sce)[!metadata(sce) %in% sample_metadata]
+  metadata(sce) <- metadata(sce)[names(metadata(sce)) != "sample_metadata"]
 
   # export altExp sce as anndata object
   scpcaTools::sce_to_anndata(

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -62,7 +62,7 @@ sce$library_id <- metadata(sce)$library_id
 sce <- scpcaTools::metadata_to_coldata(sce,
                                        join_columns = "library_id")
 # remove sample metadata from metadata, otherwise conflicts with converting object
-metadata(sce) <- metadata(sce)[!metadata(sce) %in% sample_metadata]
+metadata(sce) <- metadata(sce)[names(metadata(sce)) != "sample_metadata"]
 
 # export sce as anndata object
 scpcaTools::sce_to_anndata(
@@ -87,7 +87,7 @@ if(!is.null(opt$feature_name)){
   alt_sce <- altExp(sce, opt$feature_name)
 
   # add library ID to colData
-  metadata(alt_sce)$library_id <- metadata(sce)$library_id
+  alt_sce$library_id <- metadata(sce)$library_id
 
   # add sample metadata to alt sce metadata
   metadata(alt_sce)$sample_metadata <- sample_metadata

--- a/main.nf
+++ b/main.nf
@@ -225,7 +225,7 @@ workflow {
   // convert SCE object to anndata
   // do this for everything but multiplexed libraries
   anndata_ch = post_process_sce.out
-    .filter{!(it[0]["library_id"] in genetic_multiplex_libs.getVal())}
+    .filter{!(it[0]["library_id"] in multiplex_libs.getVal())}
   sce_to_anndata(anndata_ch)
 
    // **** Process Spatial Transcriptomics data ****

--- a/main.nf
+++ b/main.nf
@@ -222,8 +222,11 @@ workflow {
   // generate QC reports
   sce_qc_report(cluster_sce.out, report_template_tuple)
 
-  // convert RNA component of SCE object to anndata
-  sce_to_anndata(post_process_sce.out)
+  // convert SCE object to anndata
+  // do this for everything but multiplexed libraries
+  anndata_ch = post_process_sce.out
+    .filter{!(it[0]["library_id"] in genetic_multiplex_libs.getVal())}
+  sce_to_anndata(anndata_ch)
 
    // **** Process Spatial Transcriptomics data ****
   spaceranger_quant(runs_ch.spatial)


### PR DESCRIPTION
Stacked on #400 
_This is stacked because #400 fails when converting the AnnData objects. An error is thrown because of the type in the `upload_date` column of sample metadata stored in the metadata before conversion._

This PR begins adding the necessary cell-level metadata for CZI compliance to the AnnData objects. I am focusing on adding the columns from the `sample_metadata` and will file a separate PR for adding the library-specific metadata we are missing (tech version and seq unit). 

This is also based on changes made in https://github.com/AlexsLemonade/scpcaTools/pull/217, and until those are merged, and the docker image is up to date, I can't fully test them in the workflow. 

- First, I slightly modified the `sample_metadata` data frame being added to the unfiltered SCE object. I changed the name for `scpca_library_id` to `library_id`, mirroring how we named the `sample_id` column. 
- I added steps to the script that convert the SCE objects to AnnData, preparing the object to be in the correct CZI compliant format before conversion. This saves us from modifying the actual `AnnData` object after converting. 
	- I added a `library_id` column, which is input to `metadata_to_coldata`. This indicates which column in the `colData` to use for joining with the `sample_metadata`. 
	- I run `metadata_to_coldata` to incorporate the `sample_metadata` columns into the `colData`.
	- I remove the `sample_information` from the metadata, because I don't think we want duplicate information in the object. 
- The caveat here is that this script runs on every SCE object (unfiltered, filtered, and processed) so every AnnData object we export will have the additional columns in the cell-level metadata. At one point we discussed only making things fully CZI compliant in the processed objects, but doing it this way means all of the AnnData objects we have available on the portal are formatted similarly. I think that will be easier to explain in the documentation and be less confusing from a user standpoint. 
