### PR TITLE
Add style guide & reformat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,9 @@ All Nextflow processes should include a [`stub` block](https://www.nextflow.io/d
 At this stage this is purely used to allow for testing of the main workflow logic rather than the internal logic of each process.
 
 The [`test/stub-run-metadata.tsv`](test/stub-run-metadata.tsv) file is used to define input libraries that will be used for testing.
-Any additions to the overall workflow that will allow processing of a new library type should be added into `test/stub-run-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for that library type in the `test/runs/` directory.
+Each sample ID in the `stub-run-metadata.tsv` file should have a corresponding entry in [`test/stub-sample-metadata.tsv`](test/stub-sample-metadata.tsv) (which can be filled with `NA` values).
+Any additions to the overall workflow that will allow processing of a new library type should include adding new example data.
+This will involve adding rows to `test/stub-run-metadata.tsv` and `test/stub-sample-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for each library in the `test/runs/` directory.
 If a new reference type is needed, that should be defined in the [`test/stub-refs.json`](test/stub-refs.json) file.
 
 ## Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,17 @@ When the changes in `development` merit a new release, a pull request will be fi
 All Nextflow processes should include a [`stub` block](https://www.nextflow.io/docs/latest/process.html#stub) with a minimal script that can be run quickly to produce files in the expected output locations.
 At this stage this is purely used to allow for testing of the main workflow logic rather than the internal logic of each process.
 
-The [`test/stub-metadata.tsv`](test/stub-metadata.tsv) file is used to define input libraries that will be used for testing.
+The [`test/stub-run-metadata.tsv`](test/stub-run-metadata.tsv) file is used to define input libraries that will be used for testing.
 Any additions to the overall workflow that will allow processing of a new library type should be added into `test/stub-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for that library type in the `test/runs/` directory.
 If a new reference type is needed, that should be defined in the [`test/stub-refs.json`](test/stub-refs.json) file.
 
+## Code style
+
+While there is not necessarily an established code style for nextflow code, we try to keep code neat and readable.
+Line length should generally be kept under 100 characters, and indentation should be consistent.
+
+For R code, we try to follow [tidyverse style conventions](https://style.tidyverse.org), and encourage the use of the [`styler`](https://styler.r-lib.org/) package to ensure that code is formatted consistently.
+
+For python code, we encourage the use of the `black` code formatter to ensure consistent formatting.
+The `black` package can be installed with `pip install black`, and can be run on a file with `black <filename>`.
+Alternatively, if you use VSCode, you can install the [black extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ If a new reference type is needed, that should be defined in the [`test/stub-ref
 While there is not necessarily an established code style for nextflow code, we try to keep code neat and readable.
 Line length should generally be kept under 100 characters, and indentation should be consistent.
 
-For R code, we try to follow [tidyverse style conventions](https://style.tidyverse.org), and encourage the use of the [`styler`](https://styler.r-lib.org/) package to ensure that code is formatted consistently.
+For R code, we try to follow [`tidyverse` style conventions](https://style.tidyverse.org), and encourage the use of the [`styler`](https://styler.r-lib.org/) package to ensure that code is formatted consistently.
 
 For python code, we encourage the use of the `black` code formatter to ensure consistent formatting.
 The `black` package can be installed with `pip install black`, and can be run on a file with `black <filename>`.
-Alternatively, if you use VSCode, you can install the [black extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).
+Alternatively, if you use [Visual Studio Code](https://code.visualstudio.com), you can install the [`black` extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All Nextflow processes should include a [`stub` block](https://www.nextflow.io/d
 At this stage this is purely used to allow for testing of the main workflow logic rather than the internal logic of each process.
 
 The [`test/stub-run-metadata.tsv`](test/stub-run-metadata.tsv) file is used to define input libraries that will be used for testing.
-Any additions to the overall workflow that will allow processing of a new library type should be added into `test/stub-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for that library type in the `test/runs/` directory.
+Any additions to the overall workflow that will allow processing of a new library type should be added into `test/stub-run-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for that library type in the `test/runs/` directory.
 If a new reference type is needed, that should be defined in the [`test/stub-refs.json`](test/stub-refs.json) file.
 
 ## Code style
@@ -36,6 +36,6 @@ Line length should generally be kept under 100 characters, and indentation shoul
 
 For R code, we try to follow [`tidyverse` style conventions](https://style.tidyverse.org), and encourage the use of the [`styler`](https://styler.r-lib.org/) package to ensure that code is formatted consistently.
 
-For python code, we encourage the use of the `black` code formatter to ensure consistent formatting.
+For python code, we encourage the use of the [`black` code formatter](https://black.readthedocs.io/en/stable/) to ensure consistent formatting.
 The `black` package can be installed with `pip install black`, and can be run on a file with `black <filename>`.
 Alternatively, if you use [Visual Studio Code](https://code.visualstudio.com), you can install the [`black` extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All Nextflow processes should include a [`stub` block](https://www.nextflow.io/d
 At this stage this is purely used to allow for testing of the main workflow logic rather than the internal logic of each process.
 
 The [`test/stub-run-metadata.tsv`](test/stub-run-metadata.tsv) file is used to define input libraries that will be used for testing.
-Each sample ID in the `stub-run-metadata.tsv` file should have a corresponding entry in [`test/stub-sample-metadata.tsv`](test/stub-sample-metadata.tsv) (which can be filled with `NA` values).
+Each `scpca_sample_id` value in the `stub-run-metadata.tsv` file should have a corresponding entry in [`test/stub-sample-metadata.tsv`](test/stub-sample-metadata.tsv) (which can be filled with `NA` values).
 Any additions to the overall workflow that will allow processing of a new library type should include adding new example data.
 This will involve adding rows to `test/stub-run-metadata.tsv` and `test/stub-sample-metadata.tsv`, along with the appropriate input files (usually empty files with the expected names) for each library in the `test/runs/` directory.
 If a new reference type is needed, that should be defined in the [`test/stub-refs.json`](test/stub-refs.json) file.

--- a/bin/add_demux_sce.R
+++ b/bin/add_demux_sce.R
@@ -58,30 +58,30 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 
 # check that unfiltered file file exists
-if(!file.exists(opt$sce_file)){
+if (!file.exists(opt$sce_file)) {
   stop("Can't find input SCE file")
 }
 
 # check that output file name ends in .rds
-if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
+if (!(stringr::str_ends(opt$output_sce_file, ".rds"))) {
   stop("output file name must end in .rds")
 }
 
 # check for donor_ids file in vireo_dir
-if(!is.null(opt$vireo_dir)){
+if (!is.null(opt$vireo_dir)) {
   vireo_file <- file.path(opt$vireo_dir, "donor_ids.tsv")
-  if(!file.exists(vireo_file)){
+  if (!file.exists(vireo_file)) {
     stop("Can't find donor_ids.tsv file in vireo directory")
   }
 }
 
-if(is.null(opt$cellhash_pool_file)){
+if (is.null(opt$cellhash_pool_file)) {
   cellhash_df <- NULL
 } else {
-  if(!file.exists(opt$cellhash_pool_file)){
+  if (!file.exists(opt$cellhash_pool_file)) {
     stop("Can't find cellhash_pool_file")
   }
-  if(is.null(opt$library_id)){
+  if (is.null(opt$library_id)) {
     stop("Must specify library_id with cellhash_pool_file")
   }
   cellhash_df <- readr::read_tsv(opt$cellhash_pool_file) |>
@@ -93,12 +93,12 @@ if(is.null(opt$cellhash_pool_file)){
 sce <- readRDS(opt$sce_file)
 
 # check for cellhash altExp if we will use it
-if( opt$hash_demux || opt$seurat_demux ){
-  if(!"cellhash" %in% altExpNames(sce)){
+if (opt$hash_demux || opt$seurat_demux) {
+  if (!"cellhash" %in% altExpNames(sce)) {
     stop("Can't process cellhash demulitplexing without a 'cellhash' altExp")
   }
   # add cellhash sample data to SCE if present
-  if(!is.null(cellhash_df)){
+  if (!is.null(cellhash_df)) {
     sce <- scpcaTools::add_cellhash_ids(sce, cellhash_df, remove_unlabeled = TRUE)
   }
 }
@@ -106,22 +106,22 @@ if( opt$hash_demux || opt$seurat_demux ){
 cellhash_ids <- rownames(altExp(sce))
 
 # only perform demultiplexing if more than one HTO is detected
-if(length(cellhash_ids) > 1) {
+if (length(cellhash_ids) > 1) {
   # add HashedDrops results
-  if(opt$hash_demux){
+  if (opt$hash_demux) {
     sce <- scpcaTools::add_demux_hashedDrops(sce)
   }
-  
+
   # add Seurat results
-  if(opt$seurat_demux){
+  if (opt$seurat_demux) {
     sce <- scpcaTools::add_demux_seurat(sce)
   }
-  
+
   # add vireo results
-  if(!is.null(opt$vireo_dir)){
+  if (!is.null(opt$vireo_dir)) {
     vireo_table <- readr::read_tsv(vireo_file)
     sce <- scpcaTools::add_demux_vireo(sce, vireo_table)
-  } 
+  }
 }
 
 # write filtered sce to output

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -52,26 +52,26 @@ opt <- parse_args(OptionParser(option_list = option_list))
 set.seed(opt$random_seed)
 
 # check that input file file exists
-if(!file.exists(opt$input_sce_file)){
+if (!file.exists(opt$input_sce_file)) {
   stop("Missing input SCE file")
 }
 
 # check that output file ends in rds
-if (!(stringr::str_ends(opt$output_sce_file, ".rds"))){
+if (!(stringr::str_ends(opt$output_sce_file, ".rds"))) {
   stop("output sce file name must end in .rds")
 }
 
 # check that references all exist
 singler_model_file <- opt$singler_model_file
-if(!file.exists(singler_model_file)) {
+if (!file.exists(singler_model_file)) {
   stop(glue::glue("Provided model file {singler_model_file} is missing."))
 }
 
 # set up multiprocessing params
-if(opt$threads > 1){
-  bp_param = BiocParallel::MulticoreParam(opt$threads)
+if (opt$threads > 1) {
+  bp_param <- BiocParallel::MulticoreParam(opt$threads)
 } else {
-  bp_param = BiocParallel::SerialParam()
+  bp_param <- BiocParallel::SerialParam()
 }
 
 # read in input rds file
@@ -104,8 +104,6 @@ if (opt$label_name == "label.ont") {
     dplyr::rename(singler_celltype_annotation = ontology_cell_names) |>
     # make sure we keep rownames
     DataFrame(row.names = colData(sce)$barcodes)
-
-
 } else {
   # otherwise, just add cell names
   sce$singler_celltype_annotation <- singler_results$pruned.labels
@@ -123,7 +121,8 @@ metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "singler")
 
 
 # export sce with annotations added
-readr::write_rds(sce,
-                 opt$output_sce_file,
-                 compress = 'gz')
-
+readr::write_rds(
+  sce,
+  opt$output_sce_file,
+  compress = "gz"
+)

--- a/bin/classify_cellassign.R
+++ b/bin/classify_cellassign.R
@@ -1,6 +1,7 @@
 #!/usr/bin/env Rscript
 
-# This script is used to read in the predictions from CellAssign and assign cell types in the annotated RDS file
+# This script is used to read in the predictions from CellAssign
+# and assign cell types in the annotated RDS file
 
 # import libraries
 suppressPackageStartupMessages({
@@ -35,12 +36,12 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check that input file exists
-if (!file.exists(opt$input_sce_file)){
+if (!file.exists(opt$input_sce_file)) {
   stop("Missing input SCE file")
 }
 
 # check that cellassign predictions file was provided
-if (!file.exists(opt$cellassign_predictions)){
+if (!file.exists(opt$cellassign_predictions)) {
   stop("Missing CellAssign predictions file")
 }
 # check that reference_name was provided
@@ -49,7 +50,7 @@ if (is.null(opt$reference_name)) {
 }
 
 # check that output file ends in rds
-if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
+if (!(stringr::str_ends(opt$output_sce_file, ".rds"))) {
   stop("output sce file name must end in .rds")
 }
 # read in input files
@@ -57,9 +58,11 @@ sce <- readr::read_rds(opt$input_sce_file)
 predictions <- readr::read_tsv(opt$cellassign_predictions)
 
 celltype_assignments <- predictions |>
-  tidyr::pivot_longer(!barcode,
-                      names_to = "celltype",
-                      values_to = "prediction") |>
+  tidyr::pivot_longer(
+    !barcode,
+    names_to = "celltype",
+    values_to = "prediction"
+  ) |>
   dplyr::group_by(barcode) |>
   dplyr::slice_max(prediction, n = 1) |>
   dplyr::ungroup()

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -1,9 +1,9 @@
 #!/usr/bin/env Rscript
 
 # Script used to perform clustering on a given SCE object
-# 
+#
 # This script reads in an RDS file containing an SCE, and performs
-#  graph-based clustering using the specified algorithm. Cluster identities are 
+#  graph-based clustering using the specified algorithm. Cluster identities are
 #  stored in the SCE's colData slot, and the SCE is written back out to the
 #  original RDS file.
 
@@ -25,7 +25,7 @@ option_list <- list(
     default = "PCA",
     help = "Name of the PCA reduced dimensionality representation to perform
       clustering on."
-  ), 
+  ),
   make_option(
     opt_str = c("--cluster_algorithm"),
     type = "character",
@@ -43,7 +43,7 @@ option_list <- list(
   make_option(
     opt_str = c("--nearest_neighbors"),
     type = "integer",
-    default = 20, 
+    default = 20,
     help = "Nearest neighbors parameter to set for graph-based clustering. Default is 20."
   ),
   make_option(
@@ -75,8 +75,8 @@ if (!opt$pca_name %in% reducedDimNames(sce)) {
 
 # extract the principal components matrix
 clusters <- scran::clusterCells(
-  sce, 
-  use.dimred = opt$pca_name, 
+  sce,
+  use.dimred = opt$pca_name,
   BLUSPARAM = bluster::NNGraphParam(
     k = opt$nearest_neighbors,
     type = opt$cluster_weighting,

--- a/bin/generate_bulk_metadata.R
+++ b/bin/generate_bulk_metadata.R
@@ -59,35 +59,39 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check for project id
-if(is.null(opt$project_id)){
+if (is.null(opt$project_id)) {
   stop("A `project_id` is required.")
 }
 
 
 # replace workflow url and commit if not provided
-if (is.null(opt$workflow_url)){
+if (is.null(opt$workflow_url)) {
   opt$workflow_url <- NA
 }
-if (is.null(opt$workflow_version)){
+if (is.null(opt$workflow_version)) {
   opt$workflow_version <- NA
 }
-if (is.null(opt$workflow_commit)){
+if (is.null(opt$workflow_commit)) {
   opt$workflow_commit <- NA
 }
 
-# read in library metadata file 
+# read in library metadata file
 library_metadata <- readr::read_tsv(opt$library_metadata_file)
 
-# list of paths to salmon log files 
+# list of paths to salmon log files
 library_ids <- readLines(opt$salmon_dirs)
 
-# subset library metadata to only contain libraries that are being processed 
-# only keep metadata columns of interest 
+# subset library metadata to only contain libraries that are being processed
+# only keep metadata columns of interest
 bulk_metadata_df <- library_metadata |>
-  dplyr::filter(scpca_library_id %in% library_ids &
-                scpca_project_id %in% opt$project_id) |>
-  dplyr::select(scpca_sample_id, scpca_library_id, scpca_project_id,
-                technology, seq_unit) |> 
+  dplyr::filter(
+    scpca_library_id %in% library_ids &
+      scpca_project_id %in% opt$project_id
+  ) |>
+  dplyr::select(
+    scpca_sample_id, scpca_library_id, scpca_project_id,
+    technology, seq_unit
+  ) |>
   # rename column names to match format of metadata files from other modalities
   dplyr::rename(
     sample_id = scpca_sample_id,
@@ -95,30 +99,32 @@ bulk_metadata_df <- library_metadata |>
     project_id = scpca_project_id
   ) |>
   # add columns with processing information and date processed (same for all libraries )
-  dplyr::mutate(genome_assembly = opt$genome_assembly, 
-                workflow = opt$workflow_url,
-                workflow_version = opt$workflow_version,
-                workflow_commit = opt$workflow_commit)
+  dplyr::mutate(
+    genome_assembly = opt$genome_assembly,
+    workflow = opt$workflow_url,
+    workflow_version = opt$workflow_version,
+    workflow_commit = opt$workflow_commit
+  )
 
 
-# add salmon version, index, total_reads, mapped_reads for each library 
+# add salmon version, index, total_reads, mapped_reads for each library
 get_processing_info <- function(library_id) {
-  
   # read in json files for that library containing individual process information
   cmd_info_file <- file.path(library_id, "cmd_info.json")
   meta_info_file <- file.path(library_id, "aux_info", "meta_info.json")
-  
+
   cmd_info <- jsonlite::read_json(cmd_info_file)
   meta_info <- jsonlite::read_json(meta_info_file)
-  
+
   # add date processed from salmon in the format: "Mon Jan 03 15:13:14 2022"
-  date_processed <- lubridate::as_datetime(meta_info$end_time, 
-                                           format = "%a %b %d %T %Y")
+  date_processed <- lubridate::as_datetime(meta_info$end_time,
+    format = "%a %b %d %T %Y"
+  )
   # if meta_info is not recorded or the format has changed, use the modification time of the file
-  if (is.na(date_processed)){
+  if (is.na(date_processed)) {
     date_processed <- file.info(meta_info_file)$mtime
   }
-  
+
   library_processing <- data.frame(
     library_id = library_id,
     salmon_version = cmd_info$salmon_version,
@@ -127,13 +133,14 @@ get_processing_info <- function(library_id) {
     mapped_reads = meta_info$num_mapped,
     date_processed = lubridate::format_ISO8601(date_processed, usetz = TRUE)
   )
-  
+
+  return(library_processing)
 }
 
-bulk_processing_metadata <- purrr::map_dfr(library_ids, get_processing_info) 
+bulk_processing_metadata <- purrr::map_dfr(library_ids, get_processing_info)
 
 bulk_metadata_df <- bulk_metadata_df |>
   dplyr::left_join(bulk_processing_metadata, by = c("library_id"))
 
-# write out file 
+# write out file
 readr::write_tsv(bulk_metadata_df, file = opt$metadata_output)

--- a/bin/generate_cellassign_refs.R
+++ b/bin/generate_cellassign_refs.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# this script is used to create binary gene x cell marker genes matrices 
+# this script is used to create binary gene x cell marker genes matrices
 # for use as references with CellAssign
 
 library(optparse)
@@ -14,7 +14,7 @@ option_list <- list(
   make_option(
     opt_str = c("--marker_gene_file"),
     type = "character",
-    help = "File containing a list of marker genes for all cell types and all organs. 
+    help = "File containing a list of marker genes for all cell types and all organs.
       Must contain the `organ` column, `--cell_type_column` and `--gene_id_column`. "
   ),
   make_option(
@@ -45,7 +45,7 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 # Set up -----------------------------------------------------------------------
 
-if(!file.exists(opt$marker_gene_file)){
+if (!file.exists(opt$marker_gene_file)) {
   stop("Provided `marker_gene_file` does not exist.")
 }
 
@@ -55,18 +55,18 @@ organs <- stringr::str_split(opt$organs, ",") |>
   unlist() |>
   stringr::str_trim()
 
-if(!all(organs %in% marker_gene_df$organ)){
+if (!all(organs %in% marker_gene_df$organ)) {
   stop("`organs` must be present in `organ` column of `marker_gene_file`.")
 }
 
 cell_type_column <- opt$cell_type_column
 gene_id_column <- opt$gene_id_column
 
-if(!(cell_type_column %in% colnames(marker_gene_df))){
+if (!(cell_type_column %in% colnames(marker_gene_df))) {
   stop("Specified `cell_type_column` does not exist as a column in `marker_gene_file`")
 }
 
-if(!(gene_id_column %in% colnames(marker_gene_df))){
+if (!(gene_id_column %in% colnames(marker_gene_df))) {
   stop("Specified `gene_id_column` does not exist as a column in `marker_gene_file`")
 }
 
@@ -75,18 +75,20 @@ if(!(gene_id_column %in% colnames(marker_gene_df))){
 # grab marker genes for specified organs from marker gene reference
 organ_gene_df <- marker_gene_df |>
   dplyr::filter(organ %in% organs) |>
-  dplyr::select({{cell_type_column}}, {{gene_id_column}})
+  dplyr::select({{ cell_type_column }}, {{ gene_id_column }})
 
-# create a binary matrix of genes by cell type markers 
+# create a binary matrix of genes by cell type markers
 binary_mtx <- organ_gene_df |>
-  tidyr::pivot_wider(id_cols = gene_id_column,
-                     names_from = cell_type_column,
-                     values_from = cell_type_column,
-                     values_fn = length,
-                     values_fill = 0) |> 
+  tidyr::pivot_wider(
+    id_cols = gene_id_column,
+    names_from = cell_type_column,
+    values_from = cell_type_column,
+    values_fn = length,
+    values_fill = 0
+  ) |>
   tibble::column_to_rownames(gene_id_column) |>
-  # add a column with no marker genes 
-  # cell assign will assign cells to "other" when no other cell types are appropriate 
+  # add a column with no marker genes
+  # cell assign will assign cells to "other" when no other cell types are appropriate
   dplyr::mutate(other = 0)
 
 # replace length with 1
@@ -94,11 +96,11 @@ binary_mtx[binary_mtx > 1] <- 1
 
 # Add ensembl ids --------------------------------------------------------------
 
-# combine with ensembl gene id 
+# combine with ensembl gene id
 # read in gtf file (genes only for speed)
 gtf <- rtracklayer::import(opt$gtf_file, feature.type = "gene")
 
-# create a data frame with ensembl id and gene symbol 
+# create a data frame with ensembl id and gene symbol
 gene_id_map <- gtf |>
   as.data.frame() |>
   dplyr::select(

--- a/bin/generate_spaceranger_metadata.R
+++ b/bin/generate_spaceranger_metadata.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# This script generates the metadata.json file for Spatial Transcriptomics libraries. 
+# This script generates the metadata.json file for Spatial Transcriptomics libraries.
 
 # import libraries
 library(optparse)
@@ -91,55 +91,57 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check for sample and library id
-if(is.null(opt$library_id)){
+if (is.null(opt$library_id)) {
   stop("A `library_id` is required.")
 }
-if(is.null(opt$sample_id)){
+if (is.null(opt$sample_id)) {
   stop("A `sample_id` is required.")
 }
 
 # check that barcode files exist
-if(is.null(opt$unfiltered_barcodes_file) || !file.exists(opt$unfiltered_barcodes_file)){
+if (is.null(opt$unfiltered_barcodes_file) || !file.exists(opt$unfiltered_barcodes_file)) {
   stop("Unfiltered barcodes file missing or `unfiltered_barcodes_file` not specified.")
 }
-if(is.null(opt$filtered_barcodes_file) || !file.exists(opt$filtered_barcodes_file)){
+if (is.null(opt$filtered_barcodes_file) || !file.exists(opt$filtered_barcodes_file)) {
   stop("Filtered barcodes file missing or `filtered_barcodes_file` not specified.")
 }
 
-# check that metrics summary file exists 
-if(is.null(opt$metrics_summary_file) || !file.exists(opt$metrics_summary_file)){
+# check that metrics summary file exists
+if (is.null(opt$metrics_summary_file) || !file.exists(opt$metrics_summary_file)) {
   stop("Metrics summary file missing or `metrics_summary_file` not specified.")
 }
 
 # check that version file exists
-if(is.null(opt$spaceranger_versions_file) || !file.exists(opt$spaceranger_versions_file)){
+if (is.null(opt$spaceranger_versions_file) || !file.exists(opt$spaceranger_versions_file)) {
   stop("Versions file missing or `spaceranger_versions_file` not specified.")
 }
 
 # replace workflow url and commit if not provided
-if (opt$workflow_url == "null"){
+if (opt$workflow_url == "null") {
   opt$workflow_url <- NA
 }
-if (opt$workflow_version == "null"){
+if (opt$workflow_version == "null") {
   opt$workflow_version <- NA
 }
-if (opt$workflow_commit == "null"){
+if (opt$workflow_commit == "null") {
   opt$workflow_commit <- NA
 }
 
 # read in barcode files
 unfiltered_barcodes <- readr::read_tsv(opt$unfiltered_barcodes_file,
-                                       col_names = c("barcode"))
+  col_names = c("barcode")
+)
 filtered_barcodes <- readr::read_tsv(opt$filtered_barcodes_file,
-                                     col_names = c("barcode"))
+  col_names = c("barcode")
+)
 
-# read in metrics summary 
+# read in metrics summary
 metrics_summary <- readr::read_csv(opt$metrics_summary_file)
 
-# read in versions file 
+# read in versions file
 spaceranger_versions <- jsonlite::read_json(opt$spaceranger_versions_file)
 
-# compile metadata list 
+# compile metadata list
 metadata_list <- list(
   library_id = opt$library_id,
   sample_id = opt$sample_id,
@@ -158,8 +160,7 @@ metadata_list <- list(
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
-  purrr::map(~if(is.null(.)) NA else .) # convert any NULLS to NA
+  purrr::map(~ if (is.null(.)) NA else .) # convert any NULLS to NA
 
 # Output metadata as JSON
 jsonlite::write_json(metadata_list, path = opt$metadata_json, auto_unbox = TRUE)
-

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -74,22 +74,22 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check that output file name ends in .rds
-if(!(stringr::str_ends(opt$unfiltered_file, ".rds"))){
+if (!(stringr::str_ends(opt$unfiltered_file, ".rds"))) {
   stop("unfiltered file name must end in .rds")
 }
 
 # check that mitochondrial gene list exists
-if(!file.exists(opt$mito_file)){
+if (!file.exists(opt$mito_file)) {
   stop("Mitochondrial gene list file not found.")
 }
 
 # check that gtf file exists
-if(!file.exists(opt$gtf_file)){
+if (!file.exists(opt$gtf_file)) {
   stop("gtf file not found.")
 }
 
 # check that sample metadata file exists
-if(!file.exists(opt$sample_metadata_file)){
+if (!file.exists(opt$sample_metadata_file)) {
   stop("sample metadata file not found.")
 }
 
@@ -106,21 +106,25 @@ sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 include_unspliced <- !opt$spliced_only
 
 # get unfiltered sce
-unfiltered_sce <- read_alevin(quant_dir = opt$alevin_dir,
-                              include_unspliced = include_unspliced,
-                              fry_mode = TRUE,
-                              tech_version = opt$technology,
-                              library_id = opt$library_id,
-                              sample_id = sample_ids)
+unfiltered_sce <- read_alevin(
+  quant_dir = opt$alevin_dir,
+  include_unspliced = include_unspliced,
+  fry_mode = TRUE,
+  tech_version = opt$technology,
+  library_id = opt$library_id,
+  sample_id = sample_ids
+)
 
 # read and merge feature counts if present
-if (opt$feature_dir != ""){
-  feature_sce <- read_alevin(quant_dir = opt$feature_dir,
-                             include_unspliced = FALSE,
-                             fry_mode = TRUE,
-                             feature_data = TRUE,
-                             library_id = opt$library_id,
-                             sample_id = sample_ids)
+if (opt$feature_dir != "") {
+  feature_sce <- read_alevin(
+    quant_dir = opt$feature_dir,
+    include_unspliced = FALSE,
+    fry_mode = TRUE,
+    feature_data = TRUE,
+    library_id = opt$library_id,
+    sample_id = sample_ids
+  )
 
   unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name)
   # add alt experiment features stats
@@ -143,7 +147,7 @@ sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
 # add per cell and per gene statistics to colData and rowData
 unfiltered_sce <- unfiltered_sce |>
   add_cell_mito_qc(mito = mito_genes) |>
- # add gene symbols to rowData
+  # add gene symbols to rowData
   add_gene_symbols(gene_info = gtf) |>
   scuttle::addPerFeatureQCMetrics() |>
   # add dataframe with sample metadata to sce metadata
@@ -151,4 +155,3 @@ unfiltered_sce <- unfiltered_sce |>
 
 # write to rds
 readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")
-

--- a/bin/integrate_sce.R
+++ b/bin/integrate_sce.R
@@ -61,31 +61,31 @@ set.seed(opt$seed)
 # Check and assign provided method based on available methods
 available_methods <- c("fastMNN", "harmony")
 
-if(!(opt$method %in% available_methods)){
+if (!(opt$method %in% available_methods)) {
   stop("You must specify either `fastMNN` or `harmony` to the --method.")
 }
 
 # Check that provided input file exists and is an RDS file
-if(is.null(opt$input_sce_file)) {
+if (is.null(opt$input_sce_file)) {
   stop("You must provide the path to the RDS file with merged SCEs to --input_sce_file")
 } else {
-  if(!file.exists(opt$input_sce_file)) {
+  if (!file.exists(opt$input_sce_file)) {
     stop("Provided --input_sce_file file does not exist.")
   }
 }
 
 # set up multiprocessing params
-if(opt$threads > 1){
-  bp_param = BiocParallel::MulticoreParam(opt$threads)
+if (opt$threads > 1) {
+  bp_param <- BiocParallel::MulticoreParam(opt$threads)
 } else {
-  bp_param = BiocParallel::SerialParam()
+  bp_param <- BiocParallel::SerialParam()
 }
 
 # Read in SCE file -------------------------------------------------------------
 merged_sce <- readr::read_rds(opt$input_sce_file)
 
 # check that input contains a SCE object
-if(!is(merged_sce, "SingleCellExperiment")){
+if (!is(merged_sce, "SingleCellExperiment")) {
   stop("The input RDS file must contain a SingleCellExperiment object.")
 }
 
@@ -104,23 +104,25 @@ integration_args <- list(
 )
 
 # append fastMNN only args
-if(opt$method == "fastMNN"){
-  integration_args <-  append(
+if (opt$method == "fastMNN") {
+  integration_args <- append(
     integration_args,
     list(
       subset.row = merged_hvgs,
       auto.merge = TRUE,
       BPPARAM = bp_param
-   ))
+    )
+  )
 }
 
 # append harmony only args
-if(opt$method == "harmony"){
+if (opt$method == "harmony") {
   integration_arts <- append(
     integration_args,
     list(
       covariate_cols = opt$harmony_covariate_cols
-    ))
+    )
+  )
 }
 
 # perform integration
@@ -128,8 +130,10 @@ integrated_sce <- do.call(scpcaTools::integrate_sces, integration_args)
 
 # calculate UMAP from corrected PCA
 integrated_sce <- integrated_sce |>
-  scater::runUMAP(dimred = glue::glue("{opt$method}_PCA"),
-                  name = glue::glue("{opt$method}_UMAP"))
+  scater::runUMAP(
+    dimred = glue::glue("{opt$method}_PCA"),
+    name = glue::glue("{opt$method}_UMAP")
+  )
 
 # add method to integrated sce
 existing_methods <- metadata(integrated_sce)$integration_methods

--- a/bin/make_reference_fasta.R
+++ b/bin/make_reference_fasta.R
@@ -50,7 +50,7 @@ option_list <- list(
     help = "Prefix name containing organism and ensembl assembly version to be used for file naming"
   ),
   make_option(
-    opt_str = c("-l","--flank_length"),
+    opt_str = c("-l", "--flank_length"),
     type = "integer",
     default = 86,
     help = "Length of sequence flanking introns to be included in index, recommended to use read length minus 5."
@@ -77,11 +77,15 @@ spliced_cdna_tx2gene_file <- paste0(opt$reference_name, ".spliced_cdna.tx2gene.t
 # splici output
 spliced_intron_fasta <- file.path(opt$fasta_output, spliced_intron_fasta_file)
 spliced_intron_gtf <- file.path(opt$annotation_output, spliced_intron_gtf_file)
-spliced_intron_tx2gene <- file.path(opt$annotation_output,
-                                    spliced_intron_tx2gene_file)
+spliced_intron_tx2gene <- file.path(
+  opt$annotation_output,
+  spliced_intron_tx2gene_file
+)
 
-spliced_intron_tx2gene_3col <- file.path(opt$annotation_output,
-                                 spliced_intron_tx2gene_3col_file)
+spliced_intron_tx2gene_3col <- file.path(
+  opt$annotation_output,
+  spliced_intron_tx2gene_3col_file
+)
 
 # spliced cDNA output
 spliced_cdna_fasta <- file.path(opt$fasta_output, spliced_cdna_fasta_file)
@@ -134,7 +138,8 @@ splici_grl <- splici_grl[names(splici_seqs)]
 
 # write splici to fasta
 Biostrings::writeXStringSet(
-  splici_seqs, filepath = spliced_intron_fasta, compress = TRUE
+  splici_seqs,
+  filepath = spliced_intron_fasta, compress = TRUE
 )
 
 # write the associated annotations to gtf
@@ -151,12 +156,14 @@ splici_tx2gene_df <- eisaR::getTx2Gene(splici_grl)
 readr::write_tsv(splici_tx2gene_df, spliced_intron_tx2gene, col_names = FALSE)
 
 # make 3 column Tx2 gene needed for alevin-fry USA mode
-splici_tx2gene_df_3col <- splici_tx2gene_df  %>%
+splici_tx2gene_df_3col <- splici_tx2gene_df %>%
   # add status column
   # remove extra -I* on gene ID
-  mutate(gene_id = stringr::word(gene_id,1,sep = '-'),
-         #if transcript_id contains an added -I*, then it is usnpliced
-         status = ifelse(stringr::str_detect(transcript_id, '-I'), 'U', 'S'))
+  mutate(
+    gene_id = stringr::word(gene_id, 1, sep = "-"),
+    # if transcript_id contains an added -I*, then it is usnpliced
+    status = ifelse(stringr::str_detect(transcript_id, "-I"), "U", "S")
+  )
 
 # write 3 column tx2gene
 readr::write_tsv(splici_tx2gene_df_3col, spliced_intron_tx2gene_3col, col_names = FALSE)
@@ -164,16 +171,16 @@ readr::write_tsv(splici_tx2gene_df_3col, spliced_intron_tx2gene_3col, col_names 
 
 # reimport gtf to get list of mito genes
 gtf <- rtracklayer::import(spliced_intron_gtf)
-mitogenes <- gtf[seqnames(gtf) == 'MT']
+mitogenes <- gtf[seqnames(gtf) == "MT"]
 
 # write out mitochondrial gene list
 writeLines(unique(mitogenes$gene_id), mito_out)
 
 # get list of all spliced transcript ID's
-spliced_cdna_genes = metadata(grl)$featurelist$spliced
+spliced_cdna_genes <- metadata(grl)$featurelist$spliced
 
 # subset sequences for only spliced cDNA
-spliced_cdna_grl = grl[spliced_cdna_genes]
+spliced_cdna_grl <- grl[spliced_cdna_genes]
 
 spliced_cdna_seqs <- GenomicFeatures::extractTranscriptSeqs(
   x = genome,
@@ -182,7 +189,8 @@ spliced_cdna_seqs <- GenomicFeatures::extractTranscriptSeqs(
 
 # write spliced sequences only to fasta file
 Biostrings::writeXStringSet(
-  spliced_cdna_seqs, filepath = spliced_cdna_fasta, compress = TRUE
+  spliced_cdna_seqs,
+  filepath = spliced_cdna_fasta, compress = TRUE
 )
 
 # write the associated annotations to gtf
@@ -196,4 +204,3 @@ spliced_cdna_tx2gene_df <- eisaR::getTx2Gene(spliced_cdna_grl)
 
 # write out Tx2Gene for spliced transcripts
 readr::write_tsv(spliced_cdna_tx2gene_df, spliced_cdna_tx2gene, col_names = FALSE)
-

--- a/bin/merge_counts_tximport.R
+++ b/bin/merge_counts_tximport.R
@@ -40,7 +40,7 @@ opt <- parse_args(OptionParser(option_list = option_list))
 # read in tx2gene
 tx2gene <- readr::read_tsv(opt$tx2gene, col_names = c("transcript_id", "gene_id"))
 
-# list of paths to salmon files 
+# list of paths to salmon files
 library_ids <- readLines(opt$salmon_dirs)
 salmon_files <- file.path(library_ids, "quant.sf")
 names(salmon_files) <- library_ids
@@ -49,7 +49,7 @@ names(salmon_files) <- library_ids
 txi_salmon <- tximport(salmon_files, type = "salmon", tx2gene = tx2gene)
 
 # write counts matrix to txt file
-txi_salmon$counts %>%
-  as.data.frame() %>%
-  tibble::rownames_to_column("gene_id") %>%
+txi_salmon$counts |>
+  as.data.frame() |>
+  tibble::rownames_to_column("gene_id") |>
   readr::write_tsv(file = opt$output_file)

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -15,28 +15,43 @@ import argparse
 import re
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-i', '--input_hdf5_file',
-                    dest = 'input_hdf5_file',
-                    required = True,
-                    help = 'Path to HDF5 file with processed AnnData object to annotate')
-parser.add_argument('-o', '--output_predictions',
-                    dest = 'output_predictions',
-                    required = True,
-                    help = 'Path to file to save the predictions, should end in tsv')
-parser.add_argument('-r', '--reference',
-                    dest = 'reference',
-                    required = True,
-                    help = 'Path to marker by cell type reference file, should end in tsv')
-parser.add_argument('-s', '--seed',
-                    dest = 'seed',
-                    type=int,
-                    default = None,
-                    help = 'Random seed to set for scvi.')
-parser.add_argument('-t', '--threads',
-                    dest = 'threads',
-                    default = 1,
-                    type = int,
-                    help = 'Number of threads to use when training the CellAssign model')
+parser.add_argument(
+    "-i",
+    "--input_hdf5_file",
+    dest="input_hdf5_file",
+    required=True,
+    help="Path to HDF5 file with processed AnnData object to annotate",
+)
+parser.add_argument(
+    "-o",
+    "--output_predictions",
+    dest="output_predictions",
+    required=True,
+    help="Path to file to save the predictions, should end in tsv",
+)
+parser.add_argument(
+    "-r",
+    "--reference",
+    dest="reference",
+    required=True,
+    help="Path to marker by cell type reference file, should end in tsv",
+)
+parser.add_argument(
+    "-s",
+    "--seed",
+    dest="seed",
+    type=int,
+    default=None,
+    help="Random seed to set for scvi.",
+)
+parser.add_argument(
+    "-t",
+    "--threads",
+    dest="threads",
+    default=1,
+    type=int,
+    help="Number of threads to use when training the CellAssign model",
+)
 
 args = parser.parse_args()
 
@@ -53,7 +68,9 @@ file_ext = re.compile(r"\.hdf5$|.h5$", re.IGNORECASE)
 if not os.path.exists(args.input_hdf5_file):
     raise FileExistsError("--input_hdf5_file file not found.")
 elif not file_ext.search(args.input_hdf5_file):
-    raise ValueError("--input_hdf5_file must end in either .hdf5 or .h5 and contain a processed AnnData object.")
+    raise ValueError(
+        "--input_hdf5_file must end in either .hdf5 or .h5 and contain a processed AnnData object."
+    )
 
 # check that marker file exists and make sure its a tsv
 if not os.path.exists(args.reference):
@@ -64,7 +81,7 @@ if not args.output_predictions.endswith(".tsv"):
     raise ValueError("--output_predictions must provide a file path ending in tsv")
 
 # read in references as marker gene tables
-ref_matrix = pd.read_csv(args.reference, sep = "\t", index_col='ensembl_id')
+ref_matrix = pd.read_csv(args.reference, sep="\t", index_col="ensembl_id")
 
 # file path to annotated sce
 annotated_adata = adata.read_h5ad(args.input_hdf5_file)
@@ -85,7 +102,7 @@ scvi.external.CellAssign.setup_anndata(subset_adata, size_factor_key="size_facto
 model = CellAssign(subset_adata, ref_matrix)
 model.train()
 predictions = model.predict()
-predictions['barcode'] = subset_adata.obs_names
+predictions["barcode"] = subset_adata.obs_names
 
 # write out predictions as tsv
-predictions.to_csv(args.output_predictions, sep = "\t", index = False)
+predictions.to_csv(args.output_predictions, sep="\t", index=False)

--- a/bin/save_singler_refs.R
+++ b/bin/save_singler_refs.R
@@ -22,12 +22,12 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # check that provided ref name is in celldex package
-if(! opt$ref_name %in% ls("package:celldex")){
+if (!opt$ref_name %in% ls("package:celldex")) {
   stop(glue::glue("Provided `ref_name` `{opt$ref_name}` does not match a celldex dataset."))
-} 
+}
 
 # get a reference library from celldex:
 ref <- do.call(`::`, args = list("celldex", opt$ref_name))(ensembl = TRUE)
 
-# export ref data 
+# export ref data
 readr::write_rds(ref, opt$ref_file, compress = "gz")

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -102,33 +102,33 @@ option_list <- list(
 )
 
 opt <- parse_args(OptionParser(option_list = option_list))
-if(is.null(opt$library_id)){
+if (is.null(opt$library_id)) {
   stop("A `library_id` is required.")
 }
 
 # check that template file, if given, exists
-if(!is.null(opt$report_template) && !file.exists(opt$report_template)){
+if (!is.null(opt$report_template) && !file.exists(opt$report_template)) {
   stop("Specified `report_template` could not be found.")
 }
 
-if(is.null(opt$unfiltered_sce) || !file.exists(opt$unfiltered_sce)){
+if (is.null(opt$unfiltered_sce) || !file.exists(opt$unfiltered_sce)) {
   stop("Unfiltered .rds file missing or `unfiltered_sce` not specified.")
 }
-if(is.null(opt$filtered_sce) || !file.exists(opt$filtered_sce)){
+if (is.null(opt$filtered_sce) || !file.exists(opt$filtered_sce)) {
   stop("Filtered .rds file missing or `filtered_sce` not specified.")
 }
 demux_methods <- c("vireo", "HTODemux", "HashedDrops")
-if(!opt$demux_method %in% demux_methods){
+if (!opt$demux_method %in% demux_methods) {
   stop("Unknown `demux_method` value. Must be one of `vireo`, `HTOdemux`, or `HashedDrops`")
 }
 
-if (opt$workflow_url == "null"){
+if (opt$workflow_url == "null") {
   opt$workflow_url <- NA
 }
-if (opt$workflow_version == "null"){
+if (opt$workflow_version == "null") {
   opt$workflow_version <- NA
 }
-if (opt$workflow_commit == "null"){
+if (opt$workflow_commit == "null") {
   opt$workflow_commit <- NA
 }
 
@@ -146,16 +146,20 @@ processed_sce_meta <- metadata(processed_sce)
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # check for multiplexing
-multiplexed = if (length(sample_ids) > 1){TRUE} else {FALSE}
+multiplexed <- if (length(sample_ids) > 1) {
+  TRUE
+} else {
+  FALSE
+}
 
 # sanity check ids
-if (!is.null(sce_meta$sample_id)){
-  if (!all.equal(sample_ids, sce_meta$sample_id)){
+if (!is.null(sce_meta$sample_id)) {
+  if (!all.equal(sample_ids, sce_meta$sample_id)) {
     stop("--sample_id  does not match SCE metadata")
   }
 }
-if (!is.null(sce_meta$library_id)){
-  if (opt$library_id != sce_meta$library_id){
+if (!is.null(sce_meta$library_id)) {
+  if (opt$library_id != sce_meta$library_id) {
     stop("--library_id  does not match SCE metadata")
   }
 }
@@ -193,14 +197,18 @@ metadata_list <- list(
   workflow_version = opt$workflow_version,
   workflow_commit = opt$workflow_commit
 ) |>
-  purrr::map(\(x) {if(is.null(x)) NA else x}) # convert any NULLS to NA
+  purrr::map(\(x) {
+    if (is.null(x)) NA else x
+  }) # convert any NULLS to NA
 
 # add adt methods if citeseq
 if (has_citeseq) {
   metadata_list <- append(
     metadata_list,
-    list(adt_filtering_method = processed_sce_meta$adt_scpca_filter_method,
-         adt_normalization_method = processed_sce_meta$adt_normalization)
+    list(
+      adt_filtering_method = processed_sce_meta$adt_scpca_filter_method,
+      adt_normalization_method = processed_sce_meta$adt_normalization
+    )
   )
 }
 
@@ -215,9 +223,11 @@ if (multiplexed) {
   # add demux info to the metadata list
   metadata_list <- append(
     metadata_list,
-    list(demux_method = opt$demux_method,
-         demux_samples = sample_ids,
-         sample_cell_estimates = demux_counts)
+    list(
+      demux_method = opt$demux_method,
+      demux_samples = sample_ids,
+      sample_cell_estimates = demux_counts
+    )
   )
 }
 
@@ -233,4 +243,3 @@ scpcaTools::generate_qc_report(
   output = opt$qc_report_file,
   extra_params = list(seed = opt$seed)
 )
-

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -38,12 +38,12 @@ opt <- parse_args(OptionParser(option_list = option_list))
 # Set up -----------------------------------------------------------------------
 
 # check that filtered SCE file exists
-if(!file.exists(opt$input_sce_file)){
+if (!file.exists(opt$input_sce_file)) {
   stop(glue::glue("{opt$input_sce_file} does not exist."))
 }
 
 # check that output file is h5
-if(!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))){
+if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))) {
   stop("output rna file name must end in .hdf5 or .h5")
 }
 
@@ -52,8 +52,7 @@ if(!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))){
 # this function applies any necessary reformatting or changes needed to make
 # sure that the sce that is getting converted to AnnData is compliant with CZI
 # CZI 3.0.0 requirements: https://github.com/chanzuckerberg/single-cell-curation/blob/b641130fe53b8163e50c39af09ee3fcaa14c5ea7/schema/3.0.0/schema.md
-format_czi <- function(sce){
-
+format_czi <- function(sce) {
   # add library_id as an sce colData column
   sce$library_id <- metadata(sce)$library_id
 
@@ -62,7 +61,8 @@ format_czi <- function(sce){
 
   # add sample metadata to colData sce
   sce <- scpcaTools::metadata_to_coldata(sce,
-                                         join_columns = "library_id")
+    join_columns = "library_id"
+  )
 
   # remove sample metadata from sce metadata, otherwise conflicts with converting object
   metadata(sce) <- metadata(sce)[names(metadata(sce)) != "sample_metadata"]
@@ -78,7 +78,6 @@ format_czi <- function(sce){
   }
 
   return(sce)
-
 }
 
 # AltExp to AnnData -----------------------------------------------------------
@@ -102,15 +101,14 @@ scpcaTools::sce_to_anndata(
 )
 
 # if feature data exists, grab it and export to AnnData
-if(!is.null(opt$feature_name)){
-
+if (!is.null(opt$feature_name)) {
   # make sure the feature data is present
-  if(!(opt$feature_name %in% altExpNames(sce))){
+  if (!(opt$feature_name %in% altExpNames(sce))) {
     stop("feature_name must match name of altExp in provided SCE object.")
   }
 
   # check for output file
-  if(!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))){
+  if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
     stop("output feature file name must end in .hdf5 or .h5")
   }
 
@@ -128,5 +126,4 @@ if(!is.null(opt$feature_name)){
     alt_sce,
     anndata_file = opt$output_feature_h5
   )
-
 }

--- a/bin/train_SingleR.R
+++ b/bin/train_SingleR.R
@@ -60,19 +60,19 @@ opt <- parse_args(OptionParser(option_list = option_list))
 set.seed(opt$random_seed)
 
 # check that input files exist
-if(!file.exists(opt$ref_file)){
+if (!file.exists(opt$ref_file)) {
   stop("Missing input file with cell type reference (`ref_file`).")
 }
 
-if(!file.exists(opt$fry_tx2gene)){
+if (!file.exists(opt$fry_tx2gene)) {
   stop("Missing `fry_tx2gene` file.")
 }
 
 # set up multiprocessing params
-if(opt$threads > 1){
-  bp_param = BiocParallel::MulticoreParam(opt$threads)
+if (opt$threads > 1) {
+  bp_param <- BiocParallel::MulticoreParam(opt$threads)
 } else {
-  bp_param = BiocParallel::SerialParam()
+  bp_param <- BiocParallel::SerialParam()
 }
 
 # read in model
@@ -80,21 +80,23 @@ ref_data <- readr::read_rds(opt$ref_file)
 
 # check that ref data contains correct labels, and set up label column for later
 label_col <- opt$label_name
-if(!label_col %in% colnames(colData(ref_data))){
+if (!label_col %in% colnames(colData(ref_data))) {
   stop(
     glue::glue("Reference dataset must contain `{label_col}` in `colData`.")
   )
 }
 
 # read in tx2gene
-tx2gene <- readr::read_tsv(opt$fry_tx2gene,
-                           col_names = c("transcript", "gene", "transcript_type"))
+tx2gene <- readr::read_tsv(
+  opt$fry_tx2gene,
+  col_names = c("transcript", "gene", "transcript_type")
+)
 
 # select genes to use for model restriction
 gene_ids <- unique(tx2gene$gene)
 
 # check that genes aren't empty
-if (length(gene_ids) == 0){
+if (length(gene_ids) == 0) {
   stop("Provided tx2gene tsv file does not contain any genes.")
 }
 

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -18,6 +18,7 @@ Ensembl
 et
 fastq
 FASTQ
+formatter
 Github
 glioblastoma
 GRCh

--- a/get_refs.py
+++ b/get_refs.py
@@ -20,34 +20,51 @@ import json
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--refdir", type=str,
-                    default="scpca-references",
-                    help = "destination directory for downloaded reference files")
-parser.add_argument("--paramfile", type=str,
-                    default="localref_params.yaml",
-                    help = "path to nextflow param file to write (default: `localref_params.yaml`)")
-parser.add_argument("--overwrite_refs",
-                    action = "store_true",
-                    help = "replace previously downloaded files")
-parser.add_argument("-r", "--revision", type=str,
-                    default="main",
-                    metavar = "vX.X.X",
-                    help = "tag for a specific workflow version (defaults to latest revision)")
-parser.add_argument("--star_index",
-                    action = "store_true",
-                    help = "get STAR index (required for genetic demultiplexing)")
-parser.add_argument("--cellranger_index",
-                    action = "store_true",
-                    help = "get Cell Ranger index (required for spatial data)")
-parser.add_argument("--docker",
-                    action = "store_true",
-                    help = "pull and cache images for docker")
-parser.add_argument("--singularity",
-                    action = "store_true",
-                    help = "pull and cache images for singularity")
-parser.add_argument("--singularity_dir", type=str,
-                    default = "singularity",
-                    help = "directory to store singularity image files (default: `singularity`)")
+parser.add_argument(
+    "--refdir",
+    type=str,
+    default="scpca-references",
+    help="destination directory for downloaded reference files",
+)
+parser.add_argument(
+    "--paramfile",
+    type=str,
+    default="localref_params.yaml",
+    help="path to nextflow param file to write (default: `localref_params.yaml`)",
+)
+parser.add_argument(
+    "--overwrite_refs", action="store_true", help="replace previously downloaded files"
+)
+parser.add_argument(
+    "-r",
+    "--revision",
+    type=str,
+    default="main",
+    metavar="vX.X.X",
+    help="tag for a specific workflow version (defaults to latest revision)",
+)
+parser.add_argument(
+    "--star_index",
+    action="store_true",
+    help="get STAR index (required for genetic demultiplexing)",
+)
+parser.add_argument(
+    "--cellranger_index",
+    action="store_true",
+    help="get Cell Ranger index (required for spatial data)",
+)
+parser.add_argument(
+    "--docker", action="store_true", help="pull and cache images for docker"
+)
+parser.add_argument(
+    "--singularity", action="store_true", help="pull and cache images for singularity"
+)
+parser.add_argument(
+    "--singularity_dir",
+    type=str,
+    default="singularity",
+    help="directory to store singularity image files (default: `singularity`)",
+)
 args = parser.parse_args()
 
 # scpca-nf resource urls
@@ -59,11 +76,13 @@ containerfile_url = f"https://raw.githubusercontent.com/AlexsLemonade/scpca-nf/{
 # download reference file
 print("Getting list of required reference files")
 try:
-    ref_file =  urllib.request.urlopen(reffile_url)
+    ref_file = urllib.request.urlopen(reffile_url)
     json_file = urllib.request.urlopen(refjson_url)
 except urllib.error.URLError as e:
     print(e.reason)
-    print(f"The file download failed for {reffile_url} and/or {refjson_url}; please check the URLs for errors")
+    print(
+        f"The file download failed for {reffile_url} and/or {refjson_url}; please check the URLs for errors"
+    )
     print(f"Is `{args.revision}` a valid release tag?")
     exit(1)
 
@@ -75,21 +94,21 @@ ref_re = re.compile(r'(?P<id>.+?)\s*=\s*([\'"])(?P<loc>.+)\2')
 for line in ref_file:
     match = ref_re.search(line.decode())
     if match:
-        refs[match.group('id')] = match.group('loc')
+        refs[match.group("id")] = match.group("loc")
 
 # regular expressions for parameter expansion
-root_re = re.compile(r'\$\{?(params.)?ref_rootdir\}?$')
+root_re = re.compile(r"\$\{?(params.)?ref_rootdir\}?$")
 
 # get root location
 # split out protocol from the root URI
-root_parts = refs.get("ref_rootdir").split('://', maxsplit = 1)
-if root_parts[0] == 's3':
+root_parts = refs.get("ref_rootdir").split("://", maxsplit=1)
+if root_parts[0] == "s3":
     # if S3, convert bucket path to https:// url
-    bucket_path = root_parts[1].split("/", maxsplit = 1)
+    bucket_path = root_parts[1].split("/", maxsplit=1)
     url_root = f"https://{bucket_path[0]}.s3.amazonaws.com"
     if len(bucket_path) > 1:
         url_root += f"/{bucket_path[1]}"
-elif root_parts[0] in ['http', 'https', 'ftp']:
+elif root_parts[0] in ["http", "https", "ftp"]:
     # otherwise, just get the location
     url_root = refs.get("ref_rootdir")
 else:
@@ -98,20 +117,17 @@ else:
 
 # single-file references
 # the keys here are the param variables we will be downloading
-ref_keys =[
+ref_keys = [
     "ref_fasta",
     "ref_fasta_index",
     "ref_gtf",
     "mito_file",
     "t2g_3col_path",
-    "t2g_bulk_path"
+    "t2g_bulk_path",
 ]
 
 # param variables that are salmon index directories
-salmon_keys = [
-    "splici_index",
-    "salmon_bulk_index"
-]
+salmon_keys = ["splici_index", "salmon_bulk_index"]
 
 # salmon index files within index dir (must be downloaded individually through http)
 salmon_index_files = [
@@ -129,7 +145,7 @@ salmon_index_files = [
     "reflengths.bin",
     "refseq.bin",
     "seq.bin",
-    "versionInfo.json"
+    "versionInfo.json",
 ]
 
 # star index files within index dir (must be downloaded individually through http)
@@ -149,7 +165,7 @@ star_index_files = [
     "sjdbInfo.txt",
     "sjdbList.fromGTF.out.tab",
     "sjdbList.out.tab",
-    "transcriptInfo.tab"
+    "transcriptInfo.tab",
 ]
 
 # Cell Ranger index files within index dir (must be downloaded individually through http)
@@ -172,7 +188,7 @@ cr_index_files = [
     "star/sjdbInfo.txt",
     "star/sjdbList.fromGTF.out.tab",
     "star/sjdbList.out.tab",
-    "star/transcriptInfo.tab"
+    "star/transcriptInfo.tab",
 ]
 
 # create a list of all paths for all assemblies listed in reference json file
@@ -185,13 +201,17 @@ for assembly_refs in json_paths.values():
     # get paths to salmon directories and add individual files
     sa_dir = [Path(assembly_refs.get(k)) for k in salmon_keys]
     for dir in sa_dir:
-        ref_paths += [dir / f for f in salmon_index_files] # add salmon files
+        ref_paths += [dir / f for f in salmon_index_files]  # add salmon files
 
     # if cellranger and star index's are asked for, get individual files
     if args.cellranger_index:
-        ref_paths += [Path(assembly_refs.get("cellranger_index")) / f for f in cr_index_files] # add cellranger files
+        ref_paths += [
+            Path(assembly_refs.get("cellranger_index")) / f for f in cr_index_files
+        ]  # add cellranger files
     if args.star_index:
-        ref_paths += [Path(assembly_refs.get("star_index")) / f for f in star_index_files] # add star index files
+        ref_paths += [
+            Path(assembly_refs.get("star_index")) / f for f in star_index_files
+        ]  # add star index files
 
 # barcode paths are still kept in the reference config file, so add those separately
 # barcode files on S3 within the barcode_dir (must be downloaded individually through http)
@@ -200,7 +220,7 @@ barcode_files = [
     "737K-august-2016.txt",
     "cellranger_mit_license.txt",
     "visium-v1.txt",
-    "visium-v2.txt"
+    "visium-v2.txt",
 ]
 barcode_dir = Path(refs.get("barcode_dir"))
 if root_re.match(barcode_dir.parts[0]):
@@ -215,32 +235,38 @@ for path in ref_paths:
         continue
     print(f"Getting {path}")
     # make parents
-    outfile.parent.mkdir(exist_ok=True, parents = True)
+    outfile.parent.mkdir(exist_ok=True, parents=True)
     # download and write
     file_url = f"{url_root}/{path}"
     try:
         urllib.request.urlretrieve(file_url, outfile)
     except urllib.error.URLError as e:
         print(e.reason)
-        print(f"The file download failed for {file_url}; please check the URL for errors",
-              file = sys.stderr)
+        print(
+            f"The file download failed for {file_url}; please check the URL for errors",
+            file=sys.stderr,
+        )
         exit(1)
-print("Done with reference file downloads\n"
-      f"Reference files can be found at '{args.refdir}'\n")
+print(
+    "Done with reference file downloads\n"
+    f"Reference files can be found at '{args.refdir}'\n"
+)
 
 # write param file if requested
 if args.paramfile:
     pfile = Path(args.paramfile)
     # check if paramfile exists & move old if needed
     if pfile.exists():
-        print(f"A file already exists at `{pfile}`; renaming previous file to `{pfile.name}.bak`")
+        print(
+            f"A file already exists at `{pfile}`; renaming previous file to `{pfile.name}.bak`"
+        )
         shutil.move(pfile, str(pfile) + ".bak")
     # create parameter dictionary
-    nf_params = {
-        'ref_rootdir': os.path.abspath(args.refdir)
-    }
-    with open(pfile, 'w') as f:
-        f.write("# local nextflow reference file parameters, generated by `get_refs.py`\n\n")
+    nf_params = {"ref_rootdir": os.path.abspath(args.refdir)}
+    with open(pfile, "w") as f:
+        f.write(
+            "# local nextflow reference file parameters, generated by `get_refs.py`\n\n"
+        )
         for key, value in nf_params.items():
             f.write(f"{key}: {value}\n")
 
@@ -249,10 +275,12 @@ if args.singularity or args.docker:
     print("Getting list of required containers")
     containers = {}
     try:
-        container_file =  urllib.request.urlopen(containerfile_url)
+        container_file = urllib.request.urlopen(containerfile_url)
     except urllib.error.URLError as e:
         print(e.reason)
-        print(f"The file download failed for {container_url}; please check the URL for errors")
+        print(
+            f"The file download failed for {containerfile_url}; please check the URL for errors"
+        )
         print(f"Is `{args.revision}` a valid release tag?")
         exit(1)
 
@@ -261,7 +289,7 @@ if args.singularity or args.docker:
     for line in container_file:
         match = container_re.search(line.decode())
         if match:
-            containers[match.group('id')] = match.group('loc')
+            containers[match.group("id")] = match.group("loc")
 
 # pull docker images if requested
 if args.docker:
@@ -283,11 +311,10 @@ if args.singularity:
         print(image_path)
         if image_path.exists():
             image_path.unlink()
-        subprocess.run([
-            "singularity", "pull",
-            "--name", image_path,
-            f"docker://{loc}"
-        ])
+        subprocess.run(["singularity", "pull", "--name", image_path, f"docker://{loc}"])
     print("Done pulling singularity images")
-    print(f"Singularity images located at {image_dir.absolute()}; be sure to set `singularity.cacheDir` in your configuration file to this value")
+    print(
+        f"Singularity images located at {image_dir.absolute()}."
+        " Be sure to set `singularity.cacheDir` in your configuration file to this value"
+    )
     print()

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ params {
   gene_cutoff = 200 // minimum number of genes per cell cutoff used for filtering cells
   num_hvg = 2000 // number of high variance genes to use for dimension reduction
   num_pcs = 50 // number of principal components to retain in the returned SingleCellExperiment object
-  
+
   // SCE clustering options
   cluster_algorithm = "louvain" // default graph-based clustering algorithm
   cluster_weighting = "jaccard" // default weighting scheme for graph-based clustering

--- a/templates/integration-report.Rmd
+++ b/templates/integration-report.Rmd
@@ -24,17 +24,19 @@ library(SingleCellExperiment)
 library(ggplot2)
 
 # Set default ggplot theme
-theme_set(theme_bw() + 
-          theme(plot.margin = margin(rep(20, 4))))
+theme_set(
+  theme_bw() +
+    theme(plot.margin = margin(rep(20, 4)))
+)
 ```
 
 ```{r}
-# check that input files are provided 
-if(is.null(params$integrated_sce)){
+# check that input files are provided
+if (is.null(params$integrated_sce)) {
   stop("Must provide a path to a RDS file containing a integrated SCE object.")
 }
 
-# define batch column 
+# define batch column
 batch_column <- params$batch_column
 ```
 
@@ -53,28 +55,35 @@ UMAP showing batches before and after integration.
 ```{r, message=FALSE}
 # randomly shuffle cells prior to plotting
 col_order <- sample(ncol(integrated_sce))
-shuffled_sce <- integrated_sce[,col_order]
+shuffled_sce <- integrated_sce[, col_order]
 
-# set plot colors 
+# set plot colors
 num_colors <- length(unique(integrated_sce[[batch_column]]))
 plot_colors <- rainbow(n = num_colors)
 
 # list of batch umaps for all pre/post integration
-batch_umaps <- purrr::map(umap_plot_names, \(name){
+batch_umaps <- umap_plot_names |> purrr::map(\(name) {
   scater::plotReducedDim(shuffled_sce,
-                         dimred = name,
-                         colour_by = batch_column,
-                         point_size = 0.1,
-                         point_alpha = 0.4) +
-    scale_color_manual(values = plot_colors, 
-                       name = batch_column) +
+    dimred = name,
+    colour_by = batch_column,
+    point_size = 0.1,
+    point_alpha = 0.4
+  ) +
+    scale_color_manual(
+      values = plot_colors,
+      name = batch_column
+    ) +
     # relabel legend and resize dots
-    guides(color = guide_legend(override.aes = list(size = 3),
-                                label.theme = element_text(size = 10))) 
+    guides(color = guide_legend(
+      override.aes = list(size = 3),
+      label.theme = element_text(size = 10)
+    ))
 })
 
-patchwork::wrap_plots(batch_umaps, ncol = 2,
-                      guides = "collect")
+patchwork::wrap_plots(batch_umaps,
+  ncol = 2,
+  guides = "collect"
+)
 ```
 
 # Session Info

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -8,7 +8,7 @@ The following method(s) were used to perform cell typing:
 ```{r, eval = has_singler}
 knitr::asis_output(
   glue::glue(
-  "* [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach.
+    "* [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach.
   The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
   )
 )
@@ -18,15 +18,16 @@ knitr::asis_output(
 ```{r, eval = has_cellassign}
 knitr::asis_output(
   glue::glue(
-  "
+    "
   * [`CellAssign`](https://github.com/Irrationone/cellassign), which uses a marker-gene based approach.
   Marker genes associated with `{metadata(processed_sce)$cellassign_reference}` tissue were obtained from [PanglaoDB](https://panglaodb.se/).
-  ")
+  "
+  )
 )
 ```
 
 
-Cells annotated as "Unknown cell type" represent cells which could not be confidently identified using the given annotation method. 
+Cells annotated as "Unknown cell type" represent cells which could not be confidently identified using the given annotation method.
 
 If available, these results will be compared to cell type annotations provided by the data's originating research group ("submitter-provided cell type annotations".)
 
@@ -34,22 +35,22 @@ If available, these results will be compared to cell type annotations provided b
 
 ```{r}
 # This chunk defines a helper function to reformat annotations:
-#  * Annotations that are `NA`/"other" are changed to "Unknown cell type" 
-#  * Annotations are converted to a factor ordered by frequency, but with 
+#  * Annotations that are `NA`/"other" are changed to "Unknown cell type"
+#  * Annotations are converted to a factor ordered by frequency, but with
 #    "Unknown cell type" always last.
 prepare_annotation_values <- function(df, annotation_column) {
   df |>
     dplyr::mutate(
-      {{annotation_column}} := dplyr::case_when(
+      {{ annotation_column }} := dplyr::case_when(
         # singler condition
-        is.na({{annotation_column}}) ~ "Unknown cell type",
+        is.na({{ annotation_column }}) ~ "Unknown cell type",
         # cellassign conditon
-        {{annotation_column}} == "other" ~ "Unknown cell type",
+        {{ annotation_column }} == "other" ~ "Unknown cell type",
         # otherwise, keep it
-        TRUE ~ {{annotation_column}}
+        TRUE ~ {{ annotation_column }}
       ) |>
-      forcats::fct_infreq() |>
-      forcats::fct_relevel("Unknown cell type", after = Inf)
+        forcats::fct_infreq() |>
+        forcats::fct_relevel("Unknown cell type", after = Inf)
     )
 }
 ```
@@ -61,10 +62,12 @@ celltype_df <- colData(processed_sce) |>
   # barcodes to a column
   tibble::rownames_to_column(var = "barcode") |>
   # keep only cell name, celltyping, and clusters
-  dplyr::select(barcode, 
-                clusters,
-                contains("singler"),
-                contains("cellassign"))
+  dplyr::select(
+    barcode,
+    clusters,
+    contains("singler"),
+    contains("cellassign")
+  )
 
 
 
@@ -75,29 +78,31 @@ if (has_singler) {
 if (has_cellassign) {
   celltype_df <- celltype_df |>
     prepare_annotation_values(cellassign_celltype_annotation)
-} 
+}
 ```
 
 ```{r}
 # Define a helper function to create tables for singler and cellassign annotations
 create_celltype_n_table <- function(df, celltype_column) {
   df |>
-    dplyr::count({{celltype_column}}) |>
+    dplyr::count({{ celltype_column }}) |>
     # Add percentage column
     dplyr::mutate(
-      `Percent of cells` =  paste0(round(n/sum(n) * 100, digits = 2), "%")
+      `Percent of cells` = paste0(round(n / sum(n) * 100, digits = 2), "%")
     ) |>
     # set column order & rename
     dplyr::select(
-      `Annotated cell type` = {{celltype_column}},
+      `Annotated cell type` = {{ celltype_column }},
       `Number of cells` = n,
       `Percent of cells`
     ) |>
     # kable formatting
-    knitr::kable(align = 'r') |>
-    kableExtra::kable_styling(bootstrap_options = "striped",
-                             full_width = FALSE,
-                             position = "left") |>
+    knitr::kable(align = "r") |>
+    kableExtra::kable_styling(
+      bootstrap_options = "striped",
+      full_width = FALSE,
+      position = "left"
+    ) |>
     kableExtra::column_spec(2, monospace = TRUE)
 }
 ```
@@ -116,7 +121,7 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation)
 
 ```{r, eval = has_submitter_celltypes}
 knitr::asis_output("### Submitter-provided cell type annotations\n")
-# Note: submitter annotations have not yet been added to the workflow, 
+# Note: submitter annotations have not yet been added to the workflow,
 #  so this variable name `submitter_celltype_annotation` is just a placeholder
 create_celltype_n_table(celltype_df, submitter_celltype_annotation)
 ```
@@ -137,7 +142,7 @@ Higher _delta median_ values indicate more confidence in the cell type annotatio
 For more information, refer to the [`SingleR` book section on 'Annotation diagnostics'](https://bioconductor.org/books/release/SingleRBook/annotation-diagnostics.html#annotation-diagnostics).
 
 
-In the plot below, each point is the _delta median_ statistic of a given cell with the given cell type annotation. 
+In the plot below, each point is the _delta median_ statistic of a given cell with the given cell type annotation.
 Points (cells) are colored by `SingleR`'s internal confidence assessment: High-quality cell annotations are shown in black, and low-quality cell annotations are shown in blue.
 All blue points correspond to cells labeled as `Unknown cell type` in the `SingleR` result table in the previous section.
 The red overlayed boxes represent the median ± interquartile range (IQR), specifically for high-quality annotations.
@@ -149,7 +154,7 @@ The red overlayed boxes represent the median ± interquartile range (IQR), speci
 # Prepare SingleR scores for plot
 
 # extract scores into matrix
-singler_scores <- metadata(processed_sce)$singler_result$scores 
+singler_scores <- metadata(processed_sce)$singler_result$scores
 
 # Create data frame for plotting with delta median and the full *non-pruned* cell labels
 delta_median_df <- tibble::tibble(
@@ -164,19 +169,18 @@ delta_median_df <- tibble::tibble(
 # If ontologies were used for `full_labels`, we'll need to map back to cell names
 #  for the plot itself.
 if ("singler_celltype_ontology" %in% names(celltype_df)) {
-
   # we use inner_join b/c the above tibble does NOT contain "Unknown cell type", which
   #  we do not want to display here
   delta_median_df <- delta_median_df |>
-   dplyr::inner_join(
-    tibble::tibble(
-      full_labels = celltype_df$singler_celltype_ontology,
-      celltype = celltype_df$singler_celltype_annotation
-    ) |> dplyr::distinct()
-  ) |>
+    dplyr::inner_join(
+      tibble::tibble(
+        full_labels = celltype_df$singler_celltype_ontology,
+        celltype = celltype_df$singler_celltype_annotation
+      ) |> dplyr::distinct()
+    ) |>
     dplyr::select(-full_labels)
 } else {
-  # otherwise, full_labels already contain what we want to plot, so just rename it 
+  # otherwise, full_labels already contain what we want to plot, so just rename it
   delta_median_df <- delta_median_df |>
     dplyr::rename(celltype = full_labels)
 }
@@ -196,21 +200,25 @@ delta_median_df$annotation_wrapped <- factor(
 # Subset the data to just confident points for median+/-IQR
 delta_median_confident_df <- delta_median_df |>
   dplyr::filter(confident)
- 
+
 # Plot delta_median across celltypes colored by pruning
-ggplot(delta_median_df) + 
-  aes(x = annotation_wrapped, 
-      y = delta_median, 
-      color = confident) + 
-  ggforce::geom_sina(size = 0.75, 
-                     alpha = 0.5, 
-                     # Keep red points mostly in line with black
-                     position = position_dodge(width = 0.05)) +
+ggplot(delta_median_df) +
+  aes(
+    x = annotation_wrapped,
+    y = delta_median,
+    color = confident
+  ) +
+  ggforce::geom_sina(
+    size = 0.75,
+    alpha = 0.5,
+    # Keep red points mostly in line with black
+    position = position_dodge(width = 0.05)
+  ) +
   labs(
     x = "Cell type annotation",
     y = "Delta median statistic",
     color = "Confident cell type assignment"
-  ) + 
+  ) +
   scale_color_manual(values = c("blue", "black")) +
   # add median/IQR
   stat_summary(
@@ -219,12 +227,12 @@ ggplot(delta_median_df) +
     geom = "crossbar",
     width = 0.4,
     size = 0.2
-  ) + 
+  ) +
   guides(
     color = guide_legend(override.aes = list(size = 1, alpha = 0.9))
   ) +
   theme(
-    axis.text.x = element_text(angle = 55, hjust = 1, size = rel(0.85)), 
+    axis.text.x = element_text(angle = 55, hjust = 1, size = rel(0.85)),
     legend.title = element_text(size = rel(0.75)),
     legend.text = element_text(size = rel(0.75)),
     legend.position = "bottom"
@@ -251,14 +259,13 @@ In these cases, we directly show values for individual cell probabilities as lin
 
 
 ```{r, eval = has_cellassign, warning=FALSE, message=FALSE, fig.height = 8, fig.width = 7}
-
 # Prepare CellAssign scores for plot
-cellassign_prob_df <- metadata(processed_sce)$cellassign_predictions |> 
+cellassign_prob_df <- metadata(processed_sce)$cellassign_predictions |>
   # Change "other" to "Unknown cell type"
   dplyr::rename(`Unknown cell type` = other) |>
   tidyr::pivot_longer(
-    -barcode, 
-    names_to = "celltype", 
+    -barcode,
+    names_to = "celltype",
     values_to = "probability"
   ) |>
   # remove cell types that were not annotated
@@ -266,7 +273,7 @@ cellassign_prob_df <- metadata(processed_sce)$cellassign_predictions |>
   # join with actual annotations
   dplyr::inner_join(
     tibble::tibble(
-      cellassign_celltype_annotation = celltype_df$cellassign_celltype_annotation, 
+      cellassign_celltype_annotation = celltype_df$cellassign_celltype_annotation,
       barcode = colData(processed_sce)$barcodes # plural!
     )
   ) |>
@@ -293,29 +300,33 @@ celltypes_leq2_cells <- cellassign_prob_df |>
 # data frame for adding those points back
 leq2_probabilities_df <- cellassign_prob_df |>
   dplyr::filter(
-    annotation_wrapped %in% celltypes_leq2_cells, 
-    annotated 
+    annotation_wrapped %in% celltypes_leq2_cells,
+    annotated
   ) |>
   dplyr::select(annotation_wrapped, probability, annotated)
 
 # Finally, the plot:
 ggplot(cellassign_prob_df) +
-  aes(x = probability,
-      y = annotation_wrapped, 
-      fill = annotated) + 
-  ggridges::stat_density_ridges(quantile_lines = TRUE,
-                                quantiles = 2, 
-                                alpha = 0.6,
-                                # avoid overlap to extent possible in a template - 
-                                scale = 0.85) +
+  aes(
+    x = probability,
+    y = annotation_wrapped,
+    fill = annotated
+  ) +
+  ggridges::stat_density_ridges(
+    quantile_lines = TRUE,
+    quantiles = 2,
+    alpha = 0.6,
+    # avoid overlap to extent possible in a template -
+    scale = 0.85
+  ) +
   scale_fill_viridis_d(direction = -1) +
   labs(
     x = "CellAssign probability",
-    y = "Annotated cell type", 
+    y = "Annotated cell type",
     fill = "Cell annotated as given cell type"
   ) +
   theme(
-    axis.text.y = element_text(size = 9), 
+    axis.text.y = element_text(size = 9),
     legend.position = "bottom"
   ) +
   #### add line segment for N<3 distributions
@@ -329,7 +340,7 @@ ggplot(cellassign_prob_df) +
       color = annotated
     ),
     show.legend = FALSE
-  ) + 
+  ) +
   scale_color_viridis_d()
 ```
 
@@ -349,25 +360,26 @@ All other cell types are grouped together and labeled "Other cell type" (not to 
 ```{r}
 # Create dataset for plotting UMAPs with lumped cell types
 umap_df <- tibble::tibble(
-  UMAP1 = unname(reducedDim(processed_sce, "UMAP")[,1]),
-  UMAP2 = unname(reducedDim(processed_sce, "UMAP")[,2]),
+  UMAP1 = unname(reducedDim(processed_sce, "UMAP")[, 1]),
+  UMAP2 = unname(reducedDim(processed_sce, "UMAP")[, 2]),
   clusters = processed_sce$clusters
 )
 
 # helper function for lumping cell types
-lump_celltypes <- function(umap_df, 
+lump_celltypes <- function(umap_df,
                            celltype_df,
                            celltype_method,
                            n_celltypes = 7) {
-  
   umap_df |>
     dplyr::mutate(
-      celltypes =  celltype_df[[glue::glue("{celltype_method}_celltype_annotation")]],
-      celltypes = forcats::fct_lump_n(celltypes,
-                                      n_celltypes, 
-                                      other_level = "Other cell type")) |>
+      celltypes = celltype_df[[glue::glue("{celltype_method}_celltype_annotation")]] |>
+        forcats::fct_lump_n(
+          n_celltypes,
+          other_level = "Other cell type"
+        )
+    ) |>
     # finally, rename temporary `celltypes` column to the provided method
-    dplyr::rename({{celltype_method}} := celltypes)
+    dplyr::rename({{ celltype_method }} := celltypes)
 }
 
 if (has_singler) {
@@ -384,68 +396,79 @@ if (has_cellassign) {
 # Define helper function for making UMAPs in this section
 #  this function uses the default palette, which can be customized when
 #  calling the function
-plot_umap <- function(umap_df, 
+plot_umap <- function(umap_df,
                       color_variable,
-                      legend_title, 
+                      legend_title,
                       legend_nrow = 2) {
-  
-  ggplot(umap_df) + 
-    aes(x = UMAP1, 
-        y = UMAP2, 
-        color = {{color_variable}}) + 
-    geom_point(size = 0.3,
-               alpha = 0.5) + 
+  ggplot(umap_df) +
+    aes(
+      x = UMAP1,
+      y = UMAP2,
+      color = {{ color_variable }}
+    ) +
+    geom_point(
+      size = 0.3,
+      alpha = 0.5
+    ) +
     # remove axis numbers and background grid
-    scale_x_continuous(labels = NULL, breaks = NULL) + 
-    scale_y_continuous(labels = NULL, breaks = NULL) + 
-    coord_fixed() + 
+    scale_x_continuous(labels = NULL, breaks = NULL) +
+    scale_y_continuous(labels = NULL, breaks = NULL) +
+    coord_fixed() +
     guides(
-      color = guide_legend(title = legend_title, 
-                           nrow = legend_nrow,
-                           # more visible points in legend
-                           override.aes = list(alpha = 1,
-                                               size = 1.5))) + 
+      color = guide_legend(
+        title = legend_title,
+        nrow = legend_nrow,
+        # more visible points in legend
+        override.aes = list(
+          alpha = 1,
+          size = 1.5
+        )
+      )
+    ) +
     theme(legend.position = "bottom")
 }
 ```
 
-<!-- First UMAP: clusters --> 
+<!-- First UMAP: clusters -->
 ```{r message=FALSE, warning=FALSE}
-clusters_plot <- plot_umap(umap_df, 
-          clusters,
-          "Clusters") +
+clusters_plot <- plot_umap(
+  umap_df,
+  clusters,
+  "Clusters"
+) +
   ggtitle("UMAP colored by clusters")
 
 # Determine palette based on number of levels.
-# If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors). 
+# If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
 #  Otherwise, we will use the default palette.
 if (length(levels(umap_df$clusters)) <= 8) {
-  clusters_plot + 
-    scale_color_brewer(palette =  "Set2")
+  clusters_plot +
+    scale_color_brewer(palette = "Set2")
 } else {
   clusters_plot
 }
-  
 ```
 
 <!-- Now, UMAPs of cell types, where present -->
 
 ```{r eval=has_singler, message=FALSE, warning=FALSE}
-plot_umap(umap_df, 
-          singler,
-          "Cell types",
-          legend_nrow = 4) +
-  ggtitle("UMAP colored by SingleR annotations") + 
+plot_umap(umap_df,
+  singler,
+  "Cell types",
+  legend_nrow = 4
+) +
+  ggtitle("UMAP colored by SingleR annotations") +
   scale_color_brewer(palette = "Dark2")
 ```
 
 
 ```{r, eval = has_cellassign, message=FALSE, warning=FALSE}
-plot_umap(umap_df, 
-          cellassign,
-          "Cell types",
-          legend_nrow = 4) +
-  ggtitle("UMAP colored by CellAssign annotations")  + 
+plot_umap(umap_df,
+  cellassign,
+  "Cell types",
+  legend_nrow = 4
+) +
+  ggtitle("UMAP colored by CellAssign annotations") +
   scale_color_brewer(palette = "Dark2")
 ```
 
@@ -463,43 +486,44 @@ Heatmap colors represent the log number of cells present in both the given cell 
 ```{r}
 # Helper function for making a heatmap
 create_celltype_heatmap <- function(x_vector,
-                                    y_vector, 
+                                    y_vector,
                                     x_label = "",
-                                    y_label = "", 
+                                    y_label = "",
                                     column_names_rotation = 0,
-                                    row_font_size = 8, 
+                                    row_font_size = 8,
                                     column_font_size = 10) {
-  
   # build a matrix for making a heatmap
-  celltype_mtx <- table(x_vector,
-                        y_vector) |> 
+  celltype_mtx <- table(
+    x_vector,
+    y_vector
+  ) |>
     log1p() # log transform for visualization
-    
-  # Define CVD-friendly palette 
+
+  # Define CVD-friendly palette
   heatmap_palette <- viridisLite::inferno(7, alpha = 1, begin = 0, end = 1, direction = 1)
-  
+
   # heatmap
   heat <- ComplexHeatmap::Heatmap(celltype_mtx,
-                                  # Overall heatmap parameters
-                                  col = heatmap_palette,
-                                  # Column parameters
-                                  column_title = y_label,
-                                  column_title_side = "bottom", 
-                                  column_dend_side = "top",
-                                  column_names_rot = column_names_rotation,
-                                  column_names_gp = grid::gpar(fontsize = column_font_size),
-                                  # Row parameters
-                                  row_dend_side = "left",
-                                  row_title_side = "right", 
-                                  row_title = x_label,
-                                  row_names_gp = grid::gpar(fontsize = row_font_size),
-                                  # Legend parameters
-                                  heatmap_legend_param = list(
-                                    title = "Log(Number of cells)",
-                                    title_position = "leftcenter-rot",
-                                    legend_height = unit(4, "cm")
-                                    )
-                                  )
+    # Overall heatmap parameters
+    col = heatmap_palette,
+    # Column parameters
+    column_title = y_label,
+    column_title_side = "bottom",
+    column_dend_side = "top",
+    column_names_rot = column_names_rotation,
+    column_names_gp = grid::gpar(fontsize = column_font_size),
+    # Row parameters
+    row_dend_side = "left",
+    row_title_side = "right",
+    row_title = x_label,
+    row_names_gp = grid::gpar(fontsize = row_font_size),
+    # Legend parameters
+    heatmap_legend_param = list(
+      title = "Log(Number of cells)",
+      title_position = "leftcenter-rot",
+      legend_height = unit(4, "cm")
+    )
+  )
   # draw with legend on left for spacing
   ComplexHeatmap::draw(heat, heatmap_legend_side = "left")
 }
@@ -509,8 +533,8 @@ create_celltype_heatmap <- function(x_vector,
 ```{r, eval = has_singler, fig.height=5, fig.width=7}
 knitr::asis_output("### `SingleR` cluster and cell type heatmap\n")
 create_celltype_heatmap(
-  x_vector = celltype_df$singler_celltype_annotation, 
-  y_vector = celltype_df$clusters, 
+  x_vector = celltype_df$singler_celltype_annotation,
+  y_vector = celltype_df$clusters,
   y_label = "Clusters"
 )
 ```
@@ -518,8 +542,8 @@ create_celltype_heatmap(
 ```{r, eval = has_cellassign, fig.height=5, fig.width=7}
 knitr::asis_output("### `CellAssign` cluster and cell type heatmap\n")
 create_celltype_heatmap(
-  x_vector = celltype_df$cellassign_celltype_annotation, 
-  y_vector = celltype_df$clusters, 
+  x_vector = celltype_df$cellassign_celltype_annotation,
+  y_vector = celltype_df$clusters,
   y_label = "Clusters"
 )
 ```
@@ -527,14 +551,14 @@ create_celltype_heatmap(
 ```{r, eval = has_submitter_celltypes, fig.height=5, fig.width=7}
 knitr::asis_output("### Submitter-provided cluster and cell type heatmap\n")
 create_celltype_heatmap(
-  x_vector = celltype_df$submitter_celltype_annotation, 
-  y_vector = celltype_df$clusters, 
+  x_vector = celltype_df$submitter_celltype_annotation,
+  y_vector = celltype_df$clusters,
   y_label = "Clusters"
 )
 ```
 
 
-<!-- Use large height/width to accommodate cell type labels --> 
+<!-- Use large height/width to accommodate cell type labels -->
 ```{r, eval = has_cellassign & has_singler, fig.height=7, fig.width=8}
 knitr::asis_output("
 ## Comparison between annotations
@@ -544,8 +568,8 @@ Note that due to different annotations references, these methods may use differe
 ")
 
 create_celltype_heatmap(
-  x_vector = celltype_df$singler_celltype_annotation, 
-  y_vector = celltype_df$cellassign_celltype_annotation, 
+  x_vector = celltype_df$singler_celltype_annotation,
+  y_vector = celltype_df$cellassign_celltype_annotation,
   x_label = "SingleR annotations",
   y_label = "CellAssign annotations",
   column_names_rotation = 55,

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -6,7 +6,7 @@ This section details quality control statistics from the ADT (antibody-derived t
 
 ```{r}
 # add rowData if missing
-if (is.null(rowData(adt_exp)$detected)){
+if (is.null(rowData(adt_exp)$detected)) {
   adt_exp <- scuttle::addPerFeatureQCMetrics(adt_exp)
 }
 
@@ -14,24 +14,26 @@ cell_adt_counts <- Matrix::colSums(counts(adt_exp))
 
 adt_information <- tibble::tibble(
   "Number of ADTs assayed" =
-    format(nrow(adt_exp), big.mark = ',', scientific = FALSE),
+    format(nrow(adt_exp), big.mark = ",", scientific = FALSE),
   "Number of reads sequenced" =
-    format(adt_meta$total_reads, big.mark = ',', scientific = FALSE),
+    format(adt_meta$total_reads, big.mark = ",", scientific = FALSE),
   "Percent reads mapped to ADTs" =
-    paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%"),
+    paste0(round(adt_meta$mapped_reads / adt_meta$total_reads * 100, digits = 2), "%"),
   "Percent of ADTs in cells" =
-    paste0(round(sum(cell_adt_counts)/adt_meta$mapped_reads * 100, digits = 2), "%"),
+    paste0(round(sum(cell_adt_counts) / adt_meta$mapped_reads * 100, digits = 2), "%"),
   "Percent of cells with ADTs" =
-    paste0(round(sum(cell_adt_counts > 0)/length(cell_adt_counts) * 100, digits = 2), "%"),
+    paste0(round(sum(cell_adt_counts > 0) / length(cell_adt_counts) * 100, digits = 2), "%"),
   "Median ADT UMIs per cell" =
-    format(median(cell_adt_counts), big.mark = ',', scientific = FALSE)
-  )|>
+    format(median(cell_adt_counts), big.mark = ",", scientific = FALSE)
+) |>
   t()
 
-knitr::kable(adt_information, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
+knitr::kable(adt_information, align = "r") |>
+  kableExtra::kable_styling(
+    bootstrap_options = "striped",
+    full_width = FALSE,
+    position = "left"
+  ) |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
@@ -43,34 +45,35 @@ antibody_tags <- as.data.frame(rowData(adt_exp)) |>
   mutate(target_type = forcats::fct_relevel(target_type, "target")) |>
   arrange(target_type, desc(mean)) |>
   select("Antibody",
-         "Mean UMI count per cell" = mean,
-         "Percent of cells detected" = detected,
-         "ADT target type" =  target_type)
+    "Mean UMI count per cell" = mean,
+    "Percent of cells detected" = detected,
+    "ADT target type" = target_type
+  )
 
 knitr::kable(antibody_tags, digits = 2) |>
-  kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
-                            full_width = FALSE,
-                            position = "left",
-                            )
+  kableExtra::kable_styling(
+    bootstrap_options = c("striped", "condensed"),
+    full_width = FALSE,
+    position = "left",
+  )
 ```
 
 ## ADT Post-processing Statistics
 
 ```{r}
-
 if (has_processed) {
-
   basic_statistics <- tibble::tibble(
-      "Method used to identify cells to filter" = format(processed_meta$adt_scpca_filter_method)
-    )
+    "Method used to identify cells to filter" = format(processed_meta$adt_scpca_filter_method)
+  )
 
   if (!(processed_meta$adt_scpca_filter_method == "No filter")) {
     filtered_cell_count <- sum(processed_sce$adt_scpca_filter == "Keep")
 
     basic_statistics <- basic_statistics |>
       # Note that the adt_scpca_filter_method column is only present in the processed_sce object
-      mutate("Number of cells that pass filtering threshold"  = format(filtered_cell_count),
-             "Percent of cells that pass filtering threshold" = paste0(round( filtered_cell_count/ncol(processed_sce) * 100, digits = 2), "%")
+      mutate(
+        "Number of cells that pass filtering threshold" = format(filtered_cell_count),
+        "Percent of cells that pass filtering threshold" = paste0(round(filtered_cell_count / ncol(processed_sce) * 100, digits = 2), "%")
       )
   }
   basic_statistics <- basic_statistics |>
@@ -78,13 +81,15 @@ if (has_processed) {
     reformat_nulls() |>
     t()
 
-  knitr::kable(basic_statistics, align = 'r') |>
-    kableExtra::kable_styling(bootstrap_options = "striped",
-                              full_width = FALSE,
-                              position = "left") |>
+  knitr::kable(basic_statistics, align = "r") |>
+    kableExtra::kable_styling(
+      bootstrap_options = "striped",
+      full_width = FALSE,
+      position = "left"
+    ) |>
     kableExtra::column_spec(2, monospace = TRUE)
 } else {
-    glue::glue("
+  glue::glue("
     <div class=\"alert alert-warning\">
 
     No ADT post-processing was performed on this library.
@@ -92,15 +97,13 @@ if (has_processed) {
     </div>
   ")
 }
-
 ```
 
 ## Removing low quality cells based on ADT counts
 
 
 ```{r fig.alt="Cell filtering based on both ADT and RNA counts", results='asis'}
-if (has_processed & !(processed_meta$adt_scpca_filter_method == "No filter")) {
-
+if (has_processed && !(processed_meta$adt_scpca_filter_method == "No filter")) {
   glue::glue('
 
     Note that low-quality cells as identified by ADT counts are not actually filtered from the SCE object.
@@ -113,28 +116,30 @@ if (has_processed & !(processed_meta$adt_scpca_filter_method == "No filter")) {
     - "Filter (ADT only)": This cell is filtered based on only ADT counts.
     - "Filter (RNA & ADT)": This cell is filtered based on both RNA and ADT counts.
 
-  ')  |> print()
+  ') |> print()
 
   filter_levels <- c("Keep", "Filter (RNA & ADT)", "Filter (RNA only)", "Filter (ADT only)")
   filtered_coldata_df <- filtered_coldata_df |>
     # add column to represent filtering on both RNA and ADT counts
     mutate(filter_summary = case_when(
-      scpca_filter == "Keep"   & adt_scpca_filter == "Keep"   ~ filter_levels[1],
+      scpca_filter == "Keep" & adt_scpca_filter == "Keep" ~ filter_levels[1],
       scpca_filter == "Remove" & adt_scpca_filter == "Remove" ~ filter_levels[2],
-      scpca_filter == "Remove" & adt_scpca_filter == "Keep"   ~ filter_levels[3],
-      scpca_filter == "Keep"   & adt_scpca_filter == "Remove" ~ filter_levels[4],
+      scpca_filter == "Remove" & adt_scpca_filter == "Keep" ~ filter_levels[3],
+      scpca_filter == "Keep" & adt_scpca_filter == "Remove" ~ filter_levels[4],
       TRUE ~ "Error"
-    ))  |>
+    )) |>
     # now, add a count to each label and factor in count order
     # add `keep_column` for use in plotting for colors
     add_count(filter_summary) |>
-    mutate(filter_summary = glue::glue("{filter_summary}\nN={n}"),
-           filter_summary = forcats::fct_infreq(filter_summary),
-           keep_column = ifelse(
-             stringr::str_starts(filter_summary, "Keep"),
-             "Keep",
-             "Remove"
-           )) |>
+    mutate(
+      filter_summary = glue::glue("{filter_summary}\nN={n}"),
+      filter_summary = forcats::fct_infreq(filter_summary),
+      keep_column = ifelse(
+        stringr::str_starts(filter_summary, "Keep"),
+        "Keep",
+        "Remove"
+      )
+    ) |>
     select(-n)
 
   if (sum(stringr::str_detect(filtered_coldata_df$filter_summary, "Error")) != 0) {
@@ -145,12 +150,16 @@ if (has_processed & !(processed_meta$adt_scpca_filter_method == "No filter")) {
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = keep_column)) +
     geom_point(alpha = 0.5, size = 1) +
     geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
-    labs(x = "Number of genes detected",
-         y = "Mitochondrial percentage",
-         title = "Combined RNA and ADT filters") +
+    labs(
+      x = "Number of genes detected",
+      y = "Mitochondrial percentage",
+      title = "Combined RNA and ADT filters"
+    ) +
     facet_wrap(vars(filter_summary)) +
-    theme(plot.title = element_text(hjust = 0.5),
-          legend.position = "none")
+    theme(
+      plot.title = element_text(hjust = 0.5),
+      legend.position = "none"
+    )
 } else {
   glue::glue("
     <div class=\"alert alert-warning\">
@@ -172,18 +181,16 @@ The plots in this section visualize the top four most variable ADTs in the libra
 ```{r}
 # Calculate ADT variance
 if (has_processed) {
-
   top_n <- 4 # we want the top 4 ADTs
 
   # Calculate variance for each ADT
   adt_var <- altExp(processed_sce) |>
     logcounts() |>
-    apply(1, var, na.rm=TRUE)
+    apply(1, var, na.rm = TRUE)
 
   # Get the top 4
-  top_adts <- adt_var[ order(adt_var, decreasing=TRUE)[1:top_n] ] |>
+  top_adts <- adt_var[order(adt_var, decreasing = TRUE)[1:top_n]] |>
     names()
-
 } else {
   # This warning also handles "else" conditions for the next two chunks
   glue::glue("
@@ -201,14 +208,13 @@ if (has_processed) {
 
 ```{r fig.alt="Density plot showing normalized expression of highly variable ADTs", warning = FALSE, results='asis'}
 if (has_processed) {
-
   glue::glue(
-  "The plot below displays normalized expression of these four ADTs, with one ADT shown per panel.\n"
+    "The plot below displays normalized expression of these four ADTs, with one ADT shown per panel.\n"
   ) |> print()
 
 
   # grab expression for top ADTs from counts
-  var_adt_exp_df <- logcounts(altExp(processed_sce))[top_adts,] |>
+  var_adt_exp_df <- logcounts(altExp(processed_sce))[top_adts, ] |>
     # as.matrix needs to come _first_
     as.matrix() |>
     t() |>
@@ -216,8 +222,9 @@ if (has_processed) {
     tibble::rownames_to_column("barcode") |>
     # combine all ADTs into a single column for  faceting
     tidyr::pivot_longer(!barcode,
-                        names_to = "ADT",
-                        values_to = "adt_expression")
+      names_to = "ADT",
+      values_to = "adt_expression"
+    )
 
   # expression density plots
   ggplot(var_adt_exp_df, aes(x = adt_expression, fill = ADT)) +
@@ -232,7 +239,6 @@ if (has_processed) {
 
 ```{r fig.alt="UMAP calculated from RNA expression but colored by normalized expression of highly variable ADTs", fig.height = 6, results='asis'}
 if (has_processed) {
-
   # Extra blank line here keeps the plot in a separate paragraph
   glue::glue(
     "The plot below displays UMAP embeddings calculated from RNA expression, where each cell is colored by the expression level of the given ADT.
@@ -242,11 +248,12 @@ if (has_processed) {
 
 
   # create data frame of UMAPs and expression
-   umap_df <- scuttle::makePerCellDF(processed_sce) |>
-      tibble::rownames_to_column("barcode") |>
-      select(barcode,
-             UMAP1 = UMAP.1,
-             UMAP2 = UMAP.2) |>
+  umap_df <- scuttle::makePerCellDF(processed_sce) |>
+    tibble::rownames_to_column("barcode") |>
+    select(barcode,
+      UMAP1 = UMAP.1,
+      UMAP2 = UMAP.2
+    ) |>
     # combine with gene expression
     left_join(var_adt_exp_df, by = "barcode")
 
@@ -261,11 +268,13 @@ if (has_processed) {
     scale_x_continuous(labels = NULL, breaks = NULL) +
     scale_y_continuous(labels = NULL, breaks = NULL) +
     coord_fixed() +
-    theme(legend.position = "bottom",
-          axis.title = element_text(size = 8, color = "black"),
-          strip.text = element_text(size = 8),
-          legend.title = element_text(size = 9),
-          legend.text = element_text(size = 8)) +
+    theme(
+      legend.position = "bottom",
+      axis.title = element_text(size = 8, color = "black"),
+      strip.text = element_text(size = 8),
+      legend.title = element_text(size = 9),
+      legend.text = element_text(size = 8)
+    ) +
     guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
 }
 ```

--- a/templates/qc_report/multiplex_qc.rmd
+++ b/templates/qc_report/multiplex_qc.rmd
@@ -4,32 +4,34 @@
 
 ```{r}
 # add rowData if missing
-if (is.null(rowData(multiplex_exp)$detected)){
+if (is.null(rowData(multiplex_exp)$detected)) {
   multiplex_exp <- scuttle::addPerFeatureQCMetrics(multiplex_exp)
 }
 
 cell_hto_counts <- Matrix::colSums(counts(multiplex_exp))
 
 hto_information <- tibble::tibble(
-  "Number of HTOs assayed" = 
-    format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
-  "Multiplex reads sequenced" = 
-    format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
-  "Percent multiplex reads mapped to ADTs" = 
-    paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%"),
-  "Percent of HTOs in cells" = 
-    paste0(round(sum(cell_hto_counts)/multiplex_meta$mapped_reads * 100, digits = 2), "%"),
-  "Percent of cells with HTOs" = 
-    paste0(round(sum(cell_hto_counts > 0)/length(cell_hto_counts) * 100, digits = 2), "%"),
-  "Median HTO UMIs per cell" = 
-    format(median(cell_hto_counts), big.mark = ',', scientific = FALSE)
-  )|>
+  "Number of HTOs assayed" =
+    format(nrow(multiplex_exp), big.mark = ",", scientific = FALSE),
+  "Multiplex reads sequenced" =
+    format(multiplex_meta$total_reads, big.mark = ",", scientific = FALSE),
+  "Percent multiplex reads mapped to ADTs" =
+    paste0(round(multiplex_meta$mapped_reads / multiplex_meta$total_reads * 100, digits = 2), "%"),
+  "Percent of HTOs in cells" =
+    paste0(round(sum(cell_hto_counts) / multiplex_meta$mapped_reads * 100, digits = 2), "%"),
+  "Percent of cells with HTOs" =
+    paste0(round(sum(cell_hto_counts > 0) / length(cell_hto_counts) * 100, digits = 2), "%"),
+  "Median HTO UMIs per cell" =
+    format(median(cell_hto_counts), big.mark = ",", scientific = FALSE)
+) |>
   t()
 
-knitr::kable(hto_information, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
+knitr::kable(hto_information, align = "r") |>
+  kableExtra::kable_styling(
+    bootstrap_options = "striped",
+    full_width = FALSE,
+    position = "left"
+  ) |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
@@ -40,63 +42,69 @@ hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
   tibble::rownames_to_column("Hashtag Oligo (HTO)") |>
   arrange(desc(mean)) |>
   select("Hashtag Oligo (HTO)",
-         "Mean UMI count per cell" = mean,
-         "Percent of cells detected" = detected)
+    "Mean UMI count per cell" = mean,
+    "Percent of cells detected" = detected
+  )
 
 knitr::kable(hto_tags, digits = 2) |>
-  kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
-                            full_width = FALSE,
-                            position = "left",
-                            ) |>
-  kableExtra::column_spec(2:3, monospace = TRUE) 
+  kableExtra::kable_styling(
+    bootstrap_options = c("striped", "condensed"),
+    full_width = FALSE,
+    position = "left",
+  ) |>
+  kableExtra::column_spec(2:3, monospace = TRUE)
 ```
 
-## Demultiplexing Sample Calls 
+## Demultiplexing Sample Calls
 
 Demultiplexing was performed using both [`DropletUtils::hashedDrops()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [`Seurat::HTOdemux()`](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
 
-For multiplex libraries where bulk RNA-seq data is available for the individual samples, we also performed demultiplexing analysis using genotype data following the methods described in [Weber _et al._ (2021)](https://doi.org/10.1093/gigascience/giab062). 
-The genetic demultiplexing results are reported under the `vireo` column in the below table.   
+For multiplex libraries where bulk RNA-seq data is available for the individual samples, we also performed demultiplexing analysis using genotype data following the methods described in [Weber _et al._ (2021)](https://doi.org/10.1093/gigascience/giab062).
+The genetic demultiplexing results are reported under the `vireo` column in the below table.
 
-**Note:** We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples. 
+**Note:** We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples.
 
 ```{r, results='asis'}
 # grab columns that have demuxing results as not all methods could be present
-# e.g. vireo is only used if a matching bulk RNA seq library is there, 
+# e.g. vireo is only used if a matching bulk RNA seq library is there,
 # otherwise those calls will not be present
 demux_methods <- c("hashedDrops_sampleid", "HTODemux_sampleid", "vireo_sampleid")
 demux_columns <- colnames(colData(filtered_sce)) %in% demux_methods
 
-if(any(demux_columns)){
- # create a table summarizing demuxing calls for each method used 
+if (any(demux_columns)) {
+  # create a table summarizing demuxing calls for each method used
   demux_calls <- as.data.frame(colData(filtered_sce)[, demux_columns]) |>
     # remove _sampleid at the end of the column names
-    dplyr::rename_with(~stringr::str_remove(., "_sampleid")) |>
-    tidyr::pivot_longer(cols = everything(),
-                        names_to = "demux_method",
-                        values_to = "Sample") |>
-    dplyr::count(Sample, demux_method) |>
-    tidyr::pivot_wider(names_from = demux_method,
-                       values_from = n)
-  
-  
-  knitr::kable(demux_calls, digits = 2) |>
-    kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
-                              full_width = FALSE,
-                              position = "left",
+    dplyr::rename_with(~ stringr::str_remove(., "_sampleid")) |>
+    tidyr::pivot_longer(
+      cols = everything(),
+      names_to = "demux_method",
+      values_to = "Sample"
     ) |>
-    kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE)  
-}else{
+    dplyr::count(Sample, demux_method) |>
+    tidyr::pivot_wider(
+      names_from = demux_method,
+      values_from = n
+    )
+
+
+  knitr::kable(demux_calls, digits = 2) |>
+    kableExtra::kable_styling(
+      bootstrap_options = c("striped", "condensed"),
+      full_width = FALSE,
+      position = "left",
+    ) |>
+    kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE)
+} else {
   glue::glue("
     <div class=\"alert alert-info\">
-    
+
     Demultiplexing was not applied to this library using any of the above mentioned methods.
     Sample calls cannot be reported.
-    
+
     </div>
   ")
 }
-
 ```
 
 

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -33,8 +33,10 @@ library(ggplot2)
 # Set default ggplot theme
 theme_set(
   theme_bw() +
-  theme(plot.margin = margin(rep(20, 4)), 
-        strip.background = element_rect(fill = 'transparent'))
+    theme(
+      plot.margin = margin(rep(20, 4)),
+      strip.background = element_rect(fill = "transparent")
+    )
 )
 
 # Helper function to change NULL -> "N/A" in a data frame
@@ -61,33 +63,33 @@ has_filtered <- !is.null(filtered_sce)
 has_processed <- !is.null(processed_sce)
 
 # if there is no filtered sce, use the unfiltered for both
-if (!has_filtered){
+if (!has_filtered) {
   filtered_sce <- unfiltered_sce
 }
 
 # grab sample id from filtered sce, if missing set sample id to NA
-if(is.null(metadata(filtered_sce)$sample_id)){
+if (is.null(metadata(filtered_sce)$sample_id)) {
   sample_id <- NA
 } else {
   sample_id <- metadata(filtered_sce)$sample_id
 }
 
 # add cell stats if missing
-if (is.null(unfiltered_sce$sum)){
+if (is.null(unfiltered_sce$sum)) {
   unfiltered_sce <- scuttle::addPerCellQCMetrics(unfiltered_sce)
 }
-if (is.null(filtered_sce$sum)){
+if (is.null(filtered_sce$sum)) {
   filtered_sce <- scuttle::addPerCellQCMetrics(filtered_sce)
 }
-if (is.null(filtered_sce$subsets_mito_percent)){
+if (is.null(filtered_sce$subsets_mito_percent)) {
   filtered_sce$subsets_mito_percent <- NA_real_
   skip_miQC <- TRUE
-}else{
+} else {
   skip_miQC <- FALSE
 }
 
 # try to add miQC if it is missing
-if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
+if (is.null(metadata(filtered_sce)$miQC_model) && !skip_miQC) {
   filtered_sce <- scpcaTools::add_miQC(filtered_sce)
 }
 
@@ -108,14 +110,14 @@ if (has_cellhash) {
 # check for umap and celltypes, but need to be sure that processed_sce exists first
 if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
-  
+
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
-  
+
   # Note: later, we will also check for submitter-provided annotations
   # for now, we will say this is false
   has_submitter_celltypes <- FALSE
-  
+
   # If at least 1 is present, we have cell type annotations.
   has_celltypes <- any(has_singler, has_cellassign, has_submitter_celltypes)
 } else {
@@ -133,7 +135,7 @@ has_multiplex <- length(sample_id) > 1
 
 if (has_multiplex) {
   # convert sample id to bullet separated list
-  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
+  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
   glue::glue("
     <div class=\"alert alert-warning\">
 
@@ -145,7 +147,6 @@ if (has_multiplex) {
     </div>
   ")
 }
-
 ```
 
 ## Raw Sample Metrics
@@ -160,13 +161,13 @@ sample_information <- tibble::tibble(
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Data modalities" = paste(modalities, collapse = ", "),
   "Cells reported by alevin-fry" =
-    format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE),
+    format(unfiltered_meta$af_num_cells, big.mark = ",", scientific = FALSE),
   "Number of genes assayed" =
-    format(nrow(unfiltered_sce), big.mark = ',', scientific = FALSE),
+    format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE),
   "Number of RNA-seq reads sequenced" =
-    format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
+    format(unfiltered_meta$total_reads, big.mark = ",", scientific = FALSE),
   "Percent of RNA-seq reads mapped to transcripts" =
-    paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%")
+    paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%")
 )
 
 if (has_adt) {
@@ -176,11 +177,11 @@ if (has_adt) {
   sample_information <- sample_information |>
     mutate(
       "Number of antibodies assayed" =
-        format(nrow(adt_exp), big.mark = ',', scientific = FALSE),
+        format(nrow(adt_exp), big.mark = ",", scientific = FALSE),
       "Number of ADT reads sequenced" =
-        format(adt_meta$total_reads, big.mark = ',', scientific = FALSE),
+        format(adt_meta$total_reads, big.mark = ",", scientific = FALSE),
       "Percent of ADT reads mapped to ADTs" =
-        paste0(round(adt_meta$mapped_reads/adt_meta$total_reads * 100, digits = 2), "%")
+        paste0(round(adt_meta$mapped_reads / adt_meta$total_reads * 100, digits = 2), "%")
     )
 }
 
@@ -191,11 +192,11 @@ if (has_cellhash) {
   sample_information <- sample_information |>
     mutate(
       "Number of HTOs assayed" =
-        format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
+        format(nrow(multiplex_exp), big.mark = ",", scientific = FALSE),
       "Number of cellhash reads sequenced" =
-        format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
+        format(multiplex_meta$total_reads, big.mark = ",", scientific = FALSE),
       "Percent of cellhash reads mapped to HTOs" =
-        paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%")
+        paste0(round(multiplex_meta$mapped_reads / multiplex_meta$total_reads * 100, digits = 2), "%")
     )
 }
 
@@ -204,10 +205,12 @@ sample_information <- sample_information |>
   t()
 
 # make table with sample information
-knitr::kable(sample_information, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
+knitr::kable(sample_information, align = "r") |>
+  kableExtra::kable_styling(
+    bootstrap_options = "striped",
+    full_width = FALSE,
+    position = "left"
+  ) |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
@@ -218,25 +221,28 @@ knitr::kable(sample_information, align = 'r') |>
 transcript_type <- paste(unfiltered_meta$transcript_type, collapse = " ")
 
 processing_info <- tibble::tibble(
-  "Salmon version"       = format(unfiltered_meta$salmon_version),
-  "Alevin-fry version"   = format(unfiltered_meta$alevinfry_version),
-  "Transcriptome index"  = format(unfiltered_meta$reference_index),
-  "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
-  "Resolution"           = format(unfiltered_meta$af_resolution),
+  "Salmon version" = format(unfiltered_meta$salmon_version),
+  "Alevin-fry version" = format(unfiltered_meta$alevinfry_version),
+  "Transcriptome index" = format(unfiltered_meta$reference_index),
+  "Alevin-fry droplet detection" = format(unfiltered_meta$af_permit_type),
+  "Resolution" = format(unfiltered_meta$af_resolution),
   "Transcripts included" = dplyr::case_when(
-      transcript_type == "total spliced" ~ "Total and spliced only",
-      transcript_type == "spliced" ~ "Spliced only",
-      TRUE ~ transcript_type)
-  ) |>
+    transcript_type == "total spliced" ~ "Total and spliced only",
+    transcript_type == "spliced" ~ "Spliced only",
+    TRUE ~ transcript_type
+  )
+) |>
   reformat_nulls() |>
   t()
 
 
 # make table with processing information
-knitr::kable(processing_info, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
+knitr::kable(processing_info, align = "r") |>
+  kableExtra::kable_styling(
+    bootstrap_options = "striped",
+    full_width = FALSE,
+    position = "left"
+  ) |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
@@ -248,11 +254,11 @@ knitr::kable(processing_info, align = 'r') |>
 basic_statistics <- tibble::tibble(
   "Method used to filter empty droplets"          = metadata(filtered_sce)$filtering_method,
   "Number of cells post filtering empty droplets" = format(ncol(filtered_sce), big.mark = ","),
-  "Percent of reads in cells"                     = paste0(round((sum(filtered_sce$sum)/sum(unfiltered_sce$sum))*100,2),"%"),
+  "Percent of reads in cells"                     = paste0(round((sum(filtered_sce$sum) / sum(unfiltered_sce$sum)) * 100, 2), "%"),
   "Median UMI count per cell"                     = format(median(filtered_sce$sum), big.mark = ","),
   "Median genes detected per cell"                = format(median(filtered_sce$detected), big.mark = ","),
   "Median percent reads mitochondrial"            = paste0(round(median(filtered_sce$subsets_mito_percent), 2), "%")
-  )
+)
 
 # if processed sce exists add filtering and normalization table
 if (has_processed) {
@@ -261,7 +267,7 @@ if (has_processed) {
   basic_statistics <- basic_statistics |>
     mutate(
       "Method used to filter low quality cells" = format(processed_meta$scpca_filter_method),
-      "Cells after filtering low quality cells" = format(dim(processed_sce)[2], big.mark = ',', scientific = FALSE),
+      "Cells after filtering low quality cells" = format(dim(processed_sce)[2], big.mark = ",", scientific = FALSE),
       "Normalization method"                    = format(processed_meta$normalization),
       "Minimum genes per cell cutoff"           = format(processed_meta$min_gene_cutoff)
     )
@@ -278,17 +284,20 @@ basic_statistics <- basic_statistics |>
   t()
 
 # make table with basic statistics
-knitr::kable(basic_statistics, align = 'r') |>
-  kableExtra::kable_styling(bootstrap_options = "striped",
-                            full_width = FALSE,
-                            position = "left") |>
+knitr::kable(basic_statistics, align = "r") |>
+  kableExtra::kable_styling(
+    bootstrap_options = "striped",
+    full_width = FALSE,
+    position = "left"
+  ) |>
   kableExtra::column_spec(2, monospace = TRUE)
-
 ```
 
 ```{r, results='asis'}
-if (has_filtered &&
-   (metadata(filtered_sce)$filtering_method == "UMI cutoff")) {
+if (
+  has_filtered &&
+    (metadata(filtered_sce)$filtering_method == "UMI cutoff")
+) {
   glue::glue("
     <div class=\"alert alert-warning\">
 
@@ -303,8 +312,8 @@ if (has_filtered &&
 ```{r, results='asis'}
 # check for number of filtered cells
 min_filtered <- 100
-if(has_filtered){
-  if(ncol(filtered_sce) < min_filtered){
+if (has_filtered) {
+  if (ncol(filtered_sce) < min_filtered) {
     glue::glue("
       <div class=\"alert alert-warning\">
 
@@ -318,8 +327,8 @@ if(has_filtered){
 
 # check for number of cells post processing
 min_processed <- 50
-if(has_processed){
-  if(ncol(processed_sce) < min_processed){
+if (has_processed) {
+  if (ncol(processed_sce) < min_processed) {
     glue::glue("
       <div class=\"alert alert-warning\">
 
@@ -337,7 +346,7 @@ if(has_processed){
 ```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) |>
   mutate(
-    rank = rank(- unfiltered_sce$sum, ties.method = "first"), # using full spec for clarity
+    rank = rank(-unfiltered_sce$sum, ties.method = "first"), # using full spec for clarity
     filter_pass = colnames(unfiltered_sce) %in% colnames(filtered_sce)
   ) |>
   select(sum, rank, filter_pass) |>
@@ -345,7 +354,7 @@ unfiltered_celldata <- data.frame(colData(unfiltered_sce)) |>
 
 
 grouped_celldata <- unfiltered_celldata |>
-  mutate(rank_group = floor(rank / 100) )|>
+  mutate(rank_group = floor(rank / 100)) |>
   group_by(rank_group) |>
   summarize(
     med_sum = median(sum),
@@ -358,25 +367,31 @@ top_celldata <- unfiltered_celldata |>
   mutate(filter_pct = ifelse(filter_pass, 100, 0))
 
 ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
-  geom_point(mapping = aes(x = rank, y = sum, color = filter_pct),
-             data = top_celldata,
-             alpha = 0.5) +
-  geom_line(linewidth = 2, lineend = "round", linejoin= "round") +
+  geom_point(
+    mapping = aes(x = rank, y = sum, color = filter_pct),
+    data = top_celldata,
+    alpha = 0.5
+  ) +
+  geom_line(linewidth = 2, lineend = "round", linejoin = "round") +
   scale_x_log10(labels = scales::label_number(accuracy = 1)) +
   scale_y_log10(labels = scales::label_number(accuracy = 1)) +
-  scale_color_gradient2(low = "grey70",
-                        mid = "forestgreen",
-                        high = "darkgreen",
-                        midpoint = 50) +
+  scale_color_gradient2(
+    low = "grey70",
+    mid = "forestgreen",
+    high = "darkgreen",
+    midpoint = 50
+  ) +
   labs(
     x = "Rank",
     y = "Total UMI count",
     color = "% passing\ncell filter"
   ) +
-  theme(legend.position = c(0, 0),
-        legend.justification = c(0,0),
-        legend.background = element_rect(color = "grey20", linewidth = 0.25),
-        legend.box.margin = margin(rep(5, 4)))
+  theme(
+    legend.position = c(0, 0),
+    legend.justification = c(0, 0),
+    legend.background = element_rect(color = "grey20", linewidth = 0.25),
+    legend.box.margin = margin(rep(5, 4))
+  )
 ```
 
 The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets.
@@ -389,21 +404,29 @@ The color in this plot indicates the percentage of droplets in a region passing 
 ```{r, fig.alt="Total UMI x genes expressed"}
 filtered_celldata <- data.frame(colData(filtered_sce))
 
-ggplot(filtered_celldata,
-       aes (x = sum,
-            y = detected,
-            color = subsets_mito_percent)) +
+ggplot(
+  filtered_celldata,
+  aes(
+    x = sum,
+    y = detected,
+    color = subsets_mito_percent
+  )
+) +
   geom_point(alpha = 0.3) +
   scale_color_viridis_c(limits = c(0, 100)) +
   scale_x_continuous(labels = scales::label_number(accuracy = 1)) +
   scale_y_continuous(labels = scales::label_number(accuracy = 1)) +
-  labs(x = "Total UMI count",
-       y = "Number of genes detected",
-       color = "Percent reads\nmitochondrial") +
-  theme(legend.position = c(0, 1),
-        legend.justification = c(0,1),
-        legend.background = element_rect(color = "grey20", linewidth = 0.25),
-        legend.box.margin = margin(rep(5, 4)))
+  labs(
+    x = "Total UMI count",
+    y = "Number of genes detected",
+    color = "Percent reads\nmitochondrial"
+  ) +
+  theme(
+    legend.position = c(0, 1),
+    legend.justification = c(0, 1),
+    legend.background = element_rect(color = "grey20", linewidth = 0.25),
+    legend.box.margin = margin(rep(5, 4))
+  )
 ```
 
 The above plot of cell metrics includes only droplets which have passed the `emptyDropsCellRanger()` filter.
@@ -428,14 +451,18 @@ if (skip_miQC) {
   }
 
   miQC_plot +
-    coord_cartesian(ylim = c(0,100)) +
+    coord_cartesian(ylim = c(0, 100)) +
     scale_x_continuous(labels = scales::label_number(accuracy = 1)) +
-    labs(x = "Number of genes detected",
-         y = "Percent reads mitochondrial") +
-    theme(legend.position = c(1, 1),
-          legend.justification = c(1,1),
-          legend.background = element_rect(color = "grey20", linewidth = 0.25),
-          legend.box.margin = margin(rep(5, 4)))
+    labs(
+      x = "Number of genes detected",
+      y = "Percent reads mitochondrial"
+    ) +
+    theme(
+      legend.position = c(1, 1),
+      legend.justification = c(1, 1),
+      legend.background = element_rect(color = "grey20", linewidth = 0.25),
+      legend.box.margin = margin(rep(5, 4))
+    )
 }
 ```
 
@@ -460,8 +487,7 @@ The dotted vertical line indicates the minimum gene cutoff used for filtering.
 
 
 ```{r results='asis'}
-if (has_filtered & has_processed) {
-
+if (has_filtered && has_processed) {
   # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
 
@@ -475,15 +501,19 @@ if (has_filtered & has_processed) {
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = scpca_filter)) +
     geom_point(alpha = 0.5, size = 1) +
     geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
-    labs(x = "Number of genes detected",
-         y = "Mitochondrial percentage",
-         color = "Filter",
-         title = stringr::str_replace(filter_method, "_", " ")) +
-    theme(plot.title = element_text(hjust = 0.5),
-          legend.position = c(1, 1),
-          legend.justification = c(1,1),
-          legend.background = element_rect(color = "grey20", linewidth = 0.25),
-          legend.title = element_text(hjust = 0.5))
+    labs(
+      x = "Number of genes detected",
+      y = "Mitochondrial percentage",
+      color = "Filter",
+      title = stringr::str_replace(filter_method, "_", " ")
+    ) +
+    theme(
+      plot.title = element_text(hjust = 0.5),
+      legend.position = c(1, 1),
+      legend.justification = c(1, 1),
+      legend.background = element_rect(color = "grey20", linewidth = 0.25),
+      legend.title = element_text(hjust = 0.5)
+    )
 } else {
   glue::glue("
     <div class=\"alert alert-warning\">
@@ -528,7 +558,6 @@ if (requireNamespace("sessioninfo", quietly = TRUE)) {
 } else {
   sessionInfo()
 }
-
 ```
 </details>
 

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -1,18 +1,19 @@
-## Dimensionality Reduction 
+## Dimensionality Reduction
 
 The below plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
 
 ```{r message=FALSE}
-# create UMAP colored by number of genes detected 
+# create UMAP colored by number of genes detected
 scater::plotUMAP(processed_sce,
-                 point_size = 0.3,
-                 point_alpha = 0.5,
-                 colour_by = "detected") +
+  point_size = 0.3,
+  point_alpha = 0.5,
+  colour_by = "detected"
+) +
   scale_color_viridis_c() +
   # remove axis numbers and background grid
-  scale_x_continuous(labels = NULL, breaks = NULL) + 
-  scale_y_continuous(labels = NULL, breaks = NULL) + 
-  coord_fixed() + 
+  scale_x_continuous(labels = NULL, breaks = NULL) +
+  scale_y_continuous(labels = NULL, breaks = NULL) +
+  coord_fixed() +
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
   )
@@ -28,78 +29,84 @@ If gene symbols are not available, the Ensembl id will be shown.
 ```{r message=FALSE, results='asis', fig.height = 8}
 # only create plot if variable genes are present
 if (!is.null(processed_meta$highly_variable_genes)) {
-  
-  # select top genes to plot 
+  # select top genes to plot
   top_genes <- processed_meta$highly_variable_genes |>
-    head( n = 12)
-  
+    head(n = 12)
+
   # grab expression for top genes from counts
-  var_gene_exp <- logcounts(processed_sce[top_genes,]) |>
+  var_gene_exp <- logcounts(processed_sce[top_genes, ]) |>
     as.matrix() |>
     t() |>
     as.data.frame() |>
     tibble::rownames_to_column("barcode")
-  
+
   # grab rowdata as data frame to later combine with gene expression data
-  # rowdata contains the mapped gene symbol so can use that to label plots instead of ensembl gene id from rownames 
+  # rowdata contains the mapped gene symbol so can use that to label plots instead of ensembl gene id from rownames
   rowdata_df <- rowData(processed_sce) |>
     as.data.frame() |>
     tibble::rownames_to_column("ensembl_id") |>
     select(ensembl_id, gene_symbol) |>
     filter(ensembl_id %in% top_genes) |>
-    mutate(gene_symbol = ifelse(!is.na(gene_symbol), gene_symbol, ensembl_id),
-         ensembl_id = factor(ensembl_id, levels = top_genes)) |>
+    mutate(
+      gene_symbol = ifelse(!is.na(gene_symbol), gene_symbol, ensembl_id),
+      ensembl_id = factor(ensembl_id, levels = top_genes)
+    ) |>
     arrange(ensembl_id) |>
     mutate(gene_symbol = factor(gene_symbol, levels = gene_symbol))
-  
-  
+
+
   # extract umap embeddings as a dataframe to join with gene expression and coldata for plotting
   umap_df <- reducedDim(processed_sce, "UMAP") |>
     as.data.frame() |>
     tibble::rownames_to_column("barcode") |>
-    rename("UMAP1" = "V1",
-           "UMAP2" = "V2")
-  
+    rename(
+      "UMAP1" = "V1",
+      "UMAP2" = "V2"
+    )
+
   # combine gene expression with coldata, umap embeddings, and rowdata and create data frame to use for plotting
   coldata_df <- colData(processed_sce) |>
     as.data.frame() |>
     tibble::rownames_to_column("barcode") |>
     # combine with gene expression
     left_join(var_gene_exp, by = "barcode") |>
-    # combine with umap embeddings 
+    # combine with umap embeddings
     left_join(umap_df, by = "barcode") |>
-    # combine all genes into a single column for easy faceting 
-    tidyr::pivot_longer(cols = starts_with("ENSG"),
-                        names_to = "ensembl_id",
-                        values_to = "gene_expression") |>
-    # join with row data to add in gene symbols 
+    # combine all genes into a single column for easy faceting
+    tidyr::pivot_longer(
+      cols = starts_with("ENSG"),
+      names_to = "ensembl_id",
+      values_to = "gene_expression"
+    ) |>
+    # join with row data to add in gene symbols
     left_join(rowdata_df)
-  
-  
-  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) + 
-    geom_point(alpha = 0.1, size = 0.001) + 
+
+
+  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) +
+    geom_point(alpha = 0.1, size = 0.001) +
     facet_wrap(vars(gene_symbol)) +
     scale_color_viridis_c() +
     labs(
       color = "Log-normalized gene expression"
     ) +
     # remove axis numbers and background grid
-    scale_x_continuous(labels = NULL, breaks = NULL) + 
-    scale_y_continuous(labels = NULL, breaks = NULL) + 
-    coord_fixed() + 
-    theme(legend.position = "bottom", 
-          axis.title = element_text(size = 9, color = "black"),
-          strip.text = element_text(size = 8),
-          legend.title = element_text(size = 9),
-          legend.text = element_text(size = 8)) +
+    scale_x_continuous(labels = NULL, breaks = NULL) +
+    scale_y_continuous(labels = NULL, breaks = NULL) +
+    coord_fixed() +
+    theme(
+      legend.position = "bottom",
+      axis.title = element_text(size = 9, color = "black"),
+      strip.text = element_text(size = 8),
+      legend.title = element_text(size = 9),
+      legend.text = element_text(size = 8)
+    ) +
     guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
-  
 } else {
   glue::glue("
     <div class=\"alert alert-warning\">
-    
-    This library does not contain a set of highly variable genes. 
-    
+
+    This library does not contain a set of highly variable genes.
+
     </div>
   ")
 }


### PR DESCRIPTION
There is never a great time to do this, but I thought it was well past time to start using stylers in this repo when we can, and things are _kind of_ quiet at the moment, so I thought I would give it a shot. 

With that intro, here I have added a note to that effect to `CONTRIBUTING.md` and went ahead and restyled all the python, R, and rmd files. There are no code changes here aside from a couple of places where the linter wanted me to change `|` and `&` to `||` and `&&` within `if` statements, which doesn't matter for those cases but is "more correct."

There is no particular style I could find for Nextflow files, so those should be unchanged. 

