### PR TITLE
Update SingleR celltyping

### DIFF
--- a/build-celltype-ref.nf
+++ b/build-celltype-ref.nf
@@ -40,7 +40,7 @@ process train_singler_models {
       --ref_file ${ref_file} \
       --output_file ${celltype_model} \
       --fry_tx2gene ${t2g_3col_path} \
-      --label_name ${params.label_name} \
+      --label_name ${params.singler_label_name} \
       --seed ${params.seed} \
       --threads ${task.cpus}
     """

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -15,7 +15,7 @@ params{
 
   // cell type references and SingleR label of interest
   celltype_project_metafile = "s3://ccdl-scpca-data/sample_info/celltype_annotation/scpca-project-celltype-metadata.tsv"
-  label_name = "label.ont"
+  singler_label_name = "label.ont"
 
 
   // Private CCDL containers

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -14,7 +14,7 @@ process classify_singleR {
         --input_sce_file ${processed_rds} \
         --output_sce_file ${annotated_rds} \
         --singler_model_file ${singler_model_file} \
-        --label_name ${params.label_name} \
+        --label_name ${params.singler_label_name} \
         --seed ${params.seed} \
         --threads ${task.cpus}
       """

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -9,7 +9,7 @@ The following method(s) were used to perform cell typing:
 knitr::asis_output(
   glue::glue(
   "* [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach.
-  The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
+  The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex`](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
   )
 )
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -179,6 +179,9 @@ if ("singler_celltype_ontology" %in% names(celltype_df)) {
   # otherwise, full_labels already contain what we want to plot, so just rename it 
   delta_median_df <- delta_median_df |>
     dplyr::rename(celltype = full_labels)
+  # still need to add levels though:
+  # unknown will still be present, but it's not in the data, so it won't matter
+  levels(delta_median_df$celltype) <- levels(celltype_df$singler_celltype_annotation)
 }
 
 # Ensure we have no "Unknown cell type" values left:

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -216,12 +216,15 @@ ggplot(delta_median_df) +
   ) + 
   scale_color_manual(values = c("blue", "black")) +
   # add median/IQR
-  stat_summary(
+  geom_boxplot(
     data = delta_median_confident_df, # only use black points for median
     color = "red",
-    geom = "crossbar",
-    width = 0.4,
-    size = 0.2
+    width = 0.2,
+    size = 0.3, 
+    alpha = 0,
+    # remove whiskers, outliers
+    outlier.shape = 0,
+    coef = 0
   ) + 
   guides(
     color = guide_legend(override.aes = list(size = 1, alpha = 0.9))


### PR DESCRIPTION
Closes #441 

I have tested the celltyping workflow using `label.main` for `SingleR` (including "model training"), and found 2 quick things that needed to be fixed! Everything is working smoothly now, all tested.

- First, this wasn't a bug, but it seemed like the right move. We previously made a parameter called `label_name` for the singler reference label, but this was before we added cellassign. So, I just changed this workflow parameter to be named `singler_label_name` for clarity. I left all R scripts alone.
- Second, this _was_ a bug! The QC report delta median plot x-axis did not the right levels in an ontology-free scenario, so I added levels and now the plot looks as expected.

Report: [qc_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/12562576/qc_report.html.zip)