### PR TITLE
Add CellAssign process to main workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -223,9 +223,7 @@ workflow {
   cluster_sce(post_process_sce.out)
 
   // Perform celltyping, if specified
-  // todo: add check here to not enter the process if references are missing.
   annotate_celltypes( cluster_sce.out )
-
 
   // generate QC reports
   sce_qc_report(annotate_celltypes.out, report_template_tuple)

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -113,10 +113,11 @@ workflow annotate_celltypes {
         }
       
       // create input for singleR: [meta, processed, SingleR reference model]
-      singler_input_ch = celltype_input_ch
+      singler_input_ch = celltype_input_ch.run
         .map{meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name ->
              [meta, processed_rds, singler_model]}
-
+             
+             
       // perform singleR celltyping and export TSV
       classify_singleR(singler_input_ch)
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -143,8 +143,13 @@ workflow annotate_celltypes {
               by: 0, failOnMismatch: true, failOnDuplicate: true)
        .map{meta, processed_rds, singler_annotations_tsv, singler_full_results, cellassign_ref ->
           [meta, processed_rds, cellassign_ref]}
+       // branch if the ref is null. This code assumes the reference name exist if the filename exists!
+       .branch{
+          skip: it[2] == null
+          run: true
+        }    
       
-     // classify_cellassign(cellassign_ch) // output: meta, processed_rds, cellassign_predictions, cellassign_ref_name
+     // classify_cellassign(cellassign_ch.run) // output: meta, processed_rds, cellassign_predictions
 
       // TODO mix celltyping results back up with `celltype_input_ch.skip`
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -34,33 +34,48 @@ process classify_singleR {
 }
 
 
-process predict_cellassign {
+process classify_cellassign {
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${params.checkpoints_dir}/celltype/${meta.library_id}", mode: 'copy'
+    publishDir (
+        path: "${params.checkpoints_dir}/celltype/${meta.library_id}",
+        mode:  'copy',
+        pattern: "*{.tsv,.json}" // Only the prediction matrix (tsv) and meta
+    )
   label 'mem_32'
   label 'cpus_12'
   input:
-    tuple val(meta), path(processed_hdf5), path(cellassign_reference_mtx), val(ref_name)
+    tuple val(meta), path(processed_rds), path(cellassign_ref)
   output:
-    tuple val(meta), path(cellassign_predictions), val(ref_name)
+    tuple val(meta), path(processed_rds), path(cellassign_predictions_tsv)
   script:
+    processed_hdf5 = "${meta.library_id}_processed.hdf5"
     cellassign_predictions = "${meta.library_id}_predictions.tsv"
+
     """
+    # Convert SCE to AnnData
+    sce_to_anndata.R \
+        --input_sce_file ${processed_rds} \
+        --output_rna_h5 ${processed_hdf5} 
+    
+    # Run CellAssign
     predict_cellassign.py \
       --input_hdf5_file ${processed_hdf5} \
-      --output_predictions ${cellassign_predictions} \
-      --reference ${cellassign_reference_mtx} \
+      --output_predictions ${cellassign_predictions_tsv} \
+      --reference ${cellassign_ref} \
       --seed ${params.seed} \
       --threads ${task.cpus}
     """
   stub:
+    processed_hdf5 = "${meta.library_id}_processed.hdf5"
     cellassign_predictions = "${meta.library_id}_predictions.tsv"
     """
     touch "${cellassign_predictions}"
+    touch "${processed_hdf5}"
     """
 }
 
-process classify_cellassign {
+// TODO - overhaul this process
+process add_celltypes {
   container params.SCPCATOOLS_CONTAINER
   publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
   label 'mem_4'
@@ -101,27 +116,37 @@ workflow annotate_celltypes {
          Utils.parseNA(it.cellassign_ref_name)
         ]}
 
-      // create cell typing channel: [meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name]
+      // create cell typing channel: [meta, processed_rds, singler_model, cellassign_ref, cellassign_ref_name]
       celltype_input_ch = processed_sce_channel
         .map{[it[0]["project_id"]] + it}
         .combine(celltype_ch, by: 0)
         .map{it.drop(1)} // remove extra project ID
         // we only run celltyping for rows with a singler model file
+        // branch here so we have meta and processed sce in the .skip
         .branch{
           skip: it[2] == null
           run: true
         }
+        
       
       // create input for singleR: [meta, processed, SingleR reference model]
       singler_input_ch = celltype_input_ch.run
-        .map{meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name ->
+        .map{meta, processed_rds, singler_model, cellassign_ref, cellassign_ref_name ->
              [meta, processed_rds, singler_model]}
              
-             
       // perform singleR celltyping and export TSV
-      classify_singleR(singler_input_ch)
+      classify_singleR(singler_input_ch) 
 
-      // TODO: mix celltyping results back up with `celltype_input_ch.skip`
+      // proceed to cellassign, only for datasets with references
+      cellassign_ch = classify_singleR.out //  meta, processed_rds, singler_annotations_tsv singler_full_results
+        .join(celltype_input_ch.run.map{[it[0], it[3]]}, // meta, cellassign_ref
+              by: 0, failOnMismatch: true, failOnDuplicate: true)
+       .map{meta, processed_rds, singler_annotations_tsv, singler_full_results, cellassign_ref ->
+          [meta, processed_rds, cellassign_ref]}
+      
+     // classify_cellassign(cellassign_ch) // output: meta, processed_rds, cellassign_predictions, cellassign_ref_name
+
+      // TODO mix celltyping results back up with `celltype_input_ch.skip`
 
       // add back in the unchanged sce files
       // TODO update below with output channel results:

--- a/test/stub-celltype-project-metadata.tsv
+++ b/test/stub-celltype-project-metadata.tsv
@@ -4,5 +4,5 @@ STUBP02	singler_model_file.rds	cellassign_ref_file.tsv	tissue
 STUBP03	singler_model_file.rds	cellassign_ref_file.tsv	tissue
 STUBP04	singler_model_file.rds	cellassign_ref_file.tsv	tissue
 STUBP05	singler_model_file.rds	cellassign_ref_file.tsv	tissue
-STUBP06	singler_model_file.rds	cellassign_ref_file.tsv	tissue
-STUBP07	singler_model_file.rds	cellassign_ref_file.tsv	tissue
+STUBP06	NA	NA	NA
+STUBP07	singler_model_file.rds	NA	NA


### PR DESCRIPTION
Towards #415 

This PR takes the next steps towards celltyping moving into the main workflow:

- I added branching to create two channels in the subworkflow, `celltype_input_ch.run` and `celltype_input_ch.skip`, based on whether or not the singler file value is null (is there a better way to check if a value is `null` here? I couldn't find it!)
  - However, I am not currently checking if the file exists. This probably needs to happen somewhere before going into the process, but wanted to get feedback on this branching first before upgrading it.
- I then prepared a channel for heading into CellAssign, and updated the CellAssign process itself. I included the same type of branch here as well - skip the cellassign if its file value is null. I again have no checks for the file existing and I am also not checking the reference name. Do we think I should?
- I have written the code with the SingleR output files coming along for the right into the CellAssign process, but I left a couple TODO comments about where we would change code to have that not happen. In that case, we'd join these files back up with cell assign output for input to the final process that will add annotations to the SCE, in the next PR.
- A couple more TODOs for subsequent PRs are sprinkled in there, too. Let me know if anything about them is unclear.
- (Edit) - I also updated the stub celltype file to have some `NA`s, to ensure the flow of the skipped branches gets "tested".