### PR TITLE
Try blank strings instead of null

### DIFF
--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -46,13 +46,13 @@ class Utils {
    * Replace a string with an NA value with null
    *
    * @param str A string
-   * @return The input string unless it was NA or a variant thereof, in which case returns null
+   * @return The input string unless it was NA or a variant thereof, in which case returns ""
    */
   static def parseNA(str) {
     if (str){
-      str.toLowerCase() in ["na","n/a","nan"]? null : str
+      str.toLowerCase() in ["na","n/a","nan"]? "" : str
     } else {
-      null
+      ""
     }
    }
 }


### PR DESCRIPTION
In light of the stochastic failures we were seeing (and I had seen locally), I am trying a slightly different version of the parseNA function that just returns a blank string for NA values, which may avoid some java type errors that could propagate oddly. 

Part of the justification for this was an occasional error that I saw that said `WARN: Cannot serialize context map. Cause: null`.  (This was less common than `java.util.ConcurrentModificationException`, but there was a `null` in some places in that error log as well, so...)

So maybe using `null` isn't the best idea if we can avoid it. The good news is that `""` will still evaluate as `false` for the contexts where we are using it, so no other logic should need to change. 

This problem did start to pop up when I added `NA` values to the project celltype data, so that is also consistent with that being the problem.

I have tested this a number of times and it always seems to work now. So hopefully that will be durable!