### PR TITLE
Remove cell type section and fix altExp export to AnnData

### DIFF
--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -137,7 +137,7 @@ if (!is.null(opt$feature_name)) {
   alt_sce <- altExp(sce, opt$feature_name)
 
   # only convert altExp with > 1 rows
-  if(nrows(alt_sce) > 1){
+  if(nrow(alt_sce) > 1){
 
     # add sample metadata from main sce to alt sce metadata
     metadata(alt_sce)$sample_metadata <- sample_metadata
@@ -152,7 +152,7 @@ if (!is.null(opt$feature_name)) {
     )
   } else {
     # warn that the altExp cannot be converted
-    message(glue::glue("Only 1 row found in altExp named: {feature_name}.
+    message(glue::glue("Only 1 row found in altExp named: {opt$feature_name}.
                        This altExp will not be converted to an AnnData object."))
   }
 }

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -152,7 +152,11 @@ if (!is.null(opt$feature_name)) {
     )
   } else {
     # warn that the altExp cannot be converted
-    message(glue::glue("Only 1 row found in altExp named: {opt$feature_name}.
-                       This altExp will not be converted to an AnnData object."))
+    message(
+      glue::glue(
+        "Only 1 row found in altExp named: {opt$feature_name}.
+                       This altExp will not be converted to an AnnData object."
+      )
+    )
   }
 }

--- a/templates/qc_report/qc_report.rmd
+++ b/templates/qc_report/qc_report.rmd
@@ -540,12 +540,6 @@ The raw counts from all cells that remain after filtering low quality cells (RNA
 
 ```
 
-<!-- Next section only included if celltype annotations are present -->
-```{r, child='celltypes_qc.rmd', eval = has_celltypes}
-
-```
-
-
 # Session Info
 <details>
 <summary>R session information</summary>


### PR DESCRIPTION
This PR catches a few errors/issues that were in the AnnData release. 

1. Apparently I was using `nrows` instead of `nrow` for checking the number of genes/ features in the `altExp` before exporting to AnnData. R did not like that. 
2. I removed the chunk that reads in the cell type section to the qc report. 

Here's a copy of a report for a library that I tested that has submitter cell types. No more cell type section for now. 

[SCPCL000495_qc.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/13298997/SCPCL000495_qc.html.zip)
