### PR TITLE
Save singleR reference label and ontology data frame to singleR results

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -81,7 +81,7 @@ if(!is.null(opt$singler_results)){
     colData(sce) <- annotations_df |>
       dplyr::left_join(
         # column names: ontology_id, ontology_cell_names
-        singler_results$cell_ontology_df,
+        metadata(singler_results)$cell_ontology_df,
         by = c("singler_celltype_annotation" = "ontology_id")
       ) |>
       # rename columns

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -95,10 +95,11 @@ if(!is.null(opt$singler_results)){
   }
 
   # add annotations to colData
-  colData(sce) <- colData(sce) |>
+  new_coldata <- colData(sce) |>
     as.data.frame() |>
     dplyr::left_join(annotations_df, by = c("barcodes")) |>
     DataFrame(row.names = colData(sce)$barcodes)
+  colData(sce) <- new_coldata
 
   # add singler info to metadata
   metadata(sce)$singler_results <- singler_results

--- a/bin/classify_SingleR.R
+++ b/bin/classify_SingleR.R
@@ -95,7 +95,10 @@ singler_results <- SingleR::classifySingleR(
 # add reference name to singler_results DataFrame metadata
 metadata(singler_results)$reference_name <- reference_name
 # add label name to metadata
-metadata(singler_results)$reference_label <- metadata(singler_model)$reference_label
+metadata(singler_results)$reference_label <- singler_model$reference_label
+# save cell ontology table to results
+# if this doesn't exist it will just be NULL
+metadata(singler_results)$cell_ontology_df <- singler_model$cell_ontology_df
 
 # export results ---------------
 


### PR DESCRIPTION
In working on processing some projects through CellAssign, I was running into an error when adding the cell types to the SCE object. 
<img width="574" alt="Screenshot 2023-10-30 at 11 48 39 AM" src="https://github.com/AlexsLemonade/scpca-nf/assets/54039191/90454f36-babd-4435-aa7c-64384b3eca9f">

I went back and realized that we weren't properly storing the name of the reference label in the SingleR results file. Also, we didn't pass on the `cell_ontology_df` from the model to the results. We need that to map cell ontology IDs. 

One other thing to note is that I had to separate out modifying the `colData` and replacing the `colData`. Nextflow was complaining about the `colData` function. 