### PR TITLE
Add perform_celltyping parameter

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -224,12 +224,16 @@ workflow {
   // Cluster SCE
   cluster_sce(post_process_sce.out)
 
-  // Perform celltyping, if specified
-  annotate_celltypes(cluster_sce.out)
-  
+  if(params.perform_celltyping){
+    // Perform celltyping, if specified
+    annotated_celltype_ch = annotate_celltypes(cluster_sce.out)
+  } else {
+    annotated_celltype_ch = cluster_sce.out
+  }
+
   // generate QC reports
   sce_qc_report(
-    annotate_celltypes.out, 
+    annotated_celltype_ch,
     report_template_tuple
   )
 

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -19,15 +19,17 @@ process sce_qc_report{
         metadata_json = "${meta.library_id}_metadata.json"
         workflow_url = workflow.repository ?: workflow.manifest.homePage
         workflow_version = workflow.revision ?: workflow.manifest.version
-        
+
         // names for final output files
         unfiltered_out = "${meta.library_id}_unfiltered.rds"
         filtered_out = "${meta.library_id}_filtered.rds"
         processed_out = "${meta.library_id}_processed.rds"
-        
+
         // check for cell types
-        // TODO: add `params.perform_celltyping && (...)` when implemented
-        has_celltypes = (meta.submitter_cell_types_file || meta.singler_model_file || meta.cellassign_reference_file)
+        // only provide report template if cell typing was performed and either singler or cellassign was used
+        has_celltypes = (params.perform_celltyping
+                        && (meta.singler_model_file || meta.cellassign_reference_file)
+                        )
         celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
         celltype_template_path = "${template_dir}/${celltype_template_file}" // template input
 
@@ -69,9 +71,10 @@ process sce_qc_report{
         processed_out = "${meta.library_id}_processed.rds"
         qc_report = "${meta.library_id}_qc.html"
         metadata_json = "${meta.library_id}_metadata.json"
-        
-        // TODO: add `params.perform_celltyping && (...)` when implemented
-        has_celltypes = meta.submitter_cell_types_file || meta.singler_model_file || meta.cellassign_reference_file
+
+        has_celltypes = (params.perform_celltyping
+                        && (meta.singler_model_file || meta.cellassign_reference_file)
+                        )
         celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
 
         """
@@ -80,7 +83,7 @@ process sce_qc_report{
         touch ${processed_out}
         touch ${qc_report}
         ${has_celltypes ? "touch ${celltype_report}" : ""}
-        
+
         echo '{"unfiltered_cells": 10, "filtered_cells": 10, "processed_cells": 10}' > ${metadata_json}
         """
 }

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -27,9 +27,7 @@ process sce_qc_report{
 
         // check for cell types
         // only provide report template if cell typing was performed and either singler or cellassign was used
-        has_celltypes = (params.perform_celltyping
-                        && (meta.singler_model_file || meta.cellassign_reference_file)
-                        )
+        has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
         celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
         celltype_template_path = "${template_dir}/${celltype_template_file}" // template input
 
@@ -72,9 +70,7 @@ process sce_qc_report{
         qc_report = "${meta.library_id}_qc.html"
         metadata_json = "${meta.library_id}_metadata.json"
 
-        has_celltypes = (params.perform_celltyping
-                        && (meta.singler_model_file || meta.cellassign_reference_file)
-                        )
+        has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
         celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
 
         """

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ params {
   skip_genetic_demux = false // skip genetic demultiplexing steps, even if bulk data is present
   publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
   spliced_only = false // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
+  perform_celltyping = false // specify whether or not to incorporate cell type annotations
 
   seed = 2021   // random number seed for filtering and post-processing (0 means use system seed)
 
@@ -54,7 +55,7 @@ params {
 
   // Cell type annotation options
   singler_label_name = "label.ont" // celldex reference label used for SingleR reference building
-  
+
   // Docker container images
   includeConfig 'config/containers.config'
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -120,65 +120,53 @@ plot_umap <- function(
 
 
 <!-- Submitter _only_ -->
-```{r, eval = has_submitter & !(has_singler | has_cellassign)}
-knitr::asis_output(
-  glue::glue("
+```{r, eval = has_submitter & !(has_singler | has_cellassign), results='asis'}
+glue::glue("
   This section details cell type annotations provided by the original lab (`submitter-provided`) which generated this data.
   ")
-)
 ```
 
 
 <!-- At least one cell type annotation method. -->
-```{r, eval = has_singler | has_cellassign}
-knitr::asis_output(
-  glue::glue("
+```{r, eval = has_singler | has_cellassign, results='asis'}
+glue::glue("
   This section details results from performing cell type annotation.
   The following method(s) were used to perform cell typing:
  ")
-)
 ```
 
 
-```{r, eval = has_singler}
-knitr::asis_output(
-  glue::glue(
+```{r, eval = has_singler, results='asis'}
+glue::glue(
   "* [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach.
   The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
-  )
 )
 ```
 
 
-```{r, eval = has_cellassign}
-knitr::asis_output(
-  glue::glue(
+```{r, eval = has_cellassign, results='asis'}
+glue::glue(
   "* [`CellAssign`](https://github.com/Irrationone/cellassign), which uses a marker-gene based approach.
   Marker genes associated with `{metadata(processed_sce)$cellassign_reference}` tissue were obtained from [PanglaoDB](https://panglaodb.se/).
   "
-  )
 )
 ```
 
 
 <!-- Submitter and at least one inference method -->
-```{r, eval = has_submitter & (has_singler | has_cellassign)}
-knitr::asis_output(
-  glue::glue(
+```{r, eval = has_submitter & (has_singler | has_cellassign), results='asis'}
+glue::glue(
   "* Cell type annotations were also provided by the original lab (`submitter-provided`) which generated this data.
   "
-  )
 )
 ```
 
 
 <!-- At least one cell type annotation method required for the supplemental report -->
-```{r, eval = has_singler | has_cellassign}
-knitr::asis_output(
-  glue::glue("
+```{r, eval = has_singler | has_cellassign, results='asis'}
+glue::glue("
   For additional information about cell typing, including diagnostic plots and/or heatmap comparisons among annotations (if available), please refer to the [supplementary cell type QC report](`r params$celltype_report`).
  ")
-)
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -175,7 +175,15 @@ knitr::asis_output(
 )
 ```
 
-For additional information about cell typing, including diagnostic plots and/or heatmap comparisons among annotations (if available), please refer to the [supplementary cell type QC report](`r params$celltype_report`).
+
+<!-- At least one cell type annotation method required for the supplemental report -->
+```{r, eval = has_singler | has_cellassign}
+knitr::asis_output(
+  glue::glue("
+  For additional information about cell typing, including diagnostic plots and/or heatmap comparisons among annotations (if available), please refer to the [supplementary cell type QC report](`r params$celltype_report`).
+ ")
+)
+```
 
 
 ## Statistics

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -124,7 +124,7 @@ if (has_processed) {
 }
 
 # check for celltypes_report if celltypes are present
-if (has_celltypes & is.null(params$celltype_report)) {
+if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
   stop("Cell type annotations were provided but the parameter specifying the cell type report file is missing.")
 }
 ```


### PR DESCRIPTION
Closes #494 
Stacked on #503 

Here I'm adding in the flag to specify whether or not we want to run the cell typing part of the workflow with `--perform_celltyping`. As we discussed, this is set to `false` by default. This means to annotate cell types when running the workflow, you need to use the flag. 

There wasn't really anything too involved here since the output of `annotate_celltypes` already matches the output of `cluster_sce`. 
I tested this with the stub workflow both with and without `--perform_celltyping` and the expected processes were skipped when the flag was absent. I'm doing a test run with an actual library just to be sure everything is good. 
Edit: The tests finished so flag works as expected! 