### PR TITLE
Remove extra publish step

### DIFF
--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -85,7 +85,6 @@ process classify_cellassign {
 
 process add_celltypes_to_sce {
   container params.SCPCATOOLS_CONTAINER
-  publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
   label 'mem_4'
   label 'cpus_2'
   tag "${meta.library_id}"


### PR DESCRIPTION
When running through some samples and performing cell typing, I noticed that we were still publishing the `_annotated_processed.rds` file to the results directory. 
We don't want to do that and only want to publish the final SCE objects in the process that creates the QC report. 