### PR TITLE
Fixes to cell type tables

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -62,7 +62,7 @@ if(!is.null(opt$singler_results)){
   }
 
   singler_results <- readr::read_rds(opt$singler_results)
-  
+
   # get label type from metadata of singler object
   label_type <- metadata(singler_results)$reference_label
 
@@ -78,7 +78,7 @@ if(!is.null(opt$singler_results)){
   if (label_type == "label.ont") {
 
     # end up with columns: barcode, singler_celltype_annotation, singler_celltype_ontology
-    colData(sce) <- annotations_df |>
+    annotations_df <- annotations_df |>
       dplyr::left_join(
         # column names: ontology_id, ontology_cell_names
         singler_results$cell_ontology_df,

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -138,9 +138,15 @@ glue::glue(
 
 
 ```{r, eval = has_cellassign, results='asis'}
+tissue_type <- stringr::word(
+  metadata(processed_sce)$cellassign_reference,
+  -1,
+  sep = "-"
+)
+
 glue::glue(
   "* Cell types were annotated using [`CellAssign`](https://github.com/Irrationone/cellassign), which uses a marker-gene based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)).
-  Marker genes associated with `{metadata(processed_sce)$cellassign_reference}` tissue were obtained from [PanglaoDB](https://panglaodb.se/).
+  Marker genes associated with `{tissue_type}` tissue were obtained from [PanglaoDB](https://panglaodb.se/).
   "
 )
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -132,7 +132,7 @@ glue::glue(
 ```{r, eval = has_singler, results='asis'}
 glue::glue(
   "* Cell types were annotated using [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach ([Looney _et al._ 2019](https://doi.org/10.1038/s41590-018-0276-y)).
-  The `{metadata(sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
+  The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
 )
 ```
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -132,7 +132,7 @@ glue::glue(
 ```{r, eval = has_singler, results='asis'}
 glue::glue(
   "* Cell types were annotated using [`SingleR`](https://bioconductor.org/packages/release/bioc/html/SingleR.html), which uses a reference-based approach ([Looney _et al._ 2019](https://doi.org/10.1038/s41590-018-0276-y)).
-  The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html) package, was used for cell typing."
+  The `{metadata(processed_sce)$singler_reference}` reference dataset, obtained from the [`celldex` package](http://bioconductor.org/packages/release/data/experiment/html/celldex.html), was used for cell typing."
 )
 ```
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -114,7 +114,8 @@ if (has_processed) {
 
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
-  has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods
+  has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &
+    !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
   # If at least 1 is present, we have cell type annotations.
   has_celltypes <- any(has_singler, has_cellassign, has_submitter)

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -32,14 +32,7 @@ create_celltype_df <- function(processed_sce) {
   
   if("submitter_celltype_annotation" %in% names(celltype_df)){
     celltype_df <- celltype_df |> 
-      dplyr::mutate(submitter_celltype_annotation = dplyr::if_else(
-        is.na(submitter_celltype_annotation),
-        "Unclassified cell", 
-        submitter_celltype_annotation
-      ) |>
-        forcats::fct_infreq() |>
-        forcats::fct_relevel("Unclassified cell", after = Inf)
-      )
+      prepare_annotation_values(submitter_celltype_annotation, is_submitter = TRUE) 
   }
 
   if ("singler_celltype_annotation" %in% names(celltype_df)) {
@@ -63,24 +56,36 @@ create_celltype_df <- function(processed_sce) {
 #'
 #' @param df The data frame containing cell type annotations, one row per cell
 #' @param annotation_column The column (written plainly, not a string) containing annotations to reformat
+#' @param is_submitter Boolean indicating if cell types are from submitter. 
+#'   If TRUE, NA's will be set to "Unclassified cell".
+#'   If FALSE, NA's will be set to "Unknown cell type". Default is FALSE.
 #'
 #' @return Updated data frame with the `annotation_column` reformatted
-prepare_annotation_values <- function(df, annotation_column) {
+prepare_annotation_values <- function(df, annotation_column, is_submitter = FALSE) {
+  
+  submitter_string <- "Unclassified cell" # use for unclassified submitter cells 
+  method_string  <- "Unknown cell type" # use for unclassified singler and cellassign cells
+  fct_string <- ifelse(is_submitter, submitter_string, method_string) # which string to consider when reordering the factor
+
   df |>
     dplyr::mutate(
       {{ annotation_column }} := dplyr::case_when(
+        # submitter condition - HAS TO BE FIRST since these are also NA which is the singler check
+        is_submitter & is.na({{ annotation_column }})  ~ submitter_string,
         # singler condition
-        is.na({{ annotation_column }}) ~ "Unknown cell type",
+        is.na({{ annotation_column }}) ~ method_string,
         # cellassign conditon
-        {{ annotation_column }} == "other" ~ "Unknown cell type",
+        {{ annotation_column }} == "other" ~ method_string,
         # otherwise, keep it
         .default = {{ annotation_column }}
       ) |>
         # order column by number of cells
         forcats::fct_infreq() |>
-        # relevel so unknown is at the end
-        forcats::fct_relevel("Unknown cell type", after = Inf)
+        # relevel so the applied unknown is at the end
+        forcats::fct_relevel(fct_string, after = Inf)
     )
+  
+  
 }
 ```
 

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -29,10 +29,22 @@ create_celltype_df <- function(processed_sce) {
       contains("cellassign"),
       contains("submitter")
     )
+  
+  if("submitter_celltype_annotation" %in% names(celltype_df)){
+    celltype_df <- celltype_df |> 
+      dplyr::mutate(submitter_celltype_annotation = dplyr::if_else(
+        is.na(submitter_celltype_annotation),
+        "Unclassified cell", 
+        submitter_celltype_annotation
+      ) |>
+        forcats::fct_infreq() |>
+        forcats::fct_relevel("Unclassified cell", after = Inf)
+      )
+  }
 
   if ("singler_celltype_annotation" %in% names(celltype_df)) {
     celltype_df <- celltype_df |>
-      prepare_annotation_values(singler_celltype_annotation)
+      prepare_annotation_values(singler_celltype_annotation) 
   }
   if ("cellassign_celltype_annotation" %in% names(celltype_df)) {
     celltype_df <- celltype_df |>
@@ -64,7 +76,9 @@ prepare_annotation_values <- function(df, annotation_column) {
         # otherwise, keep it
         .default = {{ annotation_column }}
       ) |>
+        # order column by number of cells
         forcats::fct_infreq() |>
+        # relevel so unknown is at the end
         forcats::fct_relevel("Unknown cell type", after = Inf)
     )
 }


### PR DESCRIPTION
Closes #512 
Closes #527 

This PR makes the necessary adjustments to fix some of the formatting and display of the tables that are mentioned in #512. 

- In the `create_celltype_df` function, I added a check for submitter cell types and set NA to "Unclassified cell". 
- I also made sure to add in the re-leveling so that the table for submitter cell types is in order of percentage of cells with "Unclassified cell" last. 
- I also fixed a small typo that meant we weren't setting the cell ontology labels as the annotations, which is what we want to do. That should now fix the situation of seeing the cell ontology ids as the axis labels in the plots. 
- The last thing I did was just add a check that all submitter cell types are not NA. If that's the case, then `has_submitter` is set to `FALSE`. No more blank UMAPs or heatmaps. 

Note that because I'm running CellAssign right now I haven't been able to fully test this with Nextflow, but I did test this locally. 