### PR TITLE
Require more than one cell to create an AnnData object

### DIFF
--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -178,6 +178,7 @@ metadata_list <- list(
   is_multiplexed = multiplexed,
   has_citeseq = has_citeseq,
   has_cellhash = has_cellhash,
+  processed_cells = ncol(processed_sce),
   filtered_cells = ncol(filtered_sce),
   unfiltered_cells = ncol(unfiltered_sce),
   droplet_filtering_method = filtered_sce_meta$filtering_method,

--- a/main.nf
+++ b/main.nf
@@ -225,8 +225,12 @@ workflow {
   sce_qc_report(cluster_sce.out, report_template_tuple)
 
   // convert SCE object to anndata
-  // do this for everything but multiplexed libraries
-  anndata_ch = post_process_sce.out
+  anndata_ch = cluster_sce.out
+    // join clustering output with qc report data
+    // we need to be able to grab the number of cells for each object from the metadata json (output from sce_qc_report)
+    // tuple of [meta, unfiltered, filtered, processed, qc report, metadata json]
+    .join(sce_qc_report.out, by: 0, failOnDuplicate: true, failOnMismatch: true)
+    // skip multiplexed libraries
     .filter{!(it[0]["library_id"] in multiplex_libs.getVal())}
   sce_to_anndata(anndata_ch)
 


### PR DESCRIPTION
Closes #461 

This PR modifies the workflow so that we only create AnnData objects for SCE objects that have > 1 cell present. One option I thought of was making an optional output for the process that converts SCE to AnnData and only create the output if the number of cells is > 1. However, I was worried about using optional files as output and how that would affect downstream steps. Instead, I used an approach that would allow us to filter the input to the `export_anndata` process based on the number of cells. 

- We already provide the number of `filtered` and `unfiltered` cells in the `<library_id>_metadata.json` file that is returned in the final output. I thought it made sense to also include the number of cells present in the processed object. I added that here. 
- Previously, we had been using the output from post processing as the input to creating the AnnData object. I updated the workflow here to take the output from the clustering process instead. Additionally, I am joining that with the output from the qc report process. This creates a tuple with the `[meta, unfiltered rds, filtered rds, processed rds, qc report, metadata.json]`. This is then the input to the AnnData process. 
- In the workflow for exporting the AnnData, I added a step to read in the `metadata.json` and grab the number of cells for that specific file (e.g., unfiltered, filtered, processed). If the number of cells <= 1 then that rds file doesn't get passed to the conversion step. 

I tested this with both a regular library that should have all the objects converted and the library that was failing conversion with 1 cell. 

Another thing I want to note is that we should make an update to `scpcaTools::sce_to_anndata()` that throws an error if an object only has 1 cell. I will file that as a follow up PR. 