### PR TITLE
Parameter for skipping cell typing if results already exist

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -99,7 +99,7 @@ if(!is.null(opt$singler_results)){
 
   # add singler info to metadata
   metadata(sce)$singler_results <- singler_results
-  metadata(sce)$reference_name <- metadata(singler_results)$reference_name
+  metadata(sce)$singler_reference <- metadata(singler_results)$reference_name
 
   # add note about cell type method to metadata
   metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "singler")

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -56,59 +56,67 @@ sce <- readr::read_rds(opt$input_sce_file)
 # SingleR results --------------------------------------------------------------
 
 if(!is.null(opt$singler_results)){
-  
+
   if(!file.exists(opt$singler_results)){
     stop("Missing singleR results file")
   }
-  
+
   singler_results <- readr::read_rds(opt$singler_results)
-  
-  # first just add in labels as annotations
-  sce$singler_celltype_annotation = singler_results$pruned.labels
-  
+
+  # create a tibble with annotations and barcode
+  # later we'll add the annotations into colData by joining on barcodes column
+  annotations_df <- tibble::tibble(
+    barcodes = rownames(singler_results),
+    singler_celltype_annotation = singler_results$pruned.labels,
+  )
+
   # map ontology labels to cell type names, as needed
   # we can tell if ontologies were used because this will exist:
   if ("cell_ontology_df" %in% names(singler_results)) {
-    
+
     # end up with columns: barcode, singler_celltype_annotation, singler_celltype_ontology
-    colData(sce) <- colData(sce) |>
-      as.data.frame() |> 
+    colData(sce) <- annotations_df |>
       dplyr::left_join(
         # column names: ontology_id, ontology_cell_names
-        singler_results$cell_ontology_df, 
+        singler_results$cell_ontology_df,
         by = c("singler_celltype_annotation" = "ontology_id")
-      ) |> 
+      ) |>
       # rename columns
       dplyr::rename(
         # ontology should contain the original pruned labels
         singler_celltype_ontology = singler_celltype_annotation,
         # annotation contains the cell names associated with the ontology
         singler_celltype_annotation = ontology_cell_names
-      ) |>
-      DataFrame(row.names = colData(sce)$barcodes)
+      )
 
-  } 
+  }
 
- # add singler info to metadata
+  # add annotations to colData
+  colData(sce) <- colData(sce) |>
+    as.data.frame() |>
+    dplyr::left_join(annotations_df, by = c("barcodes")) |>
+    DataFrame(row.names = colData(sce)$barcodes)
+
+  # add singler info to metadata
   metadata(sce)$singler_results <- singler_results
   metadata(sce)$reference_name <- metadata(singler_results)$reference_name
-  
-  # add note about cell type method to metadata 
+
+  # add note about cell type method to metadata
   metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "singler")
-  
+
 }
 
 # CellAssign results -----------------------------------------------------------
 
 if(!is.null(opt$cellassign_predictions)){
- 
+
   # check that cellassign predictions file was provided
   if (!file.exists(opt$cellassign_predictions)) {
     stop("Missing CellAssign predictions file")
   }
-  
+
   predictions <- readr::read_tsv(opt$cellassign_predictions)
-  
+
   # get cell type with maximum prediction value for each cell
   celltype_assignments <- predictions |>
     tidyr::pivot_longer(
@@ -119,23 +127,23 @@ if(!is.null(opt$cellassign_predictions)){
     dplyr::group_by(barcode) |>
     dplyr::slice_max(prediction, n = 1) |>
     dplyr::ungroup()
-  
+
   # join by barcode to make sure assignments are in the right order
   celltype_assignments <- data.frame(barcode = sce$barcodes) |>
     dplyr::left_join(celltype_assignments, by = "barcode")
-  
+
   # add cell type and prediction to colData
   sce$cellassign_celltype_annotation <- celltype_assignments$celltype
   sce$cellassign_max_prediction <- celltype_assignments$prediction
-  
+
   # add entire predictions matrix and ref name to metadata
   metadata(sce)$cellassign_predictions <- predictions
   metadata(sce)$cellassign_reference <- opt$cellassign_ref_name
-  
+
   # add cellassign as celltype method
   # note that if `metadata(sce)$celltype_methods` doesn't exist yet, this will
   #  come out to just the string "cellassign"
-  metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "cellassign") 
+  metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "cellassign")
 }
 
 # export annotated object with cellassign assignments

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -18,7 +18,7 @@ option_list <- list(
   make_option(
     opt_str = c("--singler_model_file"),
     type = "character",
-    help = "path to file containing a single model generated for SingleR annotation. 
+    help = "path to file containing a single model generated for SingleR annotation.
             File name is expected to be in form: <model name>_model.rds."
   ),
   make_option(
@@ -44,7 +44,7 @@ opt <- parse_args(OptionParser(option_list = option_list))
 # Set up -----------------------------------------------------------------------
 
 # set seed
-set.seed(opt$random_seed)
+set.seed(opt$seed)
 
 # check that input file file exists
 if (!file.exists(opt$sce_file)) {

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.3.0'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -97,7 +97,7 @@ process add_celltypes_to_sce {
     annotated_rds = "${meta.library_id}_processed_annotated.rds"
     singler_present = "${singler_dir.name}" != "NO_FILE"
     singler_results = "${singler_dir}/singler_results.rds"
-    cellassign_present = "${cellassign_dir}.name" != "NO_FILE"
+    cellassign_present = "${cellassign_dir.name}" != "NO_FILE"
     cellassign_predictions = "${cellassign_dir}/cellassign_predictions.tsv"
     cellassign_ref_name = file("${meta.cellassign_reference_file}").baseName
     """
@@ -148,6 +148,8 @@ workflow annotate_celltypes {
           meta.cellassign_dir = "${meta.celltype_publish_dir}/${meta.library_id}_cellassign";
           meta.singler_model_file = singler_model_file;
           meta.cellassign_reference_file = cellassign_reference_file;
+          meta.singler_results_file = "${meta.singler_dir}/singler_results.rds";
+          meta.cellassign_predictions_file = "${meta.cellassign_dir}/cellassign_predictions.tsv"
           // return simplified input:
           [meta, processed_sce]
         }
@@ -157,18 +159,24 @@ workflow annotate_celltypes {
       singler_input_ch = celltype_input_ch
         // add in singler model or empty file
         .map{it.toList() + [file(it[0].singler_model_file ?: empty_file)]}
-        // skip if no singleR model file
+        // skip if no singleR model file or if singleR results are already present
         .branch{
-          missing_ref: it[2].name == "NO_FILE"
+          skip_singler: (!params.repeat_celltyping && file(it[0].singler_results_file).exists())
+                        || it[2].name == "NO_FILE"
           do_singler: true
         }
 
 
       // perform singleR celltyping and export results
       classify_singler(singler_input_ch.do_singler)
+
       // singleR output channel: [library_id, singler_results]
-      singler_output_ch = singler_input_ch.missing_ref
-        .map{[it[0]["library_id"], file(empty_file)]}
+      singler_output_ch = singler_input_ch.skip_singler
+        // provide existing singler results dir for those we skipped and empty file for those missing reference
+        .map{[
+          it[0]["library_id"],
+          file(it[0].singler_results_file).exists() ? file(it[0].singler_dir, type: 'dir') : file(empty_file)
+          ]}
         // add in channel outputs
         .mix(classify_singler.out)
 
@@ -178,7 +186,8 @@ workflow annotate_celltypes {
         .map{it.toList() + [file(it[0].cellassign_reference_file ?: empty_file)]}
         // skip if no cellassign reference file or reference name is not defined
         .branch{
-          missing_ref: it[2].name == "NO_FILE"
+          skip_cellassign: (!params.repeat_celltyping && file(it[0].cellassign_predictions_file).exists())
+                           || it[2].name == "NO_FILE"
           do_cellassign: true
         }
 
@@ -187,14 +196,18 @@ workflow annotate_celltypes {
       classify_cellassign(cellassign_input_ch.do_cellassign)
 
       // cellassign output channel: [library_id, cellassign_dir]
-      cellassign_output_ch = cellassign_input_ch.missing_ref
-        .map{[it[0]["library_id"], file(empty_file)]}
+      cellassign_output_ch = cellassign_input_ch.skip_cellassign
+        // provide existing cellassign predictions dir for those we skipped and empty file for those missing reference
+        .map{[
+          it[0]["library_id"],
+          file(it[0].cellassign_predictions_file).exists() ? file(it[0].cellassign_dir, type: 'dir') : file(empty_file)
+          ]}
         // add in channel outputs
         .mix(classify_cellassign.out)
 
       // prepare input for process to add celltypes to the processed SCE
       // result is [meta, processed rds, singler dir, cellassign dir]
-      assignment_input_ch = processed_sce_channel
+      assignment_input_ch = celltype_input_ch
         .map{[it[0]["library_id"]] + it}
         // add in singler results
         .join(singler_output_ch, by: 0, failOnMismatch: true, failOnDuplicate: true)
@@ -202,7 +215,7 @@ workflow annotate_celltypes {
         .join(cellassign_output_ch, by: 0, failOnMismatch: true, failOnDuplicate: true)
         .map{it.drop(1)} // remove library_id
         .branch{
-          // pull out libraries that actually have at least 1 type of annotations
+          // pull out libraries that actually have at least 1 type of annotation
           add_celltypes: (it[2].baseName != "NO_FILE") || (it[3].baseName != "NO_FILE")
           no_celltypes: true
         }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -22,7 +22,6 @@ process classify_singler {
       classify_SingleR.R \
         --sce_file "${processed_rds}" \
         --singler_model_file "${singler_model_file}" \
-        --output_singler_annotations_file "${singler_dir}/singler_annotations.tsv" \
         --output_singler_results_file "${singler_dir}/singler_results.rds" \
         --seed ${params.seed} \
         --threads ${task.cpus}
@@ -211,12 +210,12 @@ workflow annotate_celltypes {
 
       // incorporate annotations into SCE object
       add_celltypes_to_sce(assignment_input_ch.add_celltypes)
-      
+
       // mix in libraries without new celltypes
       // result is [meta, proccessed rds]
       celltyped_ch = assignment_input_ch.no_celltypes
         .map{[it[0], it[1]]}
-        .mix(add_celltypes_to_sce.out) 
+        .mix(add_celltypes_to_sce.out)
 
       // add back in the unchanged sce files to the results
       export_channel = celltyped_ch

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ params {
   publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
   spliced_only = false // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
   perform_celltyping = false // specify whether or not to incorporate cell type annotations
-  repeat_celltyping = false // if cell type annotations alread exist, skip cell type classification with SingleR and CellAssign
+  repeat_celltyping = false // if cell type annotations already exist, skip cell type classification with SingleR and CellAssign
 
   seed = 2021   // random number seed for filtering and post-processing (0 means use system seed)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,7 @@ params {
   publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
   spliced_only = false // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
   perform_celltyping = false // specify whether or not to incorporate cell type annotations
+  repeat_celltyping = false // if cell type annotations alread exist, skip cell type classification with SingleR and CellAssign
 
   seed = 2021   // random number seed for filtering and post-processing (0 means use system seed)
 


### PR DESCRIPTION
Closes #446 

This PR adds a new parameter to the workflow, `--repeat_celltyping`, that acts in a similar fashion to `--repeat_mapping`. 

- The default is set to `false`. This means that if the results from either `SingleR` or `CellAssign` already exist in the `checkpoints` folder for a specific library, then those processes will be skipped. 
- If you use the `--repeat_celltyping` option, then regardless of whether the results exist or not, they will be repeated. 
- This argument is only relevant if you are using `--perform_celltyping`, otherwise, cell typing will be skipped for all samples anyway. 
- I kept in the check for the missing reference, so if there's no reference, cell typing is still skipped as it was previously. 

A few other things: 

- I found a discrepancy between the existing `SingleR` results and the processed SCE object due to a difference in the number of cells. The cell numbers are only off by three cells for the example I looked at, but I think this is probably due to some filtering differences we have seen before. Instead of directly adding a new column with the annotations, I updated the `add_celltypes_to_sce.R` script to join by the barcodes, which is safer anyway.  
- When digging into the mismatches, I noticed we had an error in how we set the seed in `classify_singleR.R`, so I fixed that here. 
- This currently works other than generating the supplemental report, which is dependent on `ggforce` being added in. I'm still trying to figure out why the PR for adding that in is failing tests and image building... see https://github.com/AlexsLemonade/scpcaTools/pull/226