### PR TITLE
Add remaining heatmaps

### DIFF
--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -124,16 +124,18 @@ draw_heatmap <- function(heatmap, legend_side = "bottom") {
 #' @param labels_font_size Font size to use for rows and column labels.
 #' @param keep_legend_name The name to use in the legend
 #' @param column_names_angle Angle for column names. Default is 0.
-#' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`.
+#' @param col_fun Color function for the heatmap palette. Default is `heatmap_col_fun`.
 #' 
 #' @return A ComplexHeatmap object
-create_single_heatmap <- function(mat,
-                                  row_title, 
-                                  column_title, 
-                                  labels_font_size,
-                                  keep_legend_name,
-                                  column_names_angle = 0,
-                                  col_fun = heatmap_col_fun) {
+create_single_heatmap <- function(
+  mat,
+  row_title, 
+  column_title, 
+  labels_font_size,
+  keep_legend_name,
+  column_names_angle = 0,
+  col_fun = heatmap_col_fun
+) {
   
   heat <- ComplexHeatmap::Heatmap(
     t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
@@ -159,7 +161,7 @@ create_single_heatmap <- function(mat,
       direction = "horizontal",
       legend_width = unit(1.5, "in")
     ),
-    # Retain only 1 legend in the final plot      
+    # only keep legends that match `keep_legend_name`
     show_heatmap_legend = row_title == keep_legend_name,
   )
   
@@ -279,13 +281,13 @@ Cluster assignment was performed using the `r metadata(processed_sce)$cluster_al
 # Calculate all jaccard matrices of interest for input to heatmap
 jaccard_cluster_matrices <- available_celltypes |> 
   stringr::str_to_lower() |>
+  purrr::set_names(available_celltypes) |>
   purrr::map(\(name) {
     make_jaccard_matrix(
       celltype_df, 
       "cluster", 
       glue::glue("{name}_celltype_annotation")
-    )}) |>
-  purrr::set_names(available_celltypes)
+    )}) 
 
 n_celltypes <- jaccard_cluster_matrices |>
   purrr::map(colnames) |> 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -93,7 +93,7 @@ make_jaccard_matrix <- function(celltype_df, colname1, colname2){
 ```
 
 
-<!-- Define variables, options, and function for plotting heatmap from list of matrices --> 
+<!-- Define variables, options, and functions for plotting heatmaps --> 
 ```{r}
 # Define color ramp for shared use in the heatmap
 heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
@@ -101,64 +101,102 @@ heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateb
 # Set heatmap padding option
 ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
 
-#' Function to plot a ComplexHeatmap
+
+#' Draw a ComplexHeatmap
+#'
+#' @param heatmap A heatmap or list of heatmaps to draw
+#' @param legend_side Side legend appears on, default bottom
+draw_heatmap <- function(heatmap, legend_side = "bottom") {
+  # Render the heatmap or list of heatmaps
+  ComplexHeatmap::draw(
+    heatmap, 
+    heatmap_legend_side = legend_side
+  )
+}
+
+
+#' Create a ComplexHeatmap from a matrix
+#'
+#' @param mat Matrix to create heatmap from.
+#' @param row_title Label for row title.
+#' @param column_title Label for column title.
+#' @param labels_font_size Font size to use for rows and column labels.
+#' @param keep_legend_name The name to use in the legend
+#' @param column_names_angle Angle for column names. Default is 0.
+#' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`.
+#' 
+#' @return A ComplexHeatmap object
+create_single_heatmap <- function(mat,
+                                  row_title, 
+                                  column_title, 
+                                  labels_font_size,
+                                  keep_legend_name,
+                                  column_names_angle = 0,
+                                  col_fun = heatmap_col_fun) {
+  
+  heat <- ComplexHeatmap::Heatmap(
+    t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
+    col = col_fun,
+    border = TRUE, # each heatmap gets its own outline
+    ## Row parameters
+    cluster_rows = FALSE,
+    row_title = row_title, # each heatmap gets its own title
+    row_title_gp = grid::gpar(fontsize = 10), 
+    row_title_side = "right",
+    row_names_side = "left",
+    row_names_gp = grid::gpar(fontsize = labels_font_size),
+    ## Column parameters
+    cluster_columns = FALSE,
+    column_title = column_title,
+    column_title_gp = grid::gpar(fontsize = 10), 
+    column_names_side = "bottom",
+    column_names_rot = column_names_angle,
+    column_names_gp = grid::gpar(fontsize = labels_font_size),
+    ## Legend parameters
+    heatmap_legend_param = list(
+      title = "Jaccard index",
+      direction = "horizontal",
+      legend_width = unit(1.5, "in")
+    ),
+    # Retain only 1 legend in the final plot      
+    show_heatmap_legend = row_title == keep_legend_name,
+  )
+  
+  return(heat)
+}    
+      
+#' Function to plot a vertically-stacked ComplexHeatmap from a list of matrices
 #'
 #' @param matrix_list List of matrices to plot in a vertical layout. 
 #' @param column_title Title to use for columns, shared among all heatmaps
-#' @param column_names_angle Angle for column names
 #' @param labels_font_size Font size to use for rows and column labels.
-#' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`
+#' @param column_names_angle Angle for column names. Default is 0.
+#' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`.
 #'
-#' @return Draws a ComplexHeatmap, but does not explicitly return anything
-plot_heatmap <- function(matrix_list,
-                         column_title, 
-                         column_names_angle = 0,
-                         labels_font_size,
-                         col_fun = heatmap_col_fun) {
+#' @return A list of ComplexHeatmap objects
+create_heatmap_list <- function(matrix_list,
+                              column_title, 
+                              labels_font_size,
+                              column_names_angle = 0,
+                              col_fun = heatmap_col_fun) {
   
   
   # We only want one shared legend in the end, arbitrarily grab the first one
   keep_legend_name <- names(matrix_list)[1]
 
   heatmap_list <- matrix_list |> 
-    purrr::imap(\(mat, name){
-      ComplexHeatmap::Heatmap(
-        t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
-        col = col_fun,
-        border = TRUE, # each heatmap gets its own outline
-        ## Row parameters
-        cluster_rows = FALSE,
-        row_title = name, # each heatmap gets its own title
-        row_title_gp = grid::gpar(fontsize = 10), 
-        row_title_side = "right",
-        row_names_side = "left",
-        row_names_gp = grid::gpar(fontsize = labels_font_size),
-        ## Column parameters
-        cluster_columns = FALSE,
-        column_title = column_title,
-        column_names_side = "bottom",
-        column_names_rot = column_names_angle,
-        column_names_gp = grid::gpar(fontsize = labels_font_size),
-        ## Legend parameters
-        heatmap_legend_param = list(
-          title = "Jaccard index",
-          direction = "horizontal",
-          legend_width = unit(1.5, "in")
-        ),
-        # Retain only 1 legend in the final plot      
-        show_heatmap_legend = name == keep_legend_name,
-      )
-    }) |>
+    purrr::imap(
+      create_single_heatmap, 
+      column_title, 
+      labels_font_size,
+      keep_legend_name,
+      column_names_angle = column_names_angle,
+      col_fun = col_fun
+    ) |>
     # concatenate vertically into HeatmapList object
     purrr::reduce(ComplexHeatmap::`%v%`) 
   
-  
-  # Render the heatmap list
-  ComplexHeatmap::draw(
-    heatmap_list, 
-    heatmap_legend_side = "bottom"
-  )
-  
+  return(heatmap_list)
 }
 
 
@@ -197,6 +235,9 @@ find_label_size <- function(input_labels,
 # define library and sce object
 library_id <- params$library
 processed_sce <- params$processed_sce
+
+library_id <- "SCPCL000295" 
+processed_sce <- readRDS(glue::glue("{library_id}_processed.rds"))
 
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
@@ -255,17 +296,15 @@ if (has_cellassign) {
 
 # set height based on number of matrices
 heatmap_height <- length(jaccard_cluster_matrices) * 2.5
-
-
-
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
-plot_heatmap(
-  jaccard_cluster_matrices, 
-  column_title = "Clusters", 
-  labels_font_size = find_label_size(jaccard_cluster_matrices)
-)
+jaccard_cluster_matrices |>
+  create_heatmap_list(
+    column_title = "Clusters", 
+    labels_font_size = find_label_size(jaccard_cluster_matrices)
+  ) |>
+  draw_heatmap()
 ```
 
 
@@ -315,12 +354,14 @@ heatmap_height <- n_celltypes / 4.5
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
-plot_heatmap(
-  jaccard_submitter_matrices, 
-  column_title = "Submitted-provided annotations",
-  labels_font_size = find_label_size(jaccard_submitter_matrices),
-  column_names_angle = 45
-)
+# create_heatmap(
+#   jaccard_submitter_matrices, 
+#   column_title = "Submitted-provided annotations",
+#   labels_font_size = find_label_size(jaccard_submitter_matrices),
+#   column_names_angle = 45
+# )
+# 
+# draw_heatmap
 ```
 
 
@@ -351,7 +392,7 @@ labels_font_size <- find_label_size(
     rownames(singler_cellassign_matrix), 
     colnames(singler_cellassign_matrix)
   ), 
-  extact_names = FALSE
+  extract_names = FALSE
 )
 
 ComplexHeatmap::Heatmap(

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -116,7 +116,6 @@ plot_heatmap <- function(matrix_list,
   # We only want one shared legend in the end, arbitrarily grab the first one
   keep_legend_name <- names(matrix_list)[1]
 
-    
   heatmap_list <- jaccard_cluster_matrices |> 
     purrr::imap(\(mat, name){
       ComplexHeatmap::Heatmap(
@@ -290,6 +289,14 @@ Note that due to different annotations references, these methods may use differe
 ```
 
 
+```{r, eval = has_cellassign & has_singler}
+# Calculate all jaccard matrices of interest for input to next heatmap
+singler_cellassign_matrix <- make_jaccard_matrix(
+  celltype_df, 
+  "singler_celltype_annotation",
+  "cellassign_celltype_annotation"
+)
+```
 
 
 ```{r, eval = has_singler | has_cellassign }

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -236,9 +236,6 @@ find_label_size <- function(input_labels,
 library_id <- params$library
 processed_sce <- params$processed_sce
 
-library_id <- "SCPCL000295" 
-processed_sce <- readRDS(glue::glue("{library_id}_processed.rds"))
-
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
 has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
@@ -246,6 +243,14 @@ has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods
 
 # Create data frame of cell types
 celltype_df <- create_celltype_df(processed_sce)
+
+# what celltypes are available?
+available_celltypes <- c(
+  ifelse(has_submitter, "Submitter", NA),
+  ifelse(has_singler, "SingleR", NA),
+  ifelse(has_cellassign, "CellAssign", NA)
+) |> 
+  na.omit()
 ```
 
 
@@ -269,31 +274,22 @@ Cluster assignment was performed using the `r metadata(processed_sce)$cluster_al
 
 ```{r}
 # Calculate all jaccard matrices of interest for input to heatmap
-jaccard_cluster_matrices <- list()
+jaccard_cluster_matrices <- available_celltypes |> 
+  stringr::str_to_lower() |>
+  purrr::map(\(name) {
+    make_jaccard_matrix(
+      celltype_df, 
+      "cluster", 
+      glue::glue("{name}_celltype_annotation")
+    )}) |>
+  purrr::set_names(available_celltypes)
 
-if (has_submitter) {
-  jaccard_cluster_matrices[["Submitter"]] <- make_jaccard_matrix(
-    celltype_df, 
-    "cluster", 
-    "submitter_celltype_annotation"
-  )
-}
-if (has_singler) {
-  jaccard_cluster_matrices[["SingleR"]] <- make_jaccard_matrix(
-    celltype_df, 
-    "cluster", 
-    "singler_celltype_annotation"
-  )
-}
-if (has_cellassign) {
-  jaccard_cluster_matrices[["CellAssign"]] <- make_jaccard_matrix(
-    celltype_df, 
-    "cluster", 
-    "cellassign_celltype_annotation"
-  )
-}
-
-
+# TODO: incorporate this
+n_celltypes <- jaccard_cluster_matrices |>
+  purrr::map(colnames) |> 
+  unlist() |> 
+  length()
+  
 # set height based on number of matrices
 heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 ```
@@ -328,10 +324,26 @@ knitr::asis_output(
 ```
 
 ```{r}
-# Calculate all jaccard matrices of interest for input to next heatmap
-jaccard_submitter_matrices <- list()
+# don't compare submitter to submitter
+available_celltypes <- available_celltypes[!(available_celltypes == "Submitter")]
 
-n_celltypes <- 0 
+# calculate matrices comparing to submitter
+jaccard_submitter_matrices <- available_celltypes |> 
+  stringr::str_to_lower() |>
+  purrr::map(\(name) {
+    make_jaccard_matrix(
+      celltype_df, 
+      "cluster", 
+      glue::glue("{name}_celltype_annotation")
+    )}) |>
+  purrr::set_names(available_celltypes)
+
+# how many unique cell types?
+n_celltypes <- jaccard_submitter_matrices |>
+  purrr::map(colnames) |> 
+  unlist() |> 
+  length()
+
 if (has_singler) {
   jaccard_submitter_matrices[["SingleR"]] <- make_jaccard_matrix(
     celltype_df, 
@@ -354,14 +366,13 @@ heatmap_height <- n_celltypes / 4.5
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
-# create_heatmap(
-#   jaccard_submitter_matrices, 
-#   column_title = "Submitted-provided annotations",
-#   labels_font_size = find_label_size(jaccard_submitter_matrices),
-#   column_names_angle = 45
-# )
-# 
-# draw_heatmap
+jaccard_submitter_matrices |>
+  create_heatmap_list(
+    column_title = "Submitted-provided annotations", 
+    labels_font_size = find_label_size(jaccard_submitter_matrices), 
+    column_names_angle = 90
+  ) |>
+  draw_heatmap()
 ```
 
 
@@ -395,34 +406,16 @@ labels_font_size <- find_label_size(
   extract_names = FALSE
 )
 
-ComplexHeatmap::Heatmap(
-  singler_cellassign_matrix,
-  col = heatmap_col_fun,
-  border = TRUE, # each heatmap gets its own outline
-  ## Row parameters
-  cluster_rows = FALSE,
+create_single_heatmap(
+  singler_cellassign_matrix, 
   row_title = "SingleR annotations",
-  row_title_side = "right",
-  row_names_side = "left",
-  row_names_gp = grid::gpar(fontsize = labels_font_size),
-  ## Column parameters
-  cluster_columns = FALSE,
-  column_title = "CellAssign annotations",
-  column_names_side = "bottom",
-  column_names_rot = 45,
-  column_names_gp = grid::gpar(fontsize = labels_font_size),
-  ## Legend parameters
-  heatmap_legend_param = list(
-    title = "Jaccard index",
-    direction = "horizontal",
-    legend_width = unit(1.5, "in")
-  ),
-  show_heatmap_legend = TRUE
-) |>
-  # Render the heatmap list
-  ComplexHeatmap::draw(
-    heatmap_legend_side = "bottom"
-  )
+  column_title = "CellAssign annotations", 
+  labels_font_size = labels_font_size, 
+  keep_legend_name = "SingleR annotations",
+  column_names_angle = 90,
+  col_fun = heatmap_col_fun
+  ) |>
+  draw_heatmap()
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -168,10 +168,10 @@ plot_heatmap <- function(matrix_list,
 #'
 #' @return Integer of desired font size
 find_label_size <- function(input_labels, 
-                            extact_names = TRUE) {
+                            extract_names = TRUE) {
   
   # extract colnames if specified
-  if (extact_names) {
+  if (extract_names) {
     input_labels <- input_labels |>
       purrr::map(colnames) |> 
       unlist() 
@@ -183,9 +183,9 @@ find_label_size <- function(input_labels,
 
   labels_font_size <- dplyr::case_when(
     longest_name < 35 ~ 9.5, 
-    dplyr::between(longest_name, 35, 45) ~ 8.5, 
-    dplyr::between(longest_name, 46, 60) ~ 7.5,
-    longest_name > 60 ~ 6.5
+    longest_name < 45 ~ 8.5, 
+    longest_name < 60 ~ 7.5,
+    .default = 6.5
   )
   
   return(labels_font_size)

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -164,10 +164,11 @@ create_single_heatmap <- function(
 #'
 #' @return A list of ComplexHeatmap objects
 create_heatmap_list <- function(matrix_list,
-                              column_title, 
-                              labels_font_size,
-                              column_names_angle = 0,
-                              col_fun = heatmap_col_fun) {
+  column_title, 
+  labels_font_size,
+  column_names_angle = 0,
+  col_fun = heatmap_col_fun
+) {
   
   
   # We only want one shared legend in the end, arbitrarily grab the first one
@@ -191,20 +192,10 @@ create_heatmap_list <- function(matrix_list,
 
 #' Determine the label font size based on nchar of cell type labels
 #'
-#' @param input_labels List of names with column names to query
-#' @param is_list Boolean for whether the `input_labels` is a list, default TRUE.
-#'   When this value is a list, we first need to extract its names before querying them.
-#'   
-#' @return Desired font size numeric
-find_label_size <- function(input_labels, 
-                            is_list = TRUE) {
-  
-  # extract colnames if we have a list
-  if (is_list) {
-    input_labels <- input_labels |>
-      purrr::map(colnames) |> 
-      unlist() 
-  }
+#' @param input_labels Vector of cell type labels
+#' 
+#' @return Font size numeric as determined by longest cell type label
+find_label_size <- function(input_labels) {
   
   longest_name <- input_labels |>
     nchar() |> 
@@ -275,24 +266,22 @@ jaccard_cluster_matrices <- available_celltypes |>
       glue::glue("{name}_celltype_annotation")
     )}) 
 
-n_celltypes <- jaccard_cluster_matrices |>
+unique_celltypes <- jaccard_cluster_matrices |>
   purrr::map(colnames) |> 
-  unlist() |> 
-  length()
+  unlist() 
   
 # set height based on number of celltypes, and add on 2x padding
-# there are no long vertical layers here to accommodate
-heatmap_height <- n_celltypes/6 + 2*heatmap_padding
+# there are no long vertical labels here to accommodate, only cluster names (ints)
+heatmap_height <- length(unique_celltypes)/6 + 2*heatmap_padding
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters", 
-    labels_font_size = find_label_size(jaccard_cluster_matrices)
+    labels_font_size = find_label_size(unique_celltypes)
   ) |>
   ComplexHeatmap::draw(
-    heatmap, 
     heatmap_legend_side = "bottom"
   )
 ```
@@ -332,26 +321,24 @@ jaccard_submitter_matrices <- available_celltypes |>
   purrr::set_names(available_celltypes)
 
 # how many unique cell types?
-n_celltypes <- jaccard_submitter_matrices |>
+unique_celltypes <- jaccard_submitter_matrices |>
   purrr::map(colnames) |> 
-  unlist() |> 
-  length()
+  unlist() 
 
 # Set plot dimensions based on number of cell types plus:
 ## 1x padding
 ## 2" for long labels
-heatmap_height <- n_celltypes/6 + heatmap_padding + 2 
+heatmap_height <- length(unique_celltypes)/6 + heatmap_padding + 2 
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
 jaccard_submitter_matrices |>
   create_heatmap_list(
     column_title = "Submitter-provided annotations", 
-    labels_font_size = find_label_size(jaccard_submitter_matrices), 
+    labels_font_size = find_label_size(unique_celltypes), 
     column_names_angle = 90
   ) |>
   ComplexHeatmap::draw(
-    heatmap, 
     heatmap_legend_side = "bottom"
   )
 ```
@@ -368,8 +355,8 @@ Note that due to different annotations references, these methods may use differe
 ")
 
 # Set plot dimensions based on number of SingleR cell types
-n_celltypes <- length(levels(celltype_df$singler_celltype_annotation))
-heatmap_height <- n_celltypes/4 + 2 
+unique_celltypes <- levels(celltype_df$singler_celltype_annotation)
+heatmap_height <- length(unique_celltypes)/4 + 2 
 ```
 
 
@@ -381,26 +368,19 @@ singler_cellassign_matrix <- make_jaccard_matrix(
   "cellassign_celltype_annotation"
 )
 
-labels_font_size <- find_label_size(
-  c(
-    rownames(singler_cellassign_matrix), 
-    colnames(singler_cellassign_matrix)
-  ), 
-  is_list = FALSE
-)
-
 create_single_heatmap(
   singler_cellassign_matrix, 
   row_title = "SingleR annotations",
   column_title = "CellAssign annotations", 
-  labels_font_size = labels_font_size, 
+  labels_font_size = find_label_size(unique_celltypes), 
   keep_legend_name = "SingleR annotations",
   column_names_angle = 90,
   col_fun = heatmap_col_fun
   ) |>
-  draw_heatmap()
+  ComplexHeatmap::draw(
+    heatmap_legend_side = "bottom"
+  )
 ```
-
 
 ```{r, eval = has_singler | has_cellassign }
 knitr::asis_output("

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -102,20 +102,6 @@ heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateb
 heatmap_padding <- 0.2
 ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(heatmap_padding, "in"))
 
-
-#' Draw a ComplexHeatmap
-#'
-#' @param heatmap A heatmap or list of heatmaps to draw
-#' @param legend_side Side legend appears on, default bottom
-draw_heatmap <- function(heatmap, legend_side = "bottom") {
-  # Render the heatmap or list of heatmaps
-  ComplexHeatmap::draw(
-    heatmap, 
-    heatmap_legend_side = legend_side
-  )
-}
-
-
 #' Create a ComplexHeatmap from a matrix
 #'
 #' @param mat Matrix to create heatmap from.
@@ -305,7 +291,10 @@ jaccard_cluster_matrices |>
     column_title = "Clusters", 
     labels_font_size = find_label_size(jaccard_cluster_matrices)
   ) |>
-  draw_heatmap()
+  ComplexHeatmap::draw(
+    heatmap, 
+    heatmap_legend_side = "bottom"
+  )
 ```
 
 
@@ -361,7 +350,10 @@ jaccard_submitter_matrices |>
     labels_font_size = find_label_size(jaccard_submitter_matrices), 
     column_names_angle = 90
   ) |>
-  draw_heatmap()
+  ComplexHeatmap::draw(
+    heatmap, 
+    heatmap_legend_side = "bottom"
+  )
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -99,7 +99,8 @@ make_jaccard_matrix <- function(celltype_df, colname1, colname2){
 heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
 
 # Set heatmap padding option
-ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
+heatmap_padding <- 0.2
+ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(heatmap_padding, "in"))
 
 
 #' Draw a ComplexHeatmap
@@ -286,14 +287,14 @@ jaccard_cluster_matrices <- available_celltypes |>
     )}) |>
   purrr::set_names(available_celltypes)
 
-# TODO: incorporate this
 n_celltypes <- jaccard_cluster_matrices |>
   purrr::map(colnames) |> 
   unlist() |> 
   length()
   
-# set height based on number of matrices
-heatmap_height <- length(jaccard_cluster_matrices) * 2.5
+# set height based on number of celltypes, and add on 2x padding
+# there are no long vertical layers here to accommodate
+heatmap_height <- n_celltypes/6 + 2*heatmap_padding
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
@@ -304,8 +305,6 @@ jaccard_cluster_matrices |>
   ) |>
   draw_heatmap()
 ```
-
-
 
 
 
@@ -335,9 +334,10 @@ jaccard_submitter_matrices <- available_celltypes |>
   purrr::map(\(name) {
     make_jaccard_matrix(
       celltype_df, 
-      "cluster", 
+      "submitter_celltype_annotation", 
       glue::glue("{name}_celltype_annotation")
-    )}) |>
+    )
+  }) |>
   purrr::set_names(available_celltypes)
 
 # how many unique cell types?
@@ -346,36 +346,23 @@ n_celltypes <- jaccard_submitter_matrices |>
   unlist() |> 
   length()
 
-if (has_singler) {
-  jaccard_submitter_matrices[["SingleR"]] <- make_jaccard_matrix(
-    celltype_df, 
-    "submitter_celltype_annotation", 
-    "singler_celltype_annotation"
-  )
-  n_celltypes <- n_celltypes + length(unique(celltype_df$singler_celltype_annotation))
-}
-if (has_cellassign) {
-  jaccard_submitter_matrices[["CellAssign"]] <- make_jaccard_matrix(
-    celltype_df, 
-    "submitter_celltype_annotation", 
-    "cellassign_celltype_annotation"
-  )
-  n_celltypes <- n_celltypes + length(unique(celltype_df$cellassign_celltype_annotation))
-}
-
-# Set plot dimensions based on number of cell types
-heatmap_height <- n_celltypes / 4.5
+# Set plot dimensions based on number of cell types plus:
+## 1x padding
+## 2" for long labels
+heatmap_height <- n_celltypes/6 + heatmap_padding + 2 
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
 jaccard_submitter_matrices |>
   create_heatmap_list(
-    column_title = "Submitted-provided annotations", 
+    column_title = "Submitter-provided annotations", 
     labels_font_size = find_label_size(jaccard_submitter_matrices), 
     column_names_angle = 90
   ) |>
   draw_heatmap()
 ```
+
+
 
 
 ```{r, eval = has_cellassign & has_singler, fig.height=7, fig.width=8}
@@ -386,8 +373,9 @@ This section displays a heatmap directly comparing `SingleR` and `CellAssign` ce
 Note that due to different annotations references, these methods may use different names for similar cell types.
 ")
 
-# Set plot dimensions based on number of SingleR types
-heatmap_height <- length(levels(celltype_df$singler_celltype_annotation)) / 3.5
+# Set plot dimensions based on number of SingleR cell types
+n_celltypes <- length(levels(celltype_df$singler_celltype_annotation))
+heatmap_height <- n_celltypes/4 + 2 
 ```
 
 
@@ -400,7 +388,6 @@ singler_cellassign_matrix <- make_jaccard_matrix(
 )
 
 labels_font_size <- find_label_size(
-  # simply provide the vector for this heatmap since its not a list
   c(
     rownames(singler_cellassign_matrix), 
     colnames(singler_cellassign_matrix)

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -3,7 +3,6 @@ params:
   library: Example
   processed_sce: NULL
   date: !r Sys.Date()
-
 title: "`r glue::glue('ScPCA Cell type annotation supplemental QC report for {params$library}')`"
 author: "Childhood Cancer Data Lab"
 date: "`r params$date`"
@@ -41,7 +40,7 @@ theme_set(
 
 ```
 
-<!-- Define helper functions for calculating Jaccard similarity matrices --> 
+<!-- Define helper functions for calculating Jaccard matrices --> 
 ```{r}
 #' Function to calculate Jaccard similarity on two vectors
 #'
@@ -93,6 +92,7 @@ make_jaccard_matrix <- function(celltype_df, colname1, colname2){
 }
 ```
 
+
 <!-- Define variables, options, and function for plotting heatmap from list of matrices --> 
 ```{r}
 # Define color ramp for shared use in the heatmap
@@ -104,19 +104,23 @@ ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
 #' Function to plot a ComplexHeatmap
 #'
 #' @param matrix_list List of matrices to plot in a vertical layout. 
-#' @param col_fun Color function for the heatmap palette
 #' @param column_title Title to use for columns, shared among all heatmaps
+#' @param column_names_angle Angle for column names
+#' @param labels_font_size Font size to use for rows and column labels.
+#' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`
 #'
 #' @return Draws a ComplexHeatmap, but does not explicitly return anything
 plot_heatmap <- function(matrix_list,
                          column_title, 
+                         column_names_angle = 0,
+                         labels_font_size,
                          col_fun = heatmap_col_fun) {
   
   
   # We only want one shared legend in the end, arbitrarily grab the first one
   keep_legend_name <- names(matrix_list)[1]
 
-  heatmap_list <- jaccard_cluster_matrices |> 
+  heatmap_list <- matrix_list |> 
     purrr::imap(\(mat, name){
       ComplexHeatmap::Heatmap(
         t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
@@ -128,16 +132,16 @@ plot_heatmap <- function(matrix_list,
         row_title_gp = grid::gpar(fontsize = 10), 
         row_title_side = "right",
         row_names_side = "left",
-        row_names_gp = grid::gpar(fontsize = 8),
+        row_names_gp = grid::gpar(fontsize = labels_font_size),
         ## Column parameters
         cluster_columns = FALSE,
         column_title = column_title,
-        column_names_side = "top",
-        column_names_rot = 0,
-        column_names_gp = grid::gpar(fontsize = 8), # match row name size
+        column_names_side = "bottom",
+        column_names_rot = column_names_angle,
+        column_names_gp = grid::gpar(fontsize = labels_font_size),
         ## Legend parameters
         heatmap_legend_param = list(
-          title = "Jaccard similarity index",
+          title = "Jaccard index",
           direction = "horizontal",
           legend_width = unit(1.5, "in")
         ),
@@ -152,12 +156,40 @@ plot_heatmap <- function(matrix_list,
   # Render the heatmap list
   ComplexHeatmap::draw(
     heatmap_list, 
-    heatmap_legend_side = "bottom" 
+    heatmap_legend_side = "bottom"
   )
   
 }
 
 
+#' Determine the label font size based on nchar of cell type labels
+#'
+#' @param matrix_list List of names with column names to query
+#'
+#' @return Integer of desired font size
+find_label_size <- function(input_labels, 
+                            extact_names = TRUE) {
+  
+  # extract colnames if specified
+  if (extact_names) {
+    input_labels <- input_labels |>
+      purrr::map(colnames) |> 
+      unlist() 
+  }
+  
+  longest_name <- input_labels |>
+    nchar() |> 
+    max()
+
+  labels_font_size <- dplyr::case_when(
+    longest_name < 35 ~ 9.5, 
+    dplyr::between(longest_name, 35, 45) ~ 8.5, 
+    dplyr::between(longest_name, 46, 60) ~ 7.5,
+    longest_name > 60 ~ 6.5
+  )
+  
+  return(labels_font_size)
+}
 ```
 
 
@@ -180,7 +212,7 @@ celltype_df <- create_celltype_df(processed_sce)
 
 This section displays heatmaps comparing cell labels from various methods. 
 
-We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between pairs of labels from different methods.
+We use the [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between pairs of labels from different methods.
 
 The Jaccard index reflects the degree of overlap between the two labels and ranges from 0 to 1. 
 
@@ -221,11 +253,19 @@ if (has_cellassign) {
 }
 
 
+# set height based on number of matrices
 heatmap_height <- length(jaccard_cluster_matrices) * 2.5
+
+
+
 ```
 
-```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
-plot_heatmap(jaccard_cluster_matrices, "Clusters")
+```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
+plot_heatmap(
+  jaccard_cluster_matrices, 
+  column_title = "Clusters", 
+  labels_font_size = find_label_size(jaccard_cluster_matrices)
+)
 ```
 
 
@@ -250,11 +290,11 @@ knitr::asis_output(
 
 ```{r}
 # Calculate all jaccard matrices of interest for input to next heatmap
-jaccard_cluster_matrices <- list()
+jaccard_submitter_matrices <- list()
 
 n_celltypes <- 0 
 if (has_singler) {
-  jaccard_cluster_matrices[["SingleR"]] <- make_jaccard_matrix(
+  jaccard_submitter_matrices[["SingleR"]] <- make_jaccard_matrix(
     celltype_df, 
     "submitter_celltype_annotation", 
     "singler_celltype_annotation"
@@ -262,7 +302,7 @@ if (has_singler) {
   n_celltypes <- n_celltypes + length(unique(celltype_df$singler_celltype_annotation))
 }
 if (has_cellassign) {
-  jaccard_cluster_matrices[["CellAssign"]] <- make_jaccard_matrix(
+  jaccard_submitter_matrices[["CellAssign"]] <- make_jaccard_matrix(
     celltype_df, 
     "submitter_celltype_annotation", 
     "cellassign_celltype_annotation"
@@ -270,12 +310,17 @@ if (has_cellassign) {
   n_celltypes <- n_celltypes + length(unique(celltype_df$cellassign_celltype_annotation))
 }
 
-# Set plot dimensions, this time based on number of cell types that will be shown
-heatmap_height <- n_celltypes / 6
+# Set plot dimensions based on number of cell types
+heatmap_height <- n_celltypes / 4.5
 ```
 
-```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
-plot_heatmap(jaccard_cluster_matrices, "Submitter-provided annotations")
+```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
+plot_heatmap(
+  jaccard_submitter_matrices, 
+  column_title = "Submitted-provided annotations",
+  labels_font_size = find_label_size(jaccard_submitter_matrices),
+  column_names_angle = 45
+)
 ```
 
 
@@ -286,16 +331,57 @@ knitr::asis_output("
 This section displays a heatmap directly comparing `SingleR` and `CellAssign` cell type annotations.
 Note that due to different annotations references, these methods may use different names for similar cell types.
 ")
+
+# Set plot dimensions based on number of SingleR types
+heatmap_height <- length(levels(celltype_df$singler_celltype_annotation)) / 3.5
 ```
 
 
-```{r, eval = has_cellassign & has_singler}
-# Calculate all jaccard matrices of interest for input to next heatmap
+```{r, eval = has_cellassign & has_singler, fig.height = heatmap_height, fig.width = 8.5}
+# Calculate jaccard matrix
 singler_cellassign_matrix <- make_jaccard_matrix(
   celltype_df, 
   "singler_celltype_annotation",
   "cellassign_celltype_annotation"
 )
+
+labels_font_size <- find_label_size(
+  # simply provide the vector for this heatmap since its not a list
+  c(
+    rownames(singler_cellassign_matrix), 
+    colnames(singler_cellassign_matrix)
+  ), 
+  extact_names = FALSE
+)
+
+ComplexHeatmap::Heatmap(
+  singler_cellassign_matrix,
+  col = heatmap_col_fun,
+  border = TRUE, # each heatmap gets its own outline
+  ## Row parameters
+  cluster_rows = FALSE,
+  row_title = "SingleR annotations",
+  row_title_side = "right",
+  row_names_side = "left",
+  row_names_gp = grid::gpar(fontsize = labels_font_size),
+  ## Column parameters
+  cluster_columns = FALSE,
+  column_title = "CellAssign annotations",
+  column_names_side = "bottom",
+  column_names_rot = 45,
+  column_names_gp = grid::gpar(fontsize = labels_font_size),
+  ## Legend parameters
+  heatmap_legend_param = list(
+    title = "Jaccard index",
+    direction = "horizontal",
+    legend_width = unit(1.5, "in")
+  ),
+  show_heatmap_legend = TRUE
+) |>
+  # Render the heatmap list
+  ComplexHeatmap::draw(
+    heatmap_legend_side = "bottom"
+  )
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -247,7 +247,36 @@ knitr::asis_output(
   This section displays heatmaps comparing submitter-provided cell type annotations to those obtained from {methods_string}."
   )
 )
+```
 
+```{r}
+# Calculate all jaccard matrices of interest for input to next heatmap
+jaccard_cluster_matrices <- list()
+
+n_celltypes <- 0 
+if (has_singler) {
+  jaccard_cluster_matrices[["SingleR"]] <- make_jaccard_matrix(
+    celltype_df, 
+    "submitter_celltype_annotation", 
+    "singler_celltype_annotation"
+  )
+  n_celltypes <- n_celltypes + length(unique(celltype_df$singler_celltype_annotation))
+}
+if (has_cellassign) {
+  jaccard_cluster_matrices[["CellAssign"]] <- make_jaccard_matrix(
+    celltype_df, 
+    "submitter_celltype_annotation", 
+    "cellassign_celltype_annotation"
+  )
+  n_celltypes <- n_celltypes + length(unique(celltype_df$cellassign_celltype_annotation))
+}
+
+# Set plot dimensions, this time based on number of cell types that will be shown
+heatmap_height <- n_celltypes / 6
+```
+
+```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
+plot_heatmap(jaccard_cluster_matrices, "Submitter-provided annotations")
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -202,14 +202,16 @@ create_heatmap_list <- function(matrix_list,
 
 #' Determine the label font size based on nchar of cell type labels
 #'
-#' @param matrix_list List of names with column names to query
-#'
-#' @return Integer of desired font size
+#' @param input_labels List of names with column names to query
+#' @param is_list Boolean for whether the `input_labels` is a list, default TRUE.
+#'   When this value is a list, we first need to extract its names before querying them.
+#'   
+#' @return Desired font size numeric
 find_label_size <- function(input_labels, 
-                            extract_names = TRUE) {
+                            is_list = TRUE) {
   
-  # extract colnames if specified
-  if (extract_names) {
+  # extract colnames if we have a list
+  if (is_list) {
     input_labels <- input_labels |>
       purrr::map(colnames) |> 
       unlist() 
@@ -403,7 +405,7 @@ labels_font_size <- find_label_size(
     rownames(singler_cellassign_matrix), 
     colnames(singler_cellassign_matrix)
   ), 
-  extract_names = FALSE
+  is_list = FALSE
 )
 
 create_single_heatmap(

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -190,7 +190,7 @@ create_heatmap_list <- function(matrix_list,
 }
 
 
-#' Determine the label font size based on nchar of cell type labels
+#' Determine the label font size based on # characters in cell type labels
 #'
 #' @param input_labels Vector of cell type labels
 #' 
@@ -198,7 +198,7 @@ create_heatmap_list <- function(matrix_list,
 find_label_size <- function(input_labels) {
   
   longest_name <- input_labels |>
-    nchar() |> 
+    stringr::str_length() |> 
     max()
 
   labels_font_size <- dplyr::case_when(
@@ -209,6 +209,37 @@ find_label_size <- function(input_labels) {
   )
   
   return(labels_font_size)
+}
+```
+
+
+```{r}
+#' Function to calculate optimal heatmap plot view height
+#'
+#' @param row_names Vector of rownames
+#' @param col_names Vector of column names
+#' @param n_spacers Number of spacers between stacked heatmaps
+#' @param spacer_size Spacer size in inches
+#'
+#' @return Heatmap height in inches
+calculate_plot_height <- function(row_names, 
+                                  col_names, 
+                                  n_spacers,
+                                  spacer_size = heatmap_padding) {
+  
+  # first, based on number of cells in row_names:
+  #   6 cell types to an inch
+  heat_height <- length(row_names)/6
+
+  # next, based on nchar of col_names:
+  #   10 characters to an inch
+  # using stringr::str_length() in case col_names is a factor vector
+  heat_height <- heat_height + max(stringr::str_length(col_names))/10
+
+  # finally, add in any padding  
+  heat_height <- heat_height + n_spacers*spacer_size
+  
+  return(heat_height)
 }
 ```
 
@@ -266,20 +297,22 @@ jaccard_cluster_matrices <- available_celltypes |>
       glue::glue("{name}_celltype_annotation")
     )}) 
 
-unique_celltypes <- jaccard_cluster_matrices |>
+all_celltypes <- jaccard_cluster_matrices |>
   purrr::map(colnames) |> 
   unlist() 
   
-# set height based on number of celltypes, and add on 2x padding
-# there are no long vertical labels here to accommodate, only cluster names (ints)
-heatmap_height <- length(unique_celltypes)/6 + 2*heatmap_padding
+heatmap_height <- calculate_plot_height(
+  all_celltypes, 
+  unique(celltype_df$cluster),
+  2
+)
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters", 
-    labels_font_size = find_label_size(unique_celltypes)
+    labels_font_size = find_label_size(all_celltypes)
   ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"
@@ -320,22 +353,23 @@ jaccard_submitter_matrices <- available_celltypes |>
   }) |>
   purrr::set_names(available_celltypes)
 
-# how many unique cell types?
-unique_celltypes <- jaccard_submitter_matrices |>
+# how many cell types?
+all_celltypes <- jaccard_submitter_matrices |>
   purrr::map(colnames) |> 
   unlist() 
 
-# Set plot dimensions based on number of cell types plus:
-## 1x padding
-## 2" for long labels
-heatmap_height <- length(unique_celltypes)/6 + heatmap_padding + 2 
+heatmap_height <- calculate_plot_height(
+  all_celltypes, 
+  unique(celltype_df$submitter_celltype_annotation),
+  1
+)
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
 jaccard_submitter_matrices |>
   create_heatmap_list(
     column_title = "Submitter-provided annotations", 
-    labels_font_size = find_label_size(unique_celltypes), 
+    labels_font_size = find_label_size(all_celltypes), 
     column_names_angle = 90
   ) |>
   ComplexHeatmap::draw(
@@ -355,12 +389,17 @@ Note that due to different annotations references, these methods may use differe
 ")
 
 # Set plot dimensions based on number of SingleR cell types
-unique_celltypes <- levels(celltype_df$singler_celltype_annotation)
-heatmap_height <- length(unique_celltypes)/4 + 2 
+all_celltypes <- levels(celltype_df$singler_celltype_annotation)
+heatmap_height <- calculate_plot_height(
+  unique(celltype_df$singler_celltype_annotation),
+  unique(celltype_df$cellassign_celltype_annotation),
+  0
+)
 ```
 
 
 ```{r, eval = has_cellassign & has_singler, fig.height = heatmap_height, fig.width = 8.5}
+
 # Calculate jaccard matrix
 singler_cellassign_matrix <- make_jaccard_matrix(
   celltype_df, 
@@ -372,7 +411,7 @@ create_single_heatmap(
   singler_cellassign_matrix, 
   row_title = "SingleR annotations",
   column_title = "CellAssign annotations", 
-  labels_font_size = find_label_size(unique_celltypes), 
+  labels_font_size = find_label_size(all_celltypes), 
   keep_legend_name = "SingleR annotations",
   column_names_angle = 90,
   col_fun = heatmap_col_fun

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -93,6 +93,74 @@ make_jaccard_matrix <- function(celltype_df, colname1, colname2){
 }
 ```
 
+<!-- Define variables, options, and function for plotting heatmap from list of matrices --> 
+```{r}
+# Define color ramp for shared use in the heatmap
+heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
+
+# Set heatmap padding option
+ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
+
+#' Function to plot a ComplexHeatmap
+#'
+#' @param matrix_list List of matrices to plot in a vertical layout. 
+#' @param col_fun Color function for the heatmap palette
+#' @param column_title Title to use for columns, shared among all heatmaps
+#'
+#' @return Draws a ComplexHeatmap, but does not explicitly return anything
+plot_heatmap <- function(matrix_list,
+                         column_title, 
+                         col_fun = heatmap_col_fun) {
+  
+  
+  # We only want one shared legend in the end, arbitrarily grab the first one
+  keep_legend_name <- names(matrix_list)[1]
+
+    
+  heatmap_list <- jaccard_cluster_matrices |> 
+    purrr::imap(\(mat, name){
+      ComplexHeatmap::Heatmap(
+        t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
+        col = col_fun,
+        border = TRUE, # each heatmap gets its own outline
+        ## Row parameters
+        cluster_rows = FALSE,
+        row_title = name, # each heatmap gets its own title
+        row_title_gp = grid::gpar(fontsize = 10), 
+        row_title_side = "right",
+        row_names_side = "left",
+        row_names_gp = grid::gpar(fontsize = 8),
+        ## Column parameters
+        cluster_columns = FALSE,
+        column_title = column_title,
+        column_names_side = "top",
+        column_names_rot = 0,
+        column_names_gp = grid::gpar(fontsize = 8), # match row name size
+        ## Legend parameters
+        heatmap_legend_param = list(
+          title = "Jaccard similarity index",
+          direction = "horizontal",
+          legend_width = unit(1.5, "in")
+        ),
+        # Retain only 1 legend in the final plot      
+        show_heatmap_legend = name == keep_legend_name,
+      )
+    }) |>
+    # concatenate vertically into HeatmapList object
+    purrr::reduce(ComplexHeatmap::`%v%`) 
+  
+  
+  # Render the heatmap list
+  ComplexHeatmap::draw(
+    heatmap_list, 
+    heatmap_legend_side = "bottom" 
+  )
+  
+}
+
+
+```
+
 
 ```{r, message = FALSE, warning = FALSE, echo = FALSE}
 # define library and sce object
@@ -158,54 +226,7 @@ heatmap_height <- length(jaccard_cluster_matrices) * 2.5
 ```
 
 ```{r, fig.height = heatmap_height, fig.width = 7, warning = FALSE}
-# Define color ramp for shared use in the heatmap
-col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
-
-# We only want one shared legend in the end, arbitrarily grab the first one
-keep_legend_name <- names(jaccard_cluster_matrices)[1]
-
-# Set heatmap padding option
-ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(0.2, "in"))
-
-# TODO: make this into a function so can re-use for 2nd group of heatmaps (still forthcoming)
-heatmap_list <- jaccard_cluster_matrices |> 
-  purrr::imap(\(mat, name){
-    ComplexHeatmap::Heatmap(
-      t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
-      col = col_fun,
-      border = TRUE, # each heatmap gets its own outline
-      ## Row parameters
-      cluster_rows = FALSE,
-      row_title = name, # each heatmap gets its own title
-      row_title_gp = grid::gpar(fontsize = 10), 
-      row_title_side = "right",
-      row_names_side = "left",
-      row_names_gp = grid::gpar(fontsize = 8),
-      ## Column parameters
-      cluster_columns = FALSE,
-      column_title = glue::glue("Cluster"),
-      column_names_side = "top",
-      column_names_rot = 0,
-      column_names_gp = grid::gpar(fontsize = 8), # match row name size
-      ## Legend parameters
-      heatmap_legend_param = list(
-        title = "Jaccard similarity index",
-        direction = "horizontal",
-        legend_width = unit(1.5, "in")
-      ),
-      # Retain only 1 legend in the final plot      
-      show_heatmap_legend = name == keep_legend_name,
-    )
-  }) |>
-  # concatenate vertically into HeatmapList object
-  purrr::reduce(ComplexHeatmap::`%v%`) 
-
-
-# Render the heatmap list
-ComplexHeatmap::draw(
-  heatmap_list, 
-  heatmap_legend_side = "bottom" 
-)
+plot_heatmap(jaccard_cluster_matrices, "Clusters")
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -176,12 +176,15 @@ create_heatmap_list <- function(matrix_list,
 
   heatmap_list <- matrix_list |> 
     purrr::imap(
-      create_single_heatmap, 
-      column_title, 
-      labels_font_size,
-      keep_legend_name,
-      column_names_angle = column_names_angle,
-      col_fun = col_fun
+      \(mat, name) create_single_heatmap(
+        mat,
+        name,
+        column_title, 
+        labels_font_size,
+        keep_legend_name,
+        col_fun,
+        ...
+      )
     ) |>
     # concatenate vertically into HeatmapList object
     purrr::reduce(ComplexHeatmap::`%v%`) 
@@ -304,7 +307,7 @@ all_celltypes <- jaccard_cluster_matrices |>
 heatmap_height <- calculate_plot_height(
   all_celltypes, 
   unique(celltype_df$cluster),
-  2
+  length(jaccard_cluster_matrices) - 1
 )
 ```
 
@@ -361,7 +364,7 @@ all_celltypes <- jaccard_submitter_matrices |>
 heatmap_height <- calculate_plot_height(
   all_celltypes, 
   unique(celltype_df$submitter_celltype_annotation),
-  1
+  length(jaccard_submitter_matrices) - 1 
 )
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -109,8 +109,8 @@ ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(heatmap_padding, "in"))
 #' @param column_title Label for column title.
 #' @param labels_font_size Font size to use for rows and column labels.
 #' @param keep_legend_name The name to use in the legend
-#' @param column_names_angle Angle for column names. Default is 0.
 #' @param col_fun Color function for the heatmap palette. Default is `heatmap_col_fun`.
+#' @param ... Additional arguments to pass to `ComplexHeatmap::Heatmap()`
 #' 
 #' @return A ComplexHeatmap object
 create_single_heatmap <- function(
@@ -119,8 +119,8 @@ create_single_heatmap <- function(
   column_title, 
   labels_font_size,
   keep_legend_name,
-  column_names_angle = 0,
-  col_fun = heatmap_col_fun
+  col_fun = heatmap_col_fun,
+  ...
 ) {
   
   heat <- ComplexHeatmap::Heatmap(
@@ -139,8 +139,9 @@ create_single_heatmap <- function(
     column_title = column_title,
     column_title_gp = grid::gpar(fontsize = 10), 
     column_names_side = "bottom",
-    column_names_rot = column_names_angle,
     column_names_gp = grid::gpar(fontsize = labels_font_size),
+    ### passed in args
+    ...,
     ## Legend parameters
     heatmap_legend_param = list(
       title = "Jaccard index",
@@ -159,15 +160,16 @@ create_single_heatmap <- function(
 #' @param matrix_list List of matrices to plot in a vertical layout. 
 #' @param column_title Title to use for columns, shared among all heatmaps
 #' @param labels_font_size Font size to use for rows and column labels.
-#' @param column_names_angle Angle for column names. Default is 0.
 #' @param col_fun Color function for the heatmap palette. Default is `heatmat_col_fun`.
+#' @param ... Additional arguments to pass to `ComplexHeatmap::Heatmap()`
 #'
 #' @return A list of ComplexHeatmap objects
-create_heatmap_list <- function(matrix_list,
+create_heatmap_list <- function(
+  matrix_list,
   column_title, 
   labels_font_size,
-  column_names_angle = 0,
-  col_fun = heatmap_col_fun
+  col_fun = heatmap_col_fun,
+  ...
 ) {
   
   
@@ -315,7 +317,9 @@ heatmap_height <- calculate_plot_height(
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters", 
-    labels_font_size = find_label_size(all_celltypes)
+    labels_font_size = find_label_size(all_celltypes),
+    ## additional arguments
+    column_names_rot = 0
   ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"
@@ -373,7 +377,8 @@ jaccard_submitter_matrices |>
   create_heatmap_list(
     column_title = "Submitter-provided annotations", 
     labels_font_size = find_label_size(all_celltypes), 
-    column_names_angle = 90
+    # additional arguments
+    column_names_rot = 90
   ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"
@@ -416,8 +421,9 @@ create_single_heatmap(
   column_title = "CellAssign annotations", 
   labels_font_size = find_label_size(all_celltypes), 
   keep_legend_name = "SingleR annotations",
-  column_names_angle = 90,
-  col_fun = heatmap_col_fun
+  col_fun = heatmap_col_fun,
+  # additional arguments
+  column_names_rot = 90
   ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"


### PR DESCRIPTION
Ever towards #516 

More heatmaps, and please enjoy the branch name, and if you don't enjoy the branch name, it means you still need to see _Zoolander_.


### Changes in this PR

1. Heatmap function has been implemented
2. Although I use the heatmap function for the first two heatmaps, I don't for the third (directly comparing singler-cellassign) since it is not a list of stacked heatmaps.
    - If we want, I can create a 2nd function to just make a heatmap from 1 matrix and call it from the current function. This would modularize the code further; let me know if we want to see this happen! I didn't do it (yet?) since this heatmap seemed sufficiently different that it might be fine to not use the function.
3. I realized that I have been developing this with unrealistic submitter labels - they have just been single letters! We need to allow for longer names, so I updated my test data to use long names to see what needed to change. Changes were:
    - I moved heatmap column labels to the bottom, but kept the column title at the top for spacing.
    - I wrote a function to more dynamically determine the right font size based on the label `nchar`
    - I allow for column labels to now be at an angle
4. Smaller change, I updated text to say "Jaccard ~similarity~ index" all around. Shorter and consistent with the wikipedia link.


For this round, I'm attaching the full report since there are really 3 heatmaps to look at given the changes I've made.
[celltypes_supplemental_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/13228985/celltypes_supplemental_report.html.zip)

Again, we expect 1 more PR with textual updates (note I may bundle those with #514 text updates).