### PR TITLE
Include AnnData files in example output

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -164,13 +164,13 @@ sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
   dplyr::mutate(library_id = opt$library_id) 
 
 if("upload_date" %in% colnames(sample_metadata_df)){
-  sample_metadata_df -> sample_metadata_df |>
+  sample_metadata_df <- sample_metadata_df |>
     # remove upload date as we don't provide this on the portal
     dplyr::select(-upload_date)
 }
 
 if("participant_id" %in% colnames(sample_metadata_df)){
-  sample_metadata_df -> sample_metadata_df |>
+  sample_metadata_df <- sample_metadata_df |>
     # rename to donor id for czi compliance
     dplyr::rename("donor_id" = "participant_id")
 }

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -161,11 +161,19 @@ sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file) |>
   dplyr::rename("sample_id" = "scpca_sample_id") |>
   # add library ID as column in sample metadata
   # we need this so we are able to merge sample metadata with colData later
-  dplyr::mutate(library_id = opt$library_id) |>
-  # remove upload date as we don't provide this on the portal
-  dplyr::select(-upload_date) |>
-  # rename to donor id for czi compliance
-  dplyr::rename("donor_id" = "participant_id")
+  dplyr::mutate(library_id = opt$library_id) 
+
+if("upload_date" %in% colnames(sample_metadata_df)){
+  sample_metadata_df -> sample_metadata_df |>
+    # remove upload date as we don't provide this on the portal
+    dplyr::select(-upload_date)
+}
+
+if("participant_id" %in% colnames(sample_metadata_df)){
+  sample_metadata_df -> sample_metadata_df |>
+    # rename to donor id for czi compliance
+    dplyr::rename("donor_id" = "participant_id")
+}
 
 # add per cell and per gene statistics to colData and rowData
 unfiltered_sce <- unfiltered_sce |>

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -172,7 +172,7 @@ if("upload_date" %in% colnames(sample_metadata_df)){
 if("participant_id" %in% colnames(sample_metadata_df)){
   sample_metadata_df <- sample_metadata_df |>
     # rename to donor id for czi compliance
-    dplyr::rename("donor_id" = "participant_id")
+    dplyr::rename(donor_id = participant_id)
 }
 
 # add per cell and per gene statistics to colData and rowData

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -47,10 +47,12 @@ The columns of these files should match the expected input columns of the workfl
 
 Additionally, the `example_run_metadata.tsv` should contain at least 1 row with `run01` in the `scpca_run_id` column and `s3://scpca-references/example-data/example_fastqs/run01` in the `files_directory` column.
 
-Once you have confirmed that the metadata looks correct, the following command should be used to run the workflow and process the example data:
+Once you have confirmed that the metadata looks correct, the following commands should be used to run the workflow and process the example data:
 
 ```sh
-nextflow run AlexsLemonade/scpca-nf \
+nextflow pull AlexsLemonade/scpca-nf -r development
+
+nextflow run AlexsLemonade/scpca-nf -r development \
   -profile ccdl,batch \
   --run_ids run01 \
   --run_metafile s3://scpca-references/example-data/example_run_metadata.tsv \

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -47,7 +47,8 @@ The following command should be used to run the workflow and process the example
 nextflow run AlexsLemonade/scpca-nf \
   -profile ccdl,batch \
   --run_ids run01 \
-  --run_metafile s3://scpca-references/example-data/example_metadata.tsv \
+  --run_metafile s3://scpca-references/example-data/example_run_metadata.tsv \
+  --sample_metafile s3://scpca-references/example-data/example_sample_metadata.tsv \
   --outdir s3://scpca-references/example-data/scpca_out
 ```
 

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -41,7 +41,13 @@ nextflow run AlexsLemonade/scpca-nf -r v0.5.4 -profile ccdl,batch --project SCPC
 We provide an [example of the expected outputs](./examples/README.md#example-output) after running `scpca-nf` available for external users.
 If there have been major updates to the directory structure or the contents of the output, the example data should be re-processed such that the example output we provide mimics the current expected output from `scpca-nf`.
 
-The following command should be used to run the workflow and process the example data:
+First, please check the metadata files present in `s3://scpca-references/example-data` are up to date with changes in the workflow.
+There should be both an `example_run_metadata.tsv` and `example_sample_metadata.tsv`.
+The columns of these files should match the expected input columns of the workflow (see the section on preparing the [run metadata](./external-instructions.md#prepare-the-run-metadata-file) and [sample metadata](./external-instructions.md#prepare-the-sample-metadata-file)).
+
+Additionally, the `example_run_metadata.tsv` should contain at least 1 row with `run01` in the `scpca_run_id` column and `s3://scpca-references/example-data/example_fastqs/run01` in the `files_directory` column.
+
+Once you have confirmed that the metadata looks correct, the following command should be used to run the workflow and process the example data:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \


### PR DESCRIPTION
Closes #369 

This PR makes a few internal documentation updates for how to update example output files. As part of this I updated the current example output link to contain the example output with AnnData. 

- I made sure the example metadata files in `s3://scpca-references/example-data` contained the correct columns and have the correct path to the example files. 
- I ran the `development` branch of the workflow. When doing that I found an error in reading in the sample metadata where we expect columns for both `upload_date` and `participant_id`. Since those are not required columns in the sample metadata (see #467) and we only use them internally, I wrapped the modifications of those columns in `if` statements. After doing that the workflow was able to run successfully. 
- I downloaded the new outputs, zipped them up, and re-uploaded them to `s3://scpca-references/example-data/scpca_out.zip` and set the files to public. 
- I made a few changes to the internal documentation to hopefully be more detailed on how the data was generated. 

One thing to note is that the development branch currently has output with clusters, but no cell types yet. So cluster annotations are in the output too, but I think that's okay right now. We may want to re-generate the examples with cell types once that is in the workflow.