### PR TITLE
Account for failed failed model gene variance and pca

### DIFF
--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -65,30 +65,35 @@ if (!file.exists(opt$processed_sce_file)) {
 }
 sce <- readr::read_rds(opt$processed_sce_file)
 
+# only perform clustering if reduced dimension embeddings are present
+# otherwise just return the object
+if(length(reducedDimNames(sce)) > 0){
 
-# check pca_name is present
-if (!opt$pca_name %in% reducedDimNames(sce)) {
-  stop("Provided `pca_name` is not present in the SCE object.")
-}
+  # check pca_name is present
+  if (!opt$pca_name %in% reducedDimNames(sce)) {
+    stop("Provided `pca_name` is not present in the SCE object.")
+  }
 
-# Perform clustering ----------------
+  # Perform clustering ----------------
 
-# extract the principal components matrix
-clusters <- scran::clusterCells(
-  sce,
-  use.dimred = opt$pca_name,
-  BLUSPARAM = bluster::NNGraphParam(
-    k = opt$nearest_neighbors,
-    type = opt$cluster_weighting,
-    cluster.fun = opt$cluster_algorithm
+  # extract the principal components matrix
+  clusters <- scran::clusterCells(
+    sce,
+    use.dimred = opt$pca_name,
+    BLUSPARAM = bluster::NNGraphParam(
+      k = opt$nearest_neighbors,
+      type = opt$cluster_weighting,
+      cluster.fun = opt$cluster_algorithm
+    )
   )
-)
 
-# add clusters and associated parameters to SCE object
-sce$clusters <- clusters
-metadata(sce)$cluster_algorithm <- opt$cluster_algorithm
-metadata(sce)$cluster_weighting <- opt$cluster_weighting
-metadata(sce)$cluster_nn <- opt$nearest_neighbors
+  # add clusters and associated parameters to SCE object
+  sce$clusters <- clusters
+  metadata(sce)$cluster_algorithm <- opt$cluster_algorithm
+  metadata(sce)$cluster_weighting <- opt$cluster_weighting
+  metadata(sce)$cluster_nn <- opt$nearest_neighbors
+
+}
 
 # export -------------------
 # we are overwriting the `processed_sce_file` here

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -67,8 +67,9 @@ sce <- readr::read_rds(opt$processed_sce_file)
 
 # only perform clustering if reduced dimension embeddings are present
 # otherwise just return the object
-if(length(reducedDimNames(sce)) > 0){
-
+if(length(reducedDimNames(sce)) == 0) {
+  warning("No reduced dimensions present, skipping clustering")
+} else {
   # check pca_name is present
   if (!opt$pca_name %in% reducedDimNames(sce)) {
     stop("Provided `pca_name` is not present in the SCE object.")

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -67,13 +67,9 @@ sce <- readr::read_rds(opt$processed_sce_file)
 
 # only perform clustering if reduced dimension embeddings are present
 # otherwise just return the object
-if(length(reducedDimNames(sce)) == 0) {
-  warning("No reduced dimensions present, skipping clustering")
+if(!opt$pca_name %in% reducedDimNames(sce)) {
+  warning("No reduced dimensions present with provided `pca_name`, skipping clustering")
 } else {
-  # check pca_name is present
-  if (!opt$pca_name %in% reducedDimNames(sce)) {
-    stop("Provided `pca_name` is not present in the SCE object.")
-  }
 
   # Perform clustering ----------------
 

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -232,27 +232,34 @@ if (alt_exp %in% altExpNames(processed_sce)) {
 try({
   # model gene variance using `scran:modelGeneVar()`
   gene_variance <- scran::modelGeneVar(processed_sce)
-
+  
   # select the most variable genes
   var_genes <- scran::getTopHVGs(gene_variance, n = opt$n_hvg)
-
+  
   # save the most variable genes to the metadata
   metadata(processed_sce)$highly_variable_genes <- var_genes
+  
+  # dimensionality reduction
+  # highly variable genes are used as input to PCA
+  processed_sce <- scater::runPCA(
+    processed_sce,
+    ncomponents = opt$n_pcs,
+    subset_row = var_genes
+  )
+})
 
-# dimensionality reduction
-# highly variable genes are used as input to PCA
-processed_sce <- scater::runPCA(
-  processed_sce,
-  ncomponents = opt$n_pcs,
-  subset_row = var_genes
-)
-
-# calculate a UMAP matrix using the PCA results
+try({
+  # calculate a UMAP matrix using the PCA results
   processed_sce <- scater::runUMAP(
     processed_sce,
     dimred = "PCA"
   )
 })
+
+# print a warning if no embeddings present
+if(length(reducedDimNames(processed_sce)) == 0){
+  warning("Reduced dimensions could not be calculated for this object.")
+}
 
 # Export --------------
 

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -248,7 +248,8 @@ processed_sce <- scater::runPCA(
 )
 
 # calculate a UMAP matrix using the PCA results
-  processed_sce <- scater::runUMAP(processed_sce,
+  processed_sce <- scater::runUMAP(
+    processed_sce,
     dimred = "PCA"
   )
 })

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -229,14 +229,15 @@ if (alt_exp %in% altExpNames(processed_sce)) {
 
 # Perform dimension reduction --------------------
 
-# model gene variance using `scran:modelGeneVar()`
-gene_variance <- scran::modelGeneVar(processed_sce)
+try({
+  # model gene variance using `scran:modelGeneVar()`
+  gene_variance <- scran::modelGeneVar(processed_sce)
 
-# select the most variable genes
-var_genes <- scran::getTopHVGs(gene_variance, n = opt$n_hvg)
+  # select the most variable genes
+  var_genes <- scran::getTopHVGs(gene_variance, n = opt$n_hvg)
 
-# save the most variable genes to the metadata
-metadata(processed_sce)$highly_variable_genes <- var_genes
+  # save the most variable genes to the metadata
+  metadata(processed_sce)$highly_variable_genes <- var_genes
 
 # dimensionality reduction
 # highly variable genes are used as input to PCA
@@ -247,7 +248,6 @@ processed_sce <- scater::runPCA(
 )
 
 # calculate a UMAP matrix using the PCA results
-try({
   processed_sce <- scater::runUMAP(processed_sce,
     dimred = "PCA"
   )


### PR DESCRIPTION
In processing some data for release, I was getting an error for one sample at the `model_gene_var` step in post processing. This was because there was only 1 cell after filtering (yikes!). We account for a low number of cells and failing normalization, but don't account for that in downstream steps. I added a `try` statement around `model_gene_var` up until calculating the UMAP. 

I also updated the clustering script here to account for objects that don't have any PCA or reduced dimensions present. 