### PR TITLE
Establish updated heatmap styling

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -27,6 +27,7 @@ Hippen
 HTOs
 HPC
 intronic
+Jaccard
 Lun
 miQC
 nextflow

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -162,7 +162,7 @@ glue::glue("
 
 ## Statistics
 
-```{r}
+```{r, warning = FALSE}
 # Create data frame of cell types
 celltype_df <- create_celltype_df(processed_sce)
 ```

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -161,16 +161,16 @@ col_fun <- circlize::colorRamp2(c(0, 1), colors = c("yellow", "red"))
 keep_legend_name <- names(jaccard_cluster_matrices)[1]
 
 ###############################################################################
-# BELOW FAILS WITH ERROR:  - Error: object 'ComplexHeatmap' not found
+# BELOW FAILS WITH ERROR:  - Error: object 'ComplexHeatmap' not found...????
 #ComplexHeatmap::ht_opt[["TITLE_PADDING"]]<- unit(0.5, "cm")
 
 # BELOW WORKS!
-library(ComplexHeatmap)
-ht_opt[["TITLE_PADDING"]]<- unit(0.5, "cm")
+suppressPackageStartupMessages(library(ComplexHeatmap))
+ht_opt[["TITLE_PADDING"]] <- unit(0.5, "cm")
 ###############################################################################
 
 
-# TODO: We might want to make a wrapper for this, to use for direct comparison heatmaps? Circle back.
+# TODO: make this into a function so can re-use for 2nd group of heatmaps (still forthcoming)
 heatmap_list <- jaccard_cluster_matrices |> 
   purrr::imap(\(mat, name){
     ComplexHeatmap::Heatmap(
@@ -206,7 +206,8 @@ heatmap_list <- jaccard_cluster_matrices |>
 # Render the heatmap list
 ComplexHeatmap::draw(
   heatmap_list, 
-  heatmap_legend_side = "bottom")
+  heatmap_legend_side = "bottom" 
+)
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -185,7 +185,7 @@ heatmap_list <- jaccard_cluster_matrices |>
       heatmap_legend_param = list(
         title = "Jaccard similarity index",
         direction = "horizontal",
-        legend_width = unit(4, "cm")
+        legend_width = unit(1.5, "in")
       ),
       # Retain only 1 legend in the final plot      
       show_heatmap_legend = name == keep_legend_name,

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -112,8 +112,16 @@ celltype_df <- create_celltype_df(processed_sce)
 
 ## Heatmaps
 
-Below, we show heat maps comparing cell type annotations (along the y-axis) to clustering results (along the x-axis).
-Heatmap colors represent the log number of cells present in both the given cell type and cluster.
+Below, we show heat maps comparing each set of cell type annotations to clustering results.
+Heatmap colors represent the Jaccard similarity index between each grouping.
+
+This metric is bounded by 0 and 1:
+
+* A value of 1 indicates complete overlap between categories.
+The categories being compared contain the same set of cells.
+* A value of 0 indicates no overlap between categories. 
+No cells that appear in one category appear in the other.
+
 
 ```{r}
 # Calculate all jaccard matrices of interest for input to heatmap

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -154,21 +154,14 @@ heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
-# Define color ramp for shared use in the heatmap - TO BE DISCUSSED!
-col_fun <- circlize::colorRamp2(c(0, 1), colors = c("yellow", "red"))
+# Define color ramp for shared use in the heatmap
+col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
 
 # We only want one shared legend in the end, arbitrarily grab the first one
 keep_legend_name <- names(jaccard_cluster_matrices)[1]
 
-###############################################################################
-# BELOW FAILS WITH ERROR:  - Error: object 'ComplexHeatmap' not found...????
-ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.5, "cm"))
-
-# BELOW WORKS!
-suppressPackageStartupMessages(library(ComplexHeatmap))
-ht_opt[["TITLE_PADDING"]] <- unit(0.5, "cm")
-###############################################################################
-
+# Set heatmap padding option
+ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
 
 # TODO: make this into a function so can re-use for 2nd group of heatmaps (still forthcoming)
 heatmap_list <- jaccard_cluster_matrices |> 
@@ -176,6 +169,7 @@ heatmap_list <- jaccard_cluster_matrices |>
     ComplexHeatmap::Heatmap(
       t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
       col = col_fun,
+      border = TRUE, # each heatmap gets its own outline
       ## Row parameters
       cluster_rows = FALSE,
       row_title = name, # each heatmap gets its own title
@@ -188,15 +182,15 @@ heatmap_list <- jaccard_cluster_matrices |>
       column_title = glue::glue("Cluster"),
       column_names_side = "top",
       column_names_rot = 0,
-      column_names_gp = grid::gpar(fontsize = 12),
+      column_names_gp = grid::gpar(fontsize = 8), # match row name size
       ## Legend parameters
-    heatmap_legend_param = list(
-      title = "Jaccard similarity index",
-      direction = "horizontal",
-      legend_width = unit(4, "cm")
-    ),
-    # Retain only 1 legend in the final plot      
-    show_heatmap_legend = name == keep_legend_name,
+      heatmap_legend_param = list(
+        title = "Jaccard similarity index",
+        direction = "horizontal",
+        legend_width = unit(4, "cm")
+      ),
+      # Retain only 1 legend in the final plot      
+      show_heatmap_legend = name == keep_legend_name,
     )
   }) |>
   # concatenate vertically into HeatmapList object

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -108,16 +108,23 @@ has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods
 celltype_df <- create_celltype_df(processed_sce)
 ```
 
-## Comparison to clusters
-                   
-This section displays heatmaps comparing cell type annotations to cell clusters, which were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with `r metadata(processed_sce)$cluster_weighting` weighting.
 
-We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to compare pairs of labels from clusters and cell type annotations.
+## Cell label comparison plots
+
+This section displays heatmaps comparing cell labels from various methods. 
+
+We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between pairs of labels from different methods.
 
 The Jaccard index reflects the degree of overlap between the two labels and ranges from 0 to 1. 
 
 * If the labels are assigned to identical sets of cells, the Jaccard index will be 1.
 * If the labels are assigned to completely non-overlapping sets of cells, the Jaccard index will be 0.
+
+
+### Comparison with unsupervised clustering
+
+Here we show the labels from unsupervised clustering compared against cell type annotations. 
+Cluster assignment was performed using the `r metadata(processed_sce)$cluster_algorithm` algorithm.
 
 
 ```{r}
@@ -152,8 +159,7 @@ heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 
 ```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
 # Define color ramp for shared use in the heatmap
-c("#ffffff", hcl.colors(n = 5, palette = "Blues", rev =TRUE)[2:5])-> mycolors
-col_fun <- circlize::colorRamp2(c(0, 0.25, 0.5, 0.75, 1), colors = mycolors)
+col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
 
 # We only want one shared legend in the end, arbitrarily grab the first one
 keep_legend_name <- names(jaccard_cluster_matrices)[1]
@@ -208,9 +214,9 @@ ComplexHeatmap::draw(
 
 ```{r, eval = has_submitter & (has_cellassign | has_singler)}
 methods_string <- dplyr::case_when(
-  has_cellassign & has_singler ~ glue::glue("`SingleR` and `CellAssign`"),
-  has_cellassign  ~ glue::glue("`CellAssign`"),
-  has_singler  ~ glue::glue("`SingleR`"),
+  has_cellassign & has_singler ~ "`SingleR` and `CellAssign`",
+  has_singler  ~ "`SingleR`",
+  has_cellassign  ~ "`CellAssign`"
 )
 
 knitr::asis_output(
@@ -226,7 +232,7 @@ knitr::asis_output(
 
 ```{r, eval = has_cellassign & has_singler, fig.height=7, fig.width=8}
 knitr::asis_output("
-## Comparison between `SingleR` and `CellAssign` annotations
+### Comparison between `SingleR` and `CellAssign` annotations
 
 This section displays a heatmap directly comparing `SingleR` and `CellAssign` cell type annotations.
 Note that due to different annotations references, these methods may use different names for similar cell types.

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -41,6 +41,7 @@ theme_set(
 
 ```
 
+
 ```{r, message = FALSE, echo = FALSE}
 # define library and sce object
 library_id <- params$library
@@ -61,58 +62,6 @@ celltype_df <- create_celltype_df(processed_sce)
 
 Below, we show heat maps comparing cell type annotations (along the y-axis) to clustering results (along the x-axis).
 Heatmap colors represent the log number of cells present in both the given cell type and cluster.
-
-```{r}
-#' Function to calculate Jaccard similarity on two vectors
-#'
-#' @param vec1 First vector
-#' @param vec2 Second vector
-#'
-#' @return Jaccard similarity between the vectors
-jaccard <- function(vec1, vec2){
-  length(intersect(vec1, vec2)) / length(union(vec1, vec2))
-}
-
-
-# Wrapper function to calculate jaccard similarity matrix for two categorical variables
-#'
-#' @param celltype_df The celltype_df data frame which must contain these columns:
-#'   `colname1`, `colname2`, and `barcodes`
-#' @param colname1 Column name, as a string, of first categorical variable of interest
-#' @param colname2 Column name, as a string, of second categorical variable of interest
-#'   
-#' @return Jaccard similarity matrix for the two columns. `colname1` values will 
-#'   be row names and `colname2` values will be column names in the final matrix
-make_jaccard_matrix <- function(celltype_df, colname1, colname2){
-  
-  # make lists of barcodes for each classifier's assignment, named by the classifier values
-  id1_list <- split(celltype_df$barcodes, celltype_df[[colname1]])
-  id2_list <- split(celltype_df$barcodes, celltype_df[[colname2]])
-  
-  # create the grid of comparisons
-  cross_df <- tidyr::expand_grid(id1 = names(id1_list), id2 = names(id2_list))
-  
-  # calculate scores using split lists & ids
-  jaccard_scores <- cross_df |> 
-    purrr::pmap_dbl(\(id1, id2){
-      jaccard(id1_list[[id1]], id2_list[[id2]])
-    })
-  
-  # add scores to the comparison grid and convert to matrix
-  jaccard_matrix <- cross_df |> 
-    dplyr::mutate(jaccard = jaccard_scores) |>
-    # convert to matrix
-    tidyr::pivot_wider(
-      names_from = "id2", 
-      values_from = "jaccard"
-    ) |>
-    tibble::column_to_rownames(var = "id1") |>
-    as.matrix()
-    
-    return(jaccard_matrix)
-}
-```
-
 
 ```{r}
 # Calculate all jaccard matrices of interest for input to heatmap
@@ -147,49 +96,41 @@ Note that the remaining heatmap code is going to be updated next!
 ```{r}
 # heatmap function definition:
 
-#' Create a heatmap of cell type annotations with log1p transformation
+# heatmap function definition:
+
+#' Create a heatmap from a provided matrix
 #'
-#' @param x_vector Vector of values for the x-axis (rows)
-#' @param y_vector Vector of values for the y-axis (columns)
-#' @param x_label x-axis label. Default is no label.
-#' @param y_label y-axis label. Default is no label.
+#' @param celltype_mtx matrix to plot
+#' @param row_order vector specifying row order.
+#' @param column_order vector specifying column order.
+#' @param row_label row label. Default is no label.
+#' @param column_label column label. Default is no label.
 #' @param y_title_location location of the y-axis title. Default is on the bottom.
 #' @param column_names_rotation degree to rotate column names. Default is 0.
-#' @param row_font_size Size of row font. Default is 8.
-#' @param column_font_size. Size of column font. Default is 10.
+#' @param row_font_size size of row font. Default is 8.
+#' @param column_font_size. size of column font. Default is 10.
 #'
 #' @return heatmap output from `ComplexHeatmap::draw()`
 create_celltype_heatmap <- function(
-    x_vector,
-    y_vector,
-    x_label = "",
-    y_label = "",
+    celltype_mtx,
+    row_order, 
+    column_order,
+    row_label = "",
+    column_label,
     y_title_location = "bottom",
     column_names_rotation = 0,
     row_font_size = 8,
     column_font_size = 10) {
-  # build a matrix for making a heatmap
-  celltype_mtx <- table(
-    x_vector,
-    y_vector
-  ) |>
-    log1p() # log transform for visualization
-
-  # Define CVD-friendly palette
-  heatmap_palette <- viridisLite::inferno(7, alpha = 1, begin = 0, end = 1, direction = 1)
 
   # heatmap
   heat <- ComplexHeatmap::Heatmap(
     celltype_mtx,
-    # Overall heatmap parameters
-    col = heatmap_palette,
-    # Column parameters
+    row_order = row_order,
+    column_order = column_order,
     column_title = y_label,
     column_title_side = y_title_location,
-    column_dend_side = "top",
     column_names_rot = column_names_rotation,
     column_names_gp = grid::gpar(fontsize = column_font_size),
-    row_dend_side = "left",
     row_title_side = "right",
     row_title = x_label,
     row_names_gp = grid::gpar(fontsize = row_font_size),

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -120,7 +120,7 @@ Heatmap colors represent the log number of cells present in both the given cell 
 jaccard_cluster_matrices <- list()
 
 if (has_submitter) {
-  jaccard_cluster_matrices[["Submitter-provided"]] <- make_jaccard_matrix(
+  jaccard_cluster_matrices[["Submitter"]] <- make_jaccard_matrix(
     celltype_df, 
     "cluster", 
     "submitter_celltype_annotation"
@@ -140,90 +140,68 @@ if (has_cellassign) {
     "cellassign_celltype_annotation"
   )
 }
+
+
+heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 ```
 
+```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
+# Define color ramp for shared use in the heatmap - TO BE DISCUSSED!
+col_fun <- circlize::colorRamp2(c(0, 1), colors = c("yellow", "red"))
 
-Note that the remaining heatmap code is going to be updated next!
+# We only want one shared legend in the end, arbitrarily grab the first one
+keep_legend_name <- names(jaccard_cluster_matrices)[1]
 
-```{r}
-# heatmap function definition:
+###############################################################################
+# BELOW FAILS WITH ERROR:  - Error: object 'ComplexHeatmap' not found
+#ComplexHeatmap::ht_opt[["TITLE_PADDING"]]<- unit(0.5, "cm")
 
-# heatmap function definition:
+# BELOW WORKS!
+library(ComplexHeatmap)
+ht_opt[["TITLE_PADDING"]]<- unit(0.5, "cm")
+###############################################################################
 
-#' Create a heatmap from a provided matrix
-#'
-#' @param celltype_mtx matrix to plot
-#' @param row_order vector specifying row order.
-#' @param column_order vector specifying column order.
-#' @param row_label row label. Default is no label.
-#' @param column_label column label. Default is no label.
-#' @param y_title_location location of the y-axis title. Default is on the bottom.
-#' @param column_names_rotation degree to rotate column names. Default is 0.
-#' @param row_font_size size of row font. Default is 8.
-#' @param column_font_size. size of column font. Default is 10.
-#'
-#' @return heatmap output from `ComplexHeatmap::draw()`
-create_celltype_heatmap <- function(
-    celltype_mtx,
-    row_order, 
-    column_order,
-    row_label = "",
-    column_label,
-    y_title_location = "bottom",
-    column_names_rotation = 0,
-    row_font_size = 8,
-    column_font_size = 10) {
 
-  # heatmap
-  heat <- ComplexHeatmap::Heatmap(
-    celltype_mtx,
-    row_order = row_order,
-    column_order = column_order,
-    column_title = y_label,
-    column_title_side = y_title_location,
-    column_names_rot = column_names_rotation,
-    column_names_gp = grid::gpar(fontsize = column_font_size),
-    row_title_side = "right",
-    row_title = x_label,
-    row_names_gp = grid::gpar(fontsize = row_font_size),
-    # Legend parameters
+# TODO: We might want to make a wrapper for this, to use for direct comparison heatmaps? Circle back.
+heatmap_list <- jaccard_cluster_matrices |> 
+  purrr::imap(\(mat, name){
+    ComplexHeatmap::Heatmap(
+      t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
+      col = col_fun,
+      ## Row parameters
+      cluster_rows = FALSE,
+      row_title = name, # each heatmap gets its own title
+      row_title_gp = grid::gpar(fontsize = 10), 
+      row_title_side = "right",
+      row_names_side = "left",
+      row_names_gp = grid::gpar(fontsize = 8),
+      ## Column parameters
+      cluster_columns = FALSE,
+      column_title = glue::glue("Cluster"),
+      column_names_side = "top",
+      column_names_rot = 0,
+      column_names_gp = grid::gpar(fontsize = 12),
+      ## Legend parameters
     heatmap_legend_param = list(
-      title = "Log(Number of cells)",
-      title_position = "leftcenter-rot",
-      legend_height = unit(4, "cm")
+      title = "Jaccard similarity index",
+      direction = "horizontal",
+      legend_width = unit(4, "cm")
+    ),
+    # Retain only 1 legend in the final plot      
+    show_heatmap_legend = ifelse(name == keep_legend_name, TRUE, FALSE),
     )
-  )
-  # draw with legend on left for spacing
-  ComplexHeatmap::draw(heat, heatmap_legend_side = "left")
-}
+  }) |>
+  # concatenate vertically into HeatmapList object
+  purrr::reduce(ComplexHeatmap::`%v%`) 
+
+
+# Render the heatmap list
+ComplexHeatmap::draw(
+  heatmap_list, 
+  heatmap_legend_side = "bottom")
 ```
 
-```{r, eval = has_submitter, fig.height=5, fig.width=7}
-knitr::asis_output("### Submitter-provided cell type and cluster heatmap\n")
-create_celltype_heatmap(
-  x_vector = celltype_df$submitter_celltype_annotation,
-  y_vector = celltype_df$cluster,
-  y_label = "Cluster"
-)
-```
 
-```{r, eval = has_singler, fig.height=5, fig.width=7}
-knitr::asis_output("### `SingleR` cell type and cluster heatmap\n")
-create_celltype_heatmap(
-  x_vector = celltype_df$singler_celltype_annotation,
-  y_vector = celltype_df$cluster,
-  y_label = "Cluster"
-)
-```
-
-```{r, eval = has_cellassign, fig.height=5, fig.width=7}
-knitr::asis_output("### `CellAssign` cell type and cluster heatmap\n")
-create_celltype_heatmap(
-  x_vector = celltype_df$cellassign_celltype_annotation,
-  y_vector = celltype_df$cluster,
-  y_label = "Cluster"
-)
-```
 
 
 ```{r, eval = has_submitter & (has_cellassign | has_singler)}
@@ -237,30 +215,30 @@ Again, different annotations may use different names for similar cell types.
 
 
 ```{r, eval = has_submitter & has_singler, fig.height=7, fig.width=8}
-create_celltype_heatmap(
-  x_vector = celltype_df$submitter_celltype_annotation,
-  y_vector = celltype_df$singler_celltype_annotation,
-  x_label = "Submitter-provided annotations",
-  y_label = "SingleR annotations",
-  y_title_location = "top",
-  column_names_rotation = 55,
-  column_font_size = 8
-)
+#create_celltype_heatmap(
+#  x_vector = celltype_df$submitter_celltype_annotation,
+#  y_vector = celltype_df$singler_celltype_annotation,
+#  x_label = "Submitter-provided annotations",
+#  y_label = "SingleR annotations",
+#  y_title_location = "top",
+#  column_names_rotation = 55,
+#  column_font_size = 8
+#)
 ```
 
 <!-- A little extra spacing to avoid confusion between plot labels -->
 <br>
 
 ```{r, eval = has_submitter & has_cellassign, fig.height=7, fig.width=8}
-create_celltype_heatmap(
-  x_vector = celltype_df$submitter_celltype_annotation,
-  y_vector = celltype_df$cellassign_celltype_annotation,
-  x_label = "Submitter-provided annotations",
-  y_label = "CellAssign annotations",
-  y_title_location = "top",
-  column_names_rotation = 55,
-  column_font_size = 8
-)
+#create_celltype_heatmap(
+#  x_vector = celltype_df$submitter_celltype_annotation,
+#  y_vector = celltype_df$cellassign_celltype_annotation,
+#  x_label = "Submitter-provided annotations",
+#  y_label = "CellAssign annotations",
+#  y_title_location = "top",
+#  column_names_rotation = 55,
+#  column_font_size = 8
+#)
 ```
 
 <!-- Use large height/width to accommodate cell type labels -->
@@ -272,14 +250,14 @@ Below is a heatmap directly comparing `SingleR` and `CellAssign` cell type annot
 Note that due to different annotations references, these methods may use different names for similar cell types.
 ")
 
-create_celltype_heatmap(
-  x_vector = celltype_df$singler_celltype_annotation,
-  y_vector = celltype_df$cellassign_celltype_annotation,
-  x_label = "SingleR annotations",
-  y_label = "CellAssign annotations",
-  column_names_rotation = 55,
-  column_font_size = 8
-)
+#create_celltype_heatmap(
+#  x_vector = celltype_df$singler_celltype_annotation,
+#  y_vector = celltype_df$cellassign_celltype_annotation,
+#  x_label = "SingleR annotations",
+#  y_label = "CellAssign annotations",
+#  column_names_rotation = 55,
+#  column_font_size = 8
+#)
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -94,7 +94,7 @@ make_jaccard_matrix <- function(celltype_df, colname1, colname2){
 ```
 
 
-```{r, message = FALSE, echo = FALSE}
+```{r, message = FALSE, warning = FALSE, echo = FALSE}
 # define library and sce object
 library_id <- params$library
 processed_sce <- params$processed_sce

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -162,7 +162,7 @@ keep_legend_name <- names(jaccard_cluster_matrices)[1]
 
 ###############################################################################
 # BELOW FAILS WITH ERROR:  - Error: object 'ComplexHeatmap' not found...????
-#ComplexHeatmap::ht_opt[["TITLE_PADDING"]]<- unit(0.5, "cm")
+ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.5, "cm"))
 
 # BELOW WORKS!
 suppressPackageStartupMessages(library(ComplexHeatmap))
@@ -196,7 +196,7 @@ heatmap_list <- jaccard_cluster_matrices |>
       legend_width = unit(4, "cm")
     ),
     # Retain only 1 legend in the final plot      
-    show_heatmap_legend = ifelse(name == keep_legend_name, TRUE, FALSE),
+    show_heatmap_legend = name == keep_legend_name,
     )
   }) |>
   # concatenate vertically into HeatmapList object

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -108,19 +108,16 @@ has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods
 celltype_df <- create_celltype_df(processed_sce)
 ```
 
+## Comparison to clusters
+                   
+This section displays heatmaps comparing cell type annotations to cell clusters, which were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with `r metadata(processed_sce)$cluster_weighting` weighting.
 
+We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to compare pairs of labels from clusters and cell type annotations.
 
-## Heatmaps
+The Jaccard index reflects the degree of overlap between the two labels and ranges from 0 to 1. 
 
-Below, we show heat maps comparing each set of cell type annotations to clustering results.
-Heatmap colors represent the Jaccard similarity index between each grouping.
-
-This metric is bounded by 0 and 1:
-
-* A value of 1 indicates complete overlap between categories.
-The categories being compared contain the same set of cells.
-* A value of 0 indicates no overlap between categories. 
-No cells that appear in one category appear in the other.
+* If the labels are assigned to identical sets of cells, the Jaccard index will be 1.
+* If the labels are assigned to completely non-overlapping sets of cells, the Jaccard index will be 0.
 
 
 ```{r}
@@ -155,7 +152,8 @@ heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 
 ```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
 # Define color ramp for shared use in the heatmap
-col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
+c("#ffffff", hcl.colors(n = 5, palette = "Blues", rev =TRUE)[2:5])-> mycolors
+col_fun <- circlize::colorRamp2(c(0, 0.25, 0.5, 0.75, 1), colors = mycolors)
 
 # We only want one shared legend in the end, arbitrarily grab the first one
 keep_legend_name <- names(jaccard_cluster_matrices)[1]
@@ -207,60 +205,32 @@ ComplexHeatmap::draw(
 
 
 
+
 ```{r, eval = has_submitter & (has_cellassign | has_singler)}
-knitr::asis_output("
-## Comparison with submitter annotations
+methods_string <- dplyr::case_when(
+  has_cellassign & has_singler ~ glue::glue("`SingleR` and `CellAssign`"),
+  has_cellassign  ~ glue::glue("`CellAssign`"),
+  has_singler  ~ glue::glue("`SingleR`"),
+)
 
-This section shows heatmap(s) directly comparing submitter-provided cell type annotations to cell type inferred with the given method(s).
-Again, different annotations may use different names for similar cell types.
-")
+knitr::asis_output(
+  glue::glue(
+  "## Comparison with submitter annotations
+
+  This section displays heatmaps comparing submitter-provided cell type annotations to those obtained from {methods_string}."
+  )
+)
+
 ```
 
 
-```{r, eval = has_submitter & has_singler, fig.height=7, fig.width=8}
-#create_celltype_heatmap(
-#  x_vector = celltype_df$submitter_celltype_annotation,
-#  y_vector = celltype_df$singler_celltype_annotation,
-#  x_label = "Submitter-provided annotations",
-#  y_label = "SingleR annotations",
-#  y_title_location = "top",
-#  column_names_rotation = 55,
-#  column_font_size = 8
-#)
-```
-
-<!-- A little extra spacing to avoid confusion between plot labels -->
-<br>
-
-```{r, eval = has_submitter & has_cellassign, fig.height=7, fig.width=8}
-#create_celltype_heatmap(
-#  x_vector = celltype_df$submitter_celltype_annotation,
-#  y_vector = celltype_df$cellassign_celltype_annotation,
-#  x_label = "Submitter-provided annotations",
-#  y_label = "CellAssign annotations",
-#  y_title_location = "top",
-#  column_names_rotation = 55,
-#  column_font_size = 8
-#)
-```
-
-<!-- Use large height/width to accommodate cell type labels -->
 ```{r, eval = has_cellassign & has_singler, fig.height=7, fig.width=8}
 knitr::asis_output("
 ## Comparison between `SingleR` and `CellAssign` annotations
 
-Below is a heatmap directly comparing `SingleR` and `CellAssign` cell type annotations.
+This section displays a heatmap directly comparing `SingleR` and `CellAssign` cell type annotations.
 Note that due to different annotations references, these methods may use different names for similar cell types.
 ")
-
-#create_celltype_heatmap(
-#  x_vector = celltype_df$singler_celltype_annotation,
-#  y_vector = celltype_df$cellassign_celltype_annotation,
-#  x_label = "SingleR annotations",
-#  y_label = "CellAssign annotations",
-#  column_names_rotation = 55,
-#  column_font_size = 8
-#)
 ```
 
 


### PR DESCRIPTION
Towards #516 

This PR takes the next steps in updating heatmaps:

Edit - the report! 
[celltypes_supplemental_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/13207665/celltypes_supplemental_report.html.zip)


- Heatmaps now come first 
  - note that the introductory parts are still forthcoming - #514 & #515
- I removed the previous function we had been using for making heatmaps. For now, I've commented out the code that used that function to compare singler/cellassign to submitter. The next PR will clear this out using the strategy we land on in this PR.
- Heatmap styling changes:
  - I have updated the color scheme to something less dramatic - a standard yellow and red, but this can certainly change!! (it's super yellow now which is partly b/c these clusters + submitter annotations are simulated data for development)
  - No longer show dendrograms and order by frequency. The order is happily directly inherited from previous code setting factor levels before heading into matrix construction. 
- I changed the submitter label to simply be "Submitter" in the interest of spacing.
- I added some brief text about jaccard. Can (should?) be expanded!!


### a couple points of discussion
- To size the heatmap, I set the height of the viewport to 2.5x the number of heatmaps shown. I think this works ok?
- I placed the shared legend on the bottom. I did this for a few reasons:
  -  Simplifies the approach to choose which heatmap's legend we want to keep. We can arbitrarily grab the first one and use that legend (otherwise, we need a whole logic statement to choose which legend based on which cell types are present, but I have this written on the side if we want to pop it in). 
  - The title for the legend is long and horizontal looks nicer to me than vertical did.
  - Gives us more horizontal room for long cell type names
- I implemented some padding around the method labels on the right to, well, get them padded! Otherwise letters will slightly overlap with the heatmap itself. I modified [`ht_opt`](https://rdrr.io/github/jokergoo/ComplexHeatmap/man/ht_opt.html) for this. But....
  - This proved a bit weird, though not tricky - for reasons I don't totally understand, setting that padding seems to require me to actually load the `ComplexHeatmap` package; I got an "object not found" error when I tried to scope with `::`. Any ideas for how to get this global padding parameter working without loading the package, I'm all ears!
 


### what's next?

I'd like to get the heatmap code into a function so we can re-use it for the next heatmap comparing to submitter annotations, but let's get some of the styling down first in this PR. I plan to functionalize it in the next PR.