### PR TITLE
Add CellAssign process

### DIFF
--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -70,11 +70,11 @@ if (!file.exists(singler_model_file)) {
   stop(glue::glue("Provided model file {singler_model_file} is missing."))
 }
 if (!(stringr::str_ends(singler_model_file, "_model.rds"))) {
-  stop(glue::glue("Provided model file {singler_model_file} must end in .rds."))
+  stop(glue::glue("Provided model file {singler_model_file} must end in '_model.rds.'"))
 }
 
 # get & check reference name
-reference_name <- stringr::str_match(singler_model_file, "(\\w+)_model.rds")[2]
+reference_name <- stringr::str_remove(singler_model_file, "_model.rds$")
 if (reference_name == "") {
   stop(glue::glue("Provided model file name must be formatted as `<model_name>_model.rds`"))
 }
@@ -116,7 +116,6 @@ readr::write_tsv(
 )
 
 # next, the full result to a compressed rds
-
 readr::write_rds(
   singler_results,
   opt$output_singler_results_file,

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -74,7 +74,7 @@ if (!(stringr::str_ends(singler_model_file, "_model.rds"))) {
 }
 
 # get & check reference name
-reference_name <- stringr::str_remove(singler_model_file, "_model.rds")
+reference_name <- stringr::str_match(singler_model_file, "(\\w+)_model.rds")[2]
 if (reference_name == "") {
   stop(glue::glue("Provided model file name must be formatted as `<model_name>_model.rds`"))
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -48,9 +48,9 @@ process classify_cellassign {
   label 'mem_32'
   label 'cpus_12'
   input:
-      tuple val(meta), path(processed_rds), path(cellassign_reference_file)
+    tuple val(meta), path(processed_rds), path(cellassign_reference_file)
   output:
-      tuple val(meta.library_id), path(cellassign_dir)
+    tuple val(meta.library_id), path(cellassign_dir)
   script:
     cellassign_dir = file(meta.cellassign_dir).name
 
@@ -63,12 +63,12 @@ process classify_cellassign {
     # Convert SCE to AnnData
     sce_to_anndata.R \
         --input_sce_file ${processed_rds} \
-        --output_rna_h5 ${processed_hdf5} 
+        --output_rna_h5 processed.hdf5 
         
     # Run CellAssign
     predict_cellassign.py \
-      --input_hdf5_file ${processed_hdf5} \
-      --output_predictions ${cellassign_predictions_tsv} \
+      --input_hdf5_file processed.hdf5 
+      --output_predictions ${cellassign_dir}/cellassign_predictions.tsv \
       --reference ${cellassign_ref} \
       --seed ${params.seed} \
       --threads ${task.cpus}
@@ -196,9 +196,6 @@ workflow annotate_celltypes {
         // add in cell assign results
         .join(cellassign_output_ch, by: 0, failOnMismatch: true, failOnDuplicate: true)
         .map{it.drop(1)} // remove library_id
-        // bring out the reference names
-        .map{meta, processed_sce, singler_dir, cellassign_dir -> 
-          [meta, processed_sce, singler_dir, meta.singler_reference_name, cellassign_dir, meta.cellassign_reference_name]}
 
 
       // Next PR:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -119,28 +119,22 @@ workflow annotate_celltypes {
          it.scpca_project_id,
          // singler model file
          Utils.parseNA(it.singler_ref_file) ? "${params.singler_models_dir}/${it.singler_ref_file}" : null,
-         // singler reference name 
-         Utils.parseNA(it.singler_ref_name),       
          // cellassign reference file
-         Utils.parseNA(it.cellassign_ref_file) ? "${params.cellassign_ref_dir}/${it.cellassign_ref_file}" : null,
-         // cellassign reference name
-         Utils.parseNA(it.cellassign_ref_name)
+         Utils.parseNA(it.cellassign_ref_file) ? "${params.cellassign_ref_dir}/${it.cellassign_ref_file}" : null
         ]}
 
       // create input for typing: [augmented meta, processed_sce]
       celltype_input_ch = processed_sce_channel
         .map{[it[0]["project_id"]] + it}
         .combine(celltype_ch, by: 0)
-        // current contents: [project_id, meta, processed_sce, singler_model_file, singler_reference_name, cellassign_reference_file, cellassign_reference_name]
+        // current contents: [project_id, meta, processed_sce, singler_model_file, cellassign_reference_file]
         // add values to meta for later use
-        .map{ project_id, meta, processed_sce, singler_model_file, singler_reference_name, cellassign_reference_file, cellassign_reference_name ->
+        .map{ project_id, meta, processed_sce, singler_model_file, cellassign_reference_file ->
           meta.celltype_publish_dir = "${params.checkpoints_dir}/celltype/${meta.library_id}";
           meta.singler_dir = "${meta.celltype_publish_dir}/${meta.library_id}_singler";
           meta.cellassign_dir = "${meta.celltype_publish_dir}/${meta.library_id}_cellassign";
           meta.singler_model_file = singler_model_file; 
-          meta.singler_reference_name = singler_reference_name; 
           meta.cellassign_reference_file = cellassign_reference_file;
-          meta.cellassign_reference_name = cellassign_reference_name;
           // return simplified input:
           [meta, processed_sce]
         }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -60,14 +60,14 @@ process classify_cellassign {
     
     # Convert SCE to AnnData
     sce_to_anndata.R \
-        --input_sce_file ${processed_rds} \
+        --input_sce_file "${processed_rds}" \
         --output_rna_h5 processed.hdf5 
         
     # Run CellAssign
     predict_cellassign.py \
       --input_hdf5_file processed.hdf5 
-      --output_predictions ${cellassign_dir}/cellassign_predictions.tsv \
-      --reference ${cellassign_ref} \
+      --output_predictions "${cellassign_dir}/cellassign_predictions.tsv" \
+      --reference "${cellassign_reference_file} \
       --seed ${params.seed} \
       --threads ${task.cpus}
     

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -67,7 +67,7 @@ process classify_cellassign {
     predict_cellassign.py \
       --input_hdf5_file processed.hdf5 
       --output_predictions "${cellassign_dir}/cellassign_predictions.tsv" \
-      --reference "${cellassign_reference_file} \
+      --reference "${cellassign_reference_file}" \
       --seed ${params.seed} \
       --threads ${task.cpus}
     

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -81,7 +81,6 @@ process classify_cellassign {
     """
     mkdir "${cellassign_dir}"
     echo "${Utils.makeJson(meta)}" > "${cellassign_dir}/scpca-meta.json"
-
     """
 }
 
@@ -185,10 +184,9 @@ workflow annotate_celltypes {
   
       // cellassign output channel: [library_id, cellassign_dir]
       cellassign_output_ch = cellassign_input_ch.missing_ref
-        .map{[it[0]["library_id"], "NO_NAME", file(empty_file)]}
+        .map{[it[0]["library_id"], file(empty_file)]}
         // add in channel outputs
         .mix(classify_cellassign.out) 
-      
       
       // prepare input for process to add celltypes to the processed SCE
       assignment_input_ch = processed_sce_channel

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -133,7 +133,7 @@ workflow annotate_celltypes {
           meta.celltype_publish_dir = "${params.checkpoints_dir}/celltype/${meta.library_id}";
           meta.singler_dir = "${meta.celltype_publish_dir}/${meta.library_id}_singler";
           meta.cellassign_dir = "${meta.celltype_publish_dir}/${meta.library_id}_cellassign";
-          meta.singler_model_file = singler_model_file; 
+          meta.singler_model_file = singler_model_file;
           meta.cellassign_reference_file = cellassign_reference_file;
           // return simplified input:
           [meta, processed_sce]
@@ -153,7 +153,6 @@ workflow annotate_celltypes {
 
       // perform singleR celltyping and export results
       classify_singler(singler_input_ch.do_singler)
-      
       // singleR output channel: [library_id, singler_results]
       singler_output_ch = singler_input_ch.missing_ref
         .map{[it[0]["library_id"], file(empty_file)]}

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -54,8 +54,6 @@ process classify_cellassign {
   script:
     cellassign_dir = file(meta.cellassign_dir).name
 
-    processed_hdf5 = "${meta.library_id}_processed.hdf5"
-    cellassign_predictions_tsv = "${meta.library_id}_predictions.tsv"
     """
     # create output directory
     mkdir "${cellassign_dir}"


### PR DESCRIPTION
Towards #415 

The next step is running cell assign, done here! I think given all the nice organizational changes in #476 & #477 this is pretty straightforward for review. The one additional thing to note is that I realized we probably need to be including `singler_reference_name` in the same way that we include `cellassign_reference_name`. This wasn't previously needed since we had been doing singler celltyping _and adding to SCE object_ in the same process, where the reference name was accessible from the trained singler model itself. Now that we will be adding singler & cellassign to the final step all at once in the last process, we'll need to grab both reference names for input.

I also have one discussion-y comment to bring up at this point - my memory from our figjam session 🎸  was that we had decided not to keep using indicator variables in meta, e.g. `meta.has_singler=true` (edit lowercase true, this isn't R). I am not seeing any notes that explicitly say this though, so let's make sure I am remembering correctly! We can/should certainly still add relevant information to _SCE metadata_ as we had been doing, but with our current celltyping workflow structure I don't really see the need for anything in the json metadata unless I am missing something?

Noting the next PR will write the process & R script for adding celltypes into the processed SCE.