### PR TITLE
Def all internal variable

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -130,11 +130,11 @@ workflow {
   // read in metadata with all organisms to create references for
   ref_ch = Channel.fromPath(params.ref_metadata)
     .splitCsv(header: true, sep: '\t')
-    .map{[
-      reference_name = "${it.organism}.${it.assembly}.${it.version}",
-      // grab file paths for each organism
-      ref_paths[reference_name]
-    ]}
+    .map{
+      def reference_name = "${it.organism}.${it.assembly}.${it.version}";
+      // reference name & reference file paths for each organism
+      [reference_name, ref_paths[reference_name]]
+    }
     .map{it +[
       file("${params.ref_rootdir}/${it[1]["ref_fasta"]}"), // path to fasta
       file("${params.ref_rootdir}/${it[1]["ref_gtf"]}") // path to gtf

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -38,13 +38,13 @@ process{
 
 // Resource check functions
 def check_memory(memory){
-  memory = memory as nextflow.util.MemoryUnit
-  max_memory = params.max_memory as nextflow.util.MemoryUnit
+  def memory = memory as nextflow.util.MemoryUnit
+  def max_memory = params.max_memory as nextflow.util.MemoryUnit
   memory < max_memory ? memory : max_memory
 }
 
 def check_cpus(cpus){
-  cpus = cpus as int
-  max_cpus = params.max_cpus as int
+  def cpus = cpus as int
+  def max_cpus = params.max_cpus as int
   cpus < max_cpus ? cpus : max_cpus
 }

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -38,13 +38,13 @@ process{
 
 // Resource check functions
 def check_memory(memory){
-  def memory = memory as nextflow.util.MemoryUnit
+  memory = memory as nextflow.util.MemoryUnit
   def max_memory = params.max_memory as nextflow.util.MemoryUnit
   memory < max_memory ? memory : max_memory
 }
 
 def check_cpus(cpus){
-  def cpus = cpus as int
+  cpus = cpus as int
   def max_cpus = params.max_cpus as int
   cpus < max_cpus ? cpus : max_cpus
 }

--- a/main.nf
+++ b/main.nf
@@ -87,36 +87,38 @@ workflow {
     .splitCsv(header: true, sep: '\t')
     .filter{it.sample_reference in ref_paths}
     // convert row data to a metadata map, keeping columns we will need (& some renaming) and reference paths
-    .map{sample_refs = ref_paths[it.sample_reference]
-    [
-      run_id: it.scpca_run_id,
-      library_id: it.scpca_library_id,
-      sample_id: it.scpca_sample_id.split(";").sort().join(","),
-      project_id: Utils.parseNA(it.scpca_project_id)?: "no_project",
-      submitter: Utils.parseNA(it.submitter),
-      technology: it.technology,
-      assay_ontology_term_id: Utils.parseNA(it.assay_ontology_term_id),
-      seq_unit: it.seq_unit,
-      submitter_cell_types_file: Utils.parseNA(it.submitter_cell_types_file),
-      feature_barcode_file: Utils.parseNA(it.feature_barcode_file),
-      feature_barcode_geom: Utils.parseNA(it.feature_barcode_geom),
-      files_directory: Utils.parseNA(it.files_directory),
-      slide_serial_number: Utils.parseNA(it.slide_serial_number),
-      slide_section: Utils.parseNA(it.slide_section),
-      ref_assembly: it.sample_reference,
-      ref_fasta: params.ref_rootdir + "/" + sample_refs["ref_fasta"],
-      ref_fasta_index: params.ref_rootdir + "/" + sample_refs["ref_fasta_index"],
-      ref_gtf: params.ref_rootdir + "/" + sample_refs["ref_gtf"],
-      salmon_splici_index: params.ref_rootdir + "/" + sample_refs["splici_index"],
-      t2g_3col_path: params.ref_rootdir + "/" + sample_refs["t2g_3col_path"],
-      mito_file: params.ref_rootdir + "/" + sample_refs["mito_file"],
-      salmon_bulk_index: params.ref_rootdir + "/" + sample_refs["salmon_bulk_index"],
-      t2g_bulk_path: params.ref_rootdir + "/" + sample_refs["t2g_bulk_path"],
-      cellranger_index: params.ref_rootdir + "/" + sample_refs["cellranger_index"],
-      star_index: params.ref_rootdir + "/" + sample_refs["star_index"],
-      scpca_version: workflow.manifest.version,
-      nextflow_version: nextflow.version.toString()
-    ]}
+    .map{
+      def sample_refs = ref_paths[it.sample_reference];
+      [
+        run_id: it.scpca_run_id,
+        library_id: it.scpca_library_id,
+        sample_id: it.scpca_sample_id.split(";").sort().join(","),
+        project_id: Utils.parseNA(it.scpca_project_id)?: "no_project",
+        submitter: Utils.parseNA(it.submitter),
+        technology: it.technology,
+        assay_ontology_term_id: Utils.parseNA(it.assay_ontology_term_id),
+        seq_unit: it.seq_unit,
+        submitter_cell_types_file: Utils.parseNA(it.submitter_cell_types_file),
+        feature_barcode_file: Utils.parseNA(it.feature_barcode_file),
+        feature_barcode_geom: Utils.parseNA(it.feature_barcode_geom),
+        files_directory: Utils.parseNA(it.files_directory),
+        slide_serial_number: Utils.parseNA(it.slide_serial_number),
+        slide_section: Utils.parseNA(it.slide_section),
+        ref_assembly: it.sample_reference,
+        ref_fasta: params.ref_rootdir + "/" + sample_refs["ref_fasta"],
+        ref_fasta_index: params.ref_rootdir + "/" + sample_refs["ref_fasta_index"],
+        ref_gtf: params.ref_rootdir + "/" + sample_refs["ref_gtf"],
+        salmon_splici_index: params.ref_rootdir + "/" + sample_refs["splici_index"],
+        t2g_3col_path: params.ref_rootdir + "/" + sample_refs["t2g_3col_path"],
+        mito_file: params.ref_rootdir + "/" + sample_refs["mito_file"],
+        salmon_bulk_index: params.ref_rootdir + "/" + sample_refs["salmon_bulk_index"],
+        t2g_bulk_path: params.ref_rootdir + "/" + sample_refs["t2g_bulk_path"],
+        cellranger_index: params.ref_rootdir + "/" + sample_refs["cellranger_index"],
+        star_index: params.ref_rootdir + "/" + sample_refs["star_index"],
+        scpca_version: workflow.manifest.version,
+        nextflow_version: nextflow.version.toString()
+      ]
+    }
 
  runs_ch = unfiltered_runs_ch
     // only technologies we know how to process

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -139,10 +139,13 @@ workflow map_quant_feature{
 
     // add the publish directories to the channel and branch based on existing rad files
     feature_ch = feature_channel
-      .map{it.feature_rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
-           it.feature_rad_dir = "${it.feature_rad_publish_dir}/${it.run_id}-features";
-           it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
-           it}
+      .map{
+        def meta = it.clone();
+        meta.feature_rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
+        meta.feature_rad_dir = "${it.feature_rad_publish_dir}/${it.run_id}-features";
+        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
+        meta // return modified meta object
+      }
       .branch{
           has_rad: (!params.repeat_mapping
                     && file(it.feature_rad_dir).exists()

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -104,10 +104,13 @@ workflow map_quant_rna {
   main:
     // add rad publish directory, rad directory, and barcode file to meta
     rna_channel = rna_channel
-      .map{it.rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
-           it.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna";
-           it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
-           it}
+      .map{
+        meta = it.clone();
+        meta.rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
+        meta.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna";
+        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
+        meta // return modified meta object
+      }
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_rad: (!params.repeat_mapping

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -105,7 +105,7 @@ workflow map_quant_rna {
     // add rad publish directory, rad directory, and barcode file to meta
     rna_channel = rna_channel
       .map{
-        meta = it.clone();
+        def meta = it.clone();
         meta.rad_publish_dir = "${params.checkpoints_dir}/rad/${it.library_id}";
         meta.rad_dir = "${it.rad_publish_dir}/${it.run_id}-rna";
         meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -117,7 +117,7 @@ workflow bulk_quant_rna {
         bulk_channel = bulk_channel
           // add salmon directory and salmon file location to meta
           .map{
-            meta = it.clone();
+            def meta = it.clone();
             meta.salmon_publish_dir = "${params.checkpoints_dir}/salmon";
             meta.salmon_results_dir = "${it.salmon_publish_dir}/${it.library_id}";
             meta // return modified meta object

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -116,9 +116,12 @@ workflow bulk_quant_rna {
     main:
         bulk_channel = bulk_channel
           // add salmon directory and salmon file location to meta
-          .map{it.salmon_publish_dir = "${params.checkpoints_dir}/salmon";
-               it.salmon_results_dir = "${it.salmon_publish_dir}/${it.library_id}";
-               it}
+          .map{
+            meta = it.clone();
+            meta.salmon_publish_dir = "${params.checkpoints_dir}/salmon";
+            meta.salmon_results_dir = "${it.salmon_publish_dir}/${it.library_id}";
+            meta // return modified meta object
+          }
           // split based on whether repeat_mapping is false and the salmon quant.sf file exists
           // and whether the assembly matches the current assembly
           .branch{

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -13,10 +13,13 @@ workflow genetic_demux_vireo{
   main:
     // add vireo publish directory, vireo directory, and barcode file to meta
     multiplex_ch = multiplex_run_ch
-      .map{it.vireo_publish_dir = "${params.checkpoints_dir}/vireo";
-           it.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo";
-           it.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
-           it}
+      .map{
+        meta = it.clone();
+        meta.vireo_publish_dir = "${params.checkpoints_dir}/vireo";
+        meta.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo";
+        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";
+        meta // return modified meta object
+      }
        // split based in whether repeat_mapping is false and a previous dir exists
       .branch{
           has_demux: (!params.repeat_genetic_demux

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -14,7 +14,7 @@ workflow genetic_demux_vireo{
     // add vireo publish directory, vireo directory, and barcode file to meta
     multiplex_ch = multiplex_run_ch
       .map{
-        meta = it.clone();
+        def meta = it.clone();
         meta.vireo_publish_dir = "${params.checkpoints_dir}/vireo";
         meta.vireo_dir = "${it.vireo_publish_dir}/${it.library_id}-vireo";
         meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[it.technology]}";

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -114,7 +114,7 @@ workflow spaceranger_quant{
         spatial_channel = spatial_channel
         // add sample names and spatial output directory to metadata
           .map{
-            meta = it.clone();
+            def meta = it.clone();
             meta.cr_samples = getCRsamples(it.files_directory);
             meta.spaceranger_publish_dir =  "${params.checkpoints_dir}/spaceranger/${it.library_id}";
             meta.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -113,10 +113,13 @@ workflow spaceranger_quant{
     main:
         spatial_channel = spatial_channel
         // add sample names and spatial output directory to metadata
-          .map{it.cr_samples = getCRsamples(it.files_directory);
-               it.spaceranger_publish_dir =  "${params.checkpoints_dir}/spaceranger/${it.library_id}";
-               it.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
-               it}
+          .map{
+            meta = it.clone();
+            meta.cr_samples = getCRsamples(it.files_directory);
+            meta.spaceranger_publish_dir =  "${params.checkpoints_dir}/spaceranger/${it.library_id}";
+            meta.spaceranger_results_dir = "${it.spaceranger_publish_dir}/${it.run_id}-spatial";
+            meta // return modified meta object
+          }
           .branch{
             has_spatial: (!params.repeat_mapping
                           && file(it.spaceranger_results_dir).exists()

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -94,8 +94,8 @@ def getCRsamples(files_dir){
   // takes the path to the directory holding the fastq files for each sample
   // returns just the 'sample info' portion of the file names,
   // as spaceranger would interpret them, comma separated
-  fastq_files = file(files_dir).list().findAll{it.contains('.fastq.gz')}
-  samples = []
+  def fastq_files = file(files_dir).list().findAll{it.contains('.fastq.gz')}
+  def samples = []
   fastq_files.each{
     // append sample names to list, using regex to extract element before S001, etc.
     // [0] for the first match set, [1] for the first extracted element


### PR DESCRIPTION
With the knowledge gained in https://github.com/AlexsLemonade/scpca-nf/pull/487, I decided it wouldn't be a bad idea to go through this repo and make sure that all variables declared in a function or `.map{}` statement was defined only in that scope using `def`.

The ones here were not causing problems that we know of, but it seems like a good idea, partly as a bit of reminder that those `def` statements actually do something (keep scope local).

The most common changes are in the definitions of paths for step-skipping, where I now make an explicit copy of the input  object and then modify the copy. 