### PR TITLE
Drop txt and move channel merge logic

### DIFF
--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -119,7 +119,7 @@ workflow annotate_celltypes {
       // TODO update below with output channel results:
       export_channel = processed_sce_channel
         .map{[it[0]["library_id"]] + it}
-        // add add in unfiltered and filtered sce files
+        // add in unfiltered and filtered sce files
         .join(sce_files_channel.map{[it[0]["library_id"], it[1], it[2]]},
               by: 0, failOnMismatch: true, failOnDuplicate: true)
         // rearrange to be [meta, unfiltered, filtered, processed]

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -119,7 +119,7 @@ workflow annotate_celltypes {
       // TODO update below with output channel results:
       export_channel = processed_sce_channel
         .map{[it[0]["library_id"]] + it}
-        // add add in unprocessed and filtered sce files
+        // add add in unfiltered and filtered sce files
         .join(sce_files_channel.map{[it[0]["library_id"], it[1], it[2]]},
               by: 0, failOnMismatch: true, failOnDuplicate: true)
         // rearrange to be [meta, unfiltered, filtered, processed]

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -81,14 +81,17 @@ process classify_cellassign {
 }
 
 workflow annotate_celltypes {
-    take: processed_sce_channel
+    take: sce_files_channel // channel of meta, unfiltered_sce, filtered_sce, processed_sce
     main:
+      // get just the meta and processed sce
+      processed_sce_channel = sce_files_channel.map{[it[0], it[3]]}
+
       // channel with celltype model and project ids
       celltype_ch = Channel.fromPath(params.celltype_project_metafile)
         .splitCsv(header: true, sep: '\t')
         .map{[
          // project id
-         it.scpca_project_id, 
+         it.scpca_project_id,
          // singler model file
          Utils.parseNA(it.singler_ref_file) ? file("${params.singler_models_dir}/${it.singler_ref_file}") : null,
          // cellassign reference file
@@ -103,16 +106,26 @@ workflow annotate_celltypes {
         .map{[it[0]["project_id"]] + it}
         .combine(celltype_ch, by: 0)
         .map{it.drop(1)} // remove extra project ID
-        
+
       // create input for singleR: [meta, processed, SingleR reference model]
       singler_input_ch = celltype_input_ch
-        .map{meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name -> 
-          [ meta, processed_rds, singler_model ]}
+        .map{meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name ->
+             [meta, processed_rds, singler_model]}
 
       // perform singleR celltyping and export TSV
       classify_singleR(singler_input_ch)
 
-    // temporary during development
-    emit: celltype_input_ch
+      // add back in the unchanged sce files
+      // TODO update below with output channel results:
+      export_channel = processed_sce_channel
+        .map{[it[0]["library_id"]] + it}
+        // add add in unprocessed and filtered sce files
+        .join(sce_files_channel.map{[it[0]["library_id"], it[1], it[2]]},
+              by: 0, failOnMismatch: true, failOnDuplicate: true)
+        // rearrange to be [meta, unfiltered, filtered, processed]
+        .map{library_id, meta, processed_sce, unfiltered_sce, filtered_sce ->
+            [meta, unfiltered_sce, filtered_sce, processed_sce]}
+
+    emit: export_channel
 
 }

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -30,7 +30,7 @@ process make_unfiltered_sce{
 
 
         # Only run script if annotations are available:
-        if [ ${submitter_cell_types_file.name} != "NO_FILE.txt" ]; then
+        if [ ${submitter_cell_types_file.name} != "NO_FILE" ]; then
           add_submitter_annotations.R \
             --sce_file "${unfiltered_rds}" \
             --library_id "${meta.library_id}" \
@@ -86,7 +86,7 @@ process make_merged_unfiltered_sce{
           ${params.spliced_only ? '--spliced_only' : ''}
 
         # Only run script if annotations are available:
-        if [ ${submitter_cell_types_file.name} != "NO_FILE.txt" ]; then
+        if [ ${submitter_cell_types_file.name} != "NO_FILE" ]; then
           add_submitter_annotations.R \
             --sce_file "${unfiltered_rds}" \
             --library_id "${meta.library_id}" \
@@ -116,9 +116,9 @@ process filter_sce{
 
         // Checks for whether we have ADT data:
         // - feature_type should be adt
-        // - barcode file should _not_ be the empty file NO_FILE.txt
+        // - barcode file should _not_ be the empty file NO_FILE
         adt_present = meta.feature_type == 'adt' &
-          feature_barcode_file.name != "NO_FILE.txt"
+          feature_barcode_file.name != "NO_FILE"
 
         """
         filter_sce_rds.R \
@@ -219,7 +219,7 @@ process post_process_sce{
 
 
 // used when a given file is not defined in the below workflows
-empty_file = "${projectDir}/assets/NO_FILE.txt"
+empty_file = "${projectDir}/assets/NO_FILE"
 
 workflow generate_sce {
   // generate rds files for RNA-only samples


### PR DESCRIPTION
Closes #474

I also decided to move the logic of dropping and re-adding the unftilered & filtered sces from the channel into the annotation workflow itself. If we reconsidere whether we want to add annotations to filtered sces, we can do that more easily if the files are already there, and it streamlines `main.nf` a bit to make the flow a bit more clear.