### PR TITLE
Add label type for SingleR refs to annotated SCE 

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -62,6 +62,9 @@ if(!is.null(opt$singler_results)){
   }
 
   singler_results <- readr::read_rds(opt$singler_results)
+  
+  # get label type from metadata of singler object
+  label_type <- metadata(singler_results)$reference_label
 
   # create a tibble with annotations and barcode
   # later we'll add the annotations into colData by joining on barcodes column
@@ -71,8 +74,8 @@ if(!is.null(opt$singler_results)){
   )
 
   # map ontology labels to cell type names, as needed
-  # we can tell if ontologies were used because this will exist:
-  if ("cell_ontology_df" %in% names(singler_results)) {
+  # label type will be label.ont if ontology is present
+  if (label_type == "label.ont") {
 
     # end up with columns: barcode, singler_celltype_annotation, singler_celltype_ontology
     colData(sce) <- annotations_df |>
@@ -100,6 +103,7 @@ if(!is.null(opt$singler_results)){
   # add singler info to metadata
   metadata(sce)$singler_results <- singler_results
   metadata(sce)$singler_reference <- metadata(singler_results)$reference_name
+  metadata(sce)$singler_reference_label <- label_type
 
   # add note about cell type method to metadata
   metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "singler")

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -94,6 +94,8 @@ singler_results <- SingleR::classifySingleR(
 
 # add reference name to singler_results DataFrame metadata
 metadata(singler_results)$reference_name <- reference_name
+# add label name to metadata
+metadata(singler_results)$reference_label <- metadata(singler_model)$reference_label
 
 # export results ---------------
 


### PR DESCRIPTION
Based on https://github.com/AlexsLemonade/scpca-docs/pull/166#discussion_r1367258141, this PR adds back in tracking the reference label type for SingleR. When building the SingleR model se specify the label type to use. That label type is then stored in the metadata of the model object (see https://github.com/AlexsLemonade/scpca-nf/blob/934df294bbfe2a01d8ffdb94ba9f5d6b432a547d/bin/train_SingleR.R#L134).

So here I take the label name that's stored in the reference model object and store it in the results object in `classify_SingleR.R`. Then in `add_celltypes_to_sce.R`, I get the label type from the results object and add it to the metadata of the annotated SCE object. I also used it to check whether or not to map the annotations to the ontology label. 