### PR TITLE
Fix UMAPs in main cell type section of report

### DIFF
--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -86,8 +86,9 @@ if(!opt$pca_name %in% reducedDimNames(sce)) {
 
   # add clusters and associated parameters to SCE object
   sce$cluster <- clusters
-  metadata(sce)$cluster_algorithm <- opt$cluster_algorithm
-  metadata(sce)$cluster_weighting <- opt$cluster_weighting
+  # capitalize algorithm and weighting before adding to metadata
+  metadata(sce)$cluster_algorithm <- stringr::str_to_sentence(opt$cluster_algorithm)
+  metadata(sce)$cluster_weighting <- stringr::str_to_sentence(opt$cluster_weighting)
   metadata(sce)$cluster_nn <- opt$nearest_neighbors
 
 }

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -199,7 +199,7 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 ## UMAPs
 
 In this section, we show UMAPs colored by clusters. 
-Clusters were calculated using the graph-based `r stringr::str_to_sentence(metadata(processed_sce)$cluster_algorithm)` algorithm with `r stringr::str_to_sentence(metadata(processed_sce)$cluster_weighting)` weights.
+Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with `r metadata(processed_sce)$cluster_weighting` weighting.
 
 
 ```{r}
@@ -229,11 +229,11 @@ if (length(levels(umap_df$cluster)) <= 8) {
 ```
 
 
-In this section, we show UMAPs colored by cell types.
+Next, we show UMAPs colored by cell types.
 A separate UMAP is shown for each cell typing method used.
 
 For legibility, only the seven most common cell types are shown.
-All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell types," which represent cells that could not be classified).
+All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell type" or "Unclassified cell", which represent cells that could not be classified).
 
 <!-- Now, UMAPs of cell types, where present -->
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -59,7 +59,7 @@ lump_celltypes <- function(df, n_celltypes = 7) {
     dplyr::mutate(
       across(
         ends_with("_celltype_annotation"),
-        \(x) forcats::fct_lump_n(x, n_celltypes, other_level = "Other cell type"),
+        \(x) forcats::fct_lump_n(x, n_celltypes, other_level = "All remaining cell types"),
         .names = "{.col}_lumped"
       )
     )
@@ -192,12 +192,8 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 
 ## UMAPs
 
-In this section, we show UMAPs colored by clusters and cell types.
-A separate UMAP is shown for each cell typing method used.
-Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with `r metadata(processed_sce)$cluster_weighting` weights.
-
-For legibility, only the seven most common cell types are shown.
-All other cell types are grouped together and labeled "Other cell type" (not to be confused with "Unknown cell types," which represent cells that could not be classified).
+In this section, we show UMAPs colored by clusters. 
+Clusters were calculated using the graph-based `r stringr::str_to_sentence(metadata(processed_sce)$cluster_algorithm)` algorithm with `r stringr::str_to_sentence(metadata(processed_sce)$cluster_weighting)` weights.
 
 
 ```{r}
@@ -225,6 +221,13 @@ if (length(levels(umap_df$cluster)) <= 8) {
   clusters_plot
 }
 ```
+
+
+In this section, we show UMAPs colored by cell types.
+A separate UMAP is shown for each cell typing method used.
+
+For legibility, only the seven most common cell types are shown.
+All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell types," which represent cells that could not be classified).
 
 <!-- Now, UMAPs of cell types, where present -->
 


### PR DESCRIPTION
Closes #513 
Stacked on #528 

This PR makes the small adjustments to the UMAPs that were outlined in #513. 

- I made sure that the methods for clustering and weighting were capitalized. One thing to note is that we are grabbing these from the metadata of the processed object. Should we store them in the object as capitalized instead of what I did here? 
- I moved the description of the cell type UMAPs to be immediately before the first cell type UMAP rather than grouped with the description of the cluster UMAP. 
- Part of the fixes in #528 actually helped account for all the NA's being renamed and counted when grouping the cell types together. 
- I updated the name of the "other cell types" group to "All remaining cell types" and updated the text accordingly. 