### PR TITLE
Use output folder for singler

### DIFF
--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -1,35 +1,40 @@
 
-process classify_singleR {
+process classify_singler {
     container params.SCPCATOOLS_CONTAINER
-    publishDir (
-        path: "${params.checkpoints_dir}/celltype/${meta.library_id}",
-        mode:  'copy',
-        pattern: "*{_singler.rds,.tsv,.json}" // Everything except processed rds
-    )
+    publishDir "${meta.celltype_publish_dir}", mode: 'copy'
     label 'mem_8'
     label 'cpus_4'
     input:
-        tuple val(meta), path(processed_rds), path(singler_model_file)
+        tuple val(meta), path(processed_rds),
+              path(singler_model_file),
+              path(cellassign_reference_file), val(cellassign_reference_name)
     output:
-        tuple val(meta), path(processed_rds), path(singler_annotations_tsv), path(singler_full_results)
+        tuple val(meta), path(processed_rds),
+              path(singler_model_file),
+              path(cellassign_reference_file), val(cellassign_reference_name),
+              path(singler_dir)
     script:
-      singler_annotations_tsv = "${meta.library_id}_singler_annotations.tsv"
-      singler_full_results = "${meta.library_id}_singler.rds"
+      singler_dir = file(meta.singler_dir).name
       """
+      # create output directory
+      mkdir "${singler_dir}"
+
       classify_SingleR.R \
-        --sce_file ${processed_rds} \
-        --singler_model_file ${singler_model_file} \
-        --output_singler_annotations_file ${singler_annotations_tsv} \
-        --output_singler_results_file ${singler_full_results} \
+        --sce_file "${processed_rds}" \
+        --singler_model_file "${singler_model_file}" \
+        --output_singler_annotations_file "${singler_dir}/singler_annotations.tsv" \
+        --output_singler_results_file "${singler_dir}/singler_results.rds" \
         --seed ${params.seed} \
         --threads ${task.cpus}
+
+      # write out meta file
+      echo "${Utils.makeJson(meta)}" > "${singler_dir}/scpca-meta.json"
       """
     stub:
-      singler_annotations_tsv = "${meta.library_id}_singler_annotations.tsv"
-      singler_full_results = "${meta.library_id}_singler_full_results.rds"
+      singler_dir = file(meta.singler_dir).name
       """
-      touch "${singler_annotations_tsv}"
-      touch "${singler_full_results}"
+      mkdir "${singler_dir}"
+      echo "${Utils.makeJson(meta)}" > "${singler_dir}/scpca-meta.json"
       """
 }
 
@@ -80,6 +85,8 @@ process classify_cellassign {
     """
 }
 
+empty_file = "${projectDir}/assets/NO_FILE"
+
 workflow annotate_celltypes {
     take: sce_files_channel // channel of meta, unfiltered_sce, filtered_sce, processed_sce
     main:
@@ -93,27 +100,43 @@ workflow annotate_celltypes {
          // project id
          it.scpca_project_id,
          // singler model file
-         Utils.parseNA(it.singler_ref_file) ? file("${params.singler_models_dir}/${it.singler_ref_file}") : null,
+         file(Utils.parseNA(it.singler_ref_file) ? "${params.singler_models_dir}/${it.singler_ref_file}" : empty_file),
          // cellassign reference file
-         Utils.parseNA(it.cellassign_ref_file) ? file("${params.cellassign_ref_dir}/${it.cellassign_ref_file}") : null,
+         file(Utils.parseNA(it.cellassign_ref_file) ? "${params.cellassign_ref_dir}/${it.cellassign_ref_file}" : empty_file),
          // add ref name for cellassign since we cannot store it in the cellassign output
          // singler ref name does not need to be added because it is stored in the singler model
          Utils.parseNA(it.cellassign_ref_name)
         ]}
 
-
+      // create input for typing: [meta, processed, SingleR model file, cellassign reference file, cellassign reference name]
       celltype_input_ch = processed_sce_channel
         .map{[it[0]["project_id"]] + it}
         .combine(celltype_ch, by: 0)
         .map{it.drop(1)} // remove extra project ID
+        // add celltype_publish_dir to the meta object for later use
+        .map{
+          it[0].celltype_publish_dir = "${params.checkpoints_dir}/celltype/${it[0].library_id}";
+          it[0].singler_dir = "${it[0].celltype_publish_dir}/${it[0].library_id}_singler";
+          it[0].cellassign_dir = "${it[0].celltype_publish_dir}/${it[0].library_id}_cellassign";
+          it
+        }
 
-      // create input for singleR: [meta, processed, SingleR reference model]
+      // skip if no singleR model file
       singler_input_ch = celltype_input_ch
-        .map{meta, processed_rds, singler_model, cellassign_model, cellassign_ref_name ->
-             [meta, processed_rds, singler_model]}
+        .branch{
+          missing_ref: it[2].name == "NO_FILE"
+          do_singler: true
+        }
 
-      // perform singleR celltyping and export TSV
-      classify_singleR(singler_input_ch)
+      // perform singleR celltyping and export results
+      classify_singler(singler_input_ch.do_singler)
+
+      // singleR output channel
+      singler_output_ch = singler_input_ch.missing_ref
+        .map{it.add(file(empty_file))} // add empty file for missing output
+        // add in channel outputs
+        .mix(classify_singler.out)
+
 
       // add back in the unchanged sce files
       // TODO update below with output channel results:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -133,7 +133,7 @@ workflow annotate_celltypes {
 
       // singleR output channel
       singler_output_ch = singler_input_ch.missing_ref
-        .map{it.add(file(empty_file))} // add empty file for missing output
+        .map{it.asList() + [file(empty_file)]} // add empty file for missing output
         // add in channel outputs
         .mix(classify_singler.out)
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -1,7 +1,11 @@
 
 process classify_singler {
     container params.SCPCATOOLS_CONTAINER
-    publishDir "${meta.celltype_publish_dir}", mode: 'copy'
+    publishDir (
+      path: "${meta.celltype_publish_dir}",
+      mode: 'copy',
+      pattern: "${singler_dir}"
+    )
     label 'mem_8'
     label 'cpus_4'
     input:

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -17,7 +17,6 @@ process cluster_sce{
           ${params.seed ? "--random_seed ${params.seed}" : ""}
         """
     stub:
-        processed_rds = "${meta.library_id}_processed.rds"
         """
         touch ${processed_rds}
         """

--- a/test/stub-celltype-project-metadata.tsv
+++ b/test/stub-celltype-project-metadata.tsv
@@ -1,6 +1,6 @@
 scpca_project_id	singler_ref_file	cellassign_ref_file	cellassign_ref_name
 STUBP01	singler_model_file.rds	cellassign_ref_file.tsv	tissue
-STUBP02	singler_model_file.rds	cellassign_ref_file.tsv	tissue
+STUBP02	NA	cellassign_ref_file.tsv	tissue
 STUBP03	singler_model_file.rds	cellassign_ref_file.tsv	tissue
 STUBP04	singler_model_file.rds	cellassign_ref_file.tsv	tissue
 STUBP05	singler_model_file.rds	cellassign_ref_file.tsv	tissue


### PR DESCRIPTION
In my comments on https://github.com/AlexsLemonade/scpca-nf/pull/476, I proposed a bunch of change, and I decided that it would actually be easier for me to just demonstrate and make some of the changes that I was thinking about, so I did that.

The main goal here was to change the output of the singleR process to be a _folder_ with results rather than individual files. This folder also contains the `scpca-meta.json` file. This solves a couple of problems: rather than having to track a bunch of files separately, we just put the output files we want in the folder,  and then pass that along as a single unit. It also gives us a place to put `scpca-meta.json` where we won't be overwriting it or having to give it different names depending on the output. 

For some reason, maybe my bad memory, I thought we wanted to just pass everything through the processes as simply as possible, so I added the cellassign refs to the singler process inputs & outputs so we can got to the next step without a join. (We could still drop the singleR ref before the cellassign process: it is larger than the others so that might be worth it)

Relatedly, I added a `singler_output_ch` mostly just to demonstrate how the mixing would go, with adding an `empty_file` for the skipped singler results. I also chose different names for the branches in anticipation of adding a 3rd branch, `has_singler` or similar, that would just fetch the existing results.

To make all of that easier, I followed as similar pattern that we used in `af-rna.nf` and elsewhere, where we had previously had output directories and step skipping: https://github.com/AlexsLemonade/scpca-nf/blob/2b3fb3cf4f39ba08851465de55b0d231e8059e4b/modules/af-rna.nf#L107-L111

Essentially we are now defining the output directories at the start of the subworkflow and adding them into the meta object so we can access them later, both within the process, as I do now, and as we implement step skipping. 

Finally, for testing purposes, I changed one of the values in the stub file to be NA, and it did seem to work.