### PR TITLE
Make sure that AnnData conversion is skipped for any library with cell hashing

### DIFF
--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -55,10 +55,10 @@ if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))) {
 # sure that the sce that is getting converted to AnnData is compliant with CZI
 # CZI 3.0.0 requirements: https://github.com/chanzuckerberg/single-cell-curation/blob/b641130fe53b8163e50c39af09ee3fcaa14c5ea7/schema/3.0.0/schema.md
 format_czi <- function(sce) {
-  
+
   # add schema version
   metadata(sce)$schema_version = "3.0.0"
-  
+
   # add library_id as an sce colData column
   # need this column to join in the sample metadata with the colData
   sce$library_id <- metadata(sce)$library_id
@@ -136,15 +136,23 @@ if (!is.null(opt$feature_name)) {
   # extract altExp
   alt_sce <- altExp(sce, opt$feature_name)
 
-  # add sample metadata from main sce to alt sce metadata
-  metadata(alt_sce)$sample_metadata <- sample_metadata
+  # only convert altExp with > 1 rows
+  if(nrows(alt_sce) > 1){
 
-  # make sce czi compliant
-  alt_sce <- format_czi(alt_sce)
+    # add sample metadata from main sce to alt sce metadata
+    metadata(alt_sce)$sample_metadata <- sample_metadata
 
-  # export altExp sce as anndata object
-  scpcaTools::sce_to_anndata(
-    alt_sce,
-    anndata_file = opt$output_feature_h5
-  )
+    # make sce czi compliant
+    alt_sce <- format_czi(alt_sce)
+
+    # export altExp sce as anndata object
+    scpcaTools::sce_to_anndata(
+      alt_sce,
+      anndata_file = opt$output_feature_h5
+    )
+  } else {
+    # warn that the altExp cannot be converted
+    message(glue::glue("Only 1 row found in altExp named: {feature_name}.
+                       This altExp will not be converted to an AnnData object."))
+  }
 }

--- a/main.nf
+++ b/main.nf
@@ -224,10 +224,17 @@ workflow {
   // generate QC reports and publish .rds files with SCEs.
   sce_qc_report(cluster_sce.out, report_template_tuple)
 
+  // because we have some libraries that have cell hashing, but don't need multiplexing
+  // only 1 sample per library, we need to create a separate list of all the libraries
+  // that contain cell hashing, these will not go through anndata conversion
+  cellhash_libs = runs_ch.feature
+    .filter{it.technology in cellhash_techs}
+    .collect{it.library_id}
+
   // convert SCE object to anndata
   anndata_ch = sce_qc_report.out.data
-    // skip multiplexed libraries
-    .filter{!(it[0]["library_id"] in multiplex_libs.getVal())}
+    // skip cell hashed libraries
+    .filter{!(it[0]["library_id"] in cellhash_libs.getVal())}
   sce_to_anndata(anndata_ch)
 
    // **** Process Spatial Transcriptomics data ****

--- a/main.nf
+++ b/main.nf
@@ -224,17 +224,10 @@ workflow {
   // generate QC reports and publish .rds files with SCEs.
   sce_qc_report(cluster_sce.out, report_template_tuple)
 
-  // because we have some libraries that have cell hashing, but don't need multiplexing
-  // only 1 sample per library, we need to create a separate list of all the libraries
-  // that contain cell hashing, these will not go through anndata conversion
-  cellhash_libs = runs_ch.feature
-    .filter{it.technology in cellhash_techs}
-    .collect{it.library_id}
-
   // convert SCE object to anndata
   anndata_ch = sce_qc_report.out.data
-    // skip cell hashed libraries
-    .filter{!(it[0]["library_id"] in cellhash_libs.getVal())}
+    // skip multiplexed libraries
+    .filter{!(it[0]["library_id"] in multiplex_libs.getVal())}
   sce_to_anndata(anndata_ch)
 
    // **** Process Spatial Transcriptomics data ****


### PR DESCRIPTION
When running the multiplexed project through the workflow, I noticed that one of the libraries was still getting converted to AnnData, even though it has a cell hashing library. This then threw an error in the actual conversion process which we want to avoid. This library was still around because even though it has a cell hashing library, it's not actually multiple samples, so it doesn't get categorized as a `multiplex_libs`. So then it's not filtered out. 

Here, I created a separate list of all libraries that have cell hashing even if they aren't multiplexed. I then use that to filter before converting to AnnData. I tested this with the problem library and AnnData conversion was successfully skipped. 