### PR TITLE
Adjust processes to not modify inputs

### DIFF
--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -20,6 +20,11 @@ option_list <- list(
       Must contain a PCA matrix to calculate clusters from."
   ),
   make_option(
+    opt_str = c("-o", "--output_sce_file"),
+    type = "character",
+    help = "Output path for clustered SCE file. Must end in .rds"
+  ),
+  make_option(
     opt_str = c("--pca_name"),
     type = "character",
     default = "PCA",
@@ -92,5 +97,4 @@ if (!opt$pca_name %in% reducedDimNames(sce)) {
 }
 
 # export -------------------
-# we are overwriting the `processed_sce_file` here
-readr::write_rds(sce, opt$processed_sce_file)
+readr::write_rds(sce, opt$output_sce_file)

--- a/bin/cluster_sce.R
+++ b/bin/cluster_sce.R
@@ -70,6 +70,10 @@ if (!file.exists(opt$processed_sce_file)) {
 }
 sce <- readr::read_rds(opt$processed_sce_file)
 
+if (!stringr::str_ends(opt$output_sce_file, ".rds")) {
+  stop("`output_sce_file` must end in .rds")
+}
+
 # only perform clustering if reduced dimension embeddings are present
 # otherwise just return the object
 if (!opt$pca_name %in% reducedDimNames(sce)) {

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -74,7 +74,7 @@ if (!all(stringr::str_ends(
   c(opt$out_filtered_sce_file, opt$out_processed_sce_file),
   ".rds"
 ))) {
-  stop("output file names must end in .rds")
+  stop("Output SCE file names must end in .rds")
 }
 
 

--- a/bin/post_process_sce.R
+++ b/bin/post_process_sce.R
@@ -16,7 +16,12 @@ option_list <- list(
     help = "path to rds file with input sce object to be processed"
   ),
   make_option(
-    opt_str = c("-o", "--output_sce_file"),
+    opt_str = c("-f", "--out_filtered_sce_file"),
+    type = "character",
+    help = "path to output rds file to store updated filtered sce object. Must end in .rds"
+  ),
+  make_option(
+    opt_str = c("-o", "--out_processed_sce_file"),
     type = "character",
     help = "path to output rds file to store processed sce object. Must end in .rds"
   ),
@@ -64,10 +69,14 @@ if (!file.exists(opt$filtered_sce_file)) {
   stop("Missing filtered.rds file")
 }
 
-# check that output file name ends in .rds
-if (!(stringr::str_ends(opt$output_sce_file, ".rds"))) {
-  stop("output file name must end in .rds")
+# check that output file names end in .rds
+if (!all(stringr::str_ends(
+  c(opt$out_filtered_sce_file, opt$out_processed_sce_file),
+  ".rds"
+))) {
+  stop("output file names must end in .rds")
 }
+
 
 # read in filtered rds file
 sce <- readr::read_rds(opt$filtered_sce_file)
@@ -263,8 +272,8 @@ if (length(reducedDimNames(processed_sce)) == 0) {
 
 # Export --------------
 
-# write out _original_ filtered SCE with additional filtering column
-readr::write_rds(sce, opt$filtered_sce_file, compress = "gz")
+# write out  filtered SCE with additional filtering column
+readr::write_rds(sce, opt$out_filtered_sce_file, compress = "gz")
 
 # write out processed SCE
-readr::write_rds(processed_sce, opt$output_sce_file, compress = "gz")
+readr::write_rds(processed_sce, opt$out_processed_sce_file, compress = "gz")

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -50,6 +50,12 @@ There are several flags and/or parameters which you may additionally wish to spe
     + By default, the workflow checks whether each library has existing `alevin-fry` or `salmon` mapping results, and skips mapping for libraries with existing results.
     Using this flag will override that default behavior and repeat mapping even if the given library's results exist.
     + For more implementation details, please refer to the [external instructions](external-instructions.md#repeating-mapping-steps).
+  + `--skip_genetic_demux`: Use this flag to skip genetic demultiplexing, which is turned on by default.
+    + Genetic demultiplexing requires mapping of both bulk and single-cell data, followed by SNP calling and genetic demultiplexing, which can be quite time consuming.
+    + When genetic demultiplexing is skipped, the workflow will still perform cellhash-based demultiplexing, if available for a given library.
+  + `--repeat_genetic_demux`: Use this flag to repeat genetic demultiplexing, even if results already exist.
+    + By default, the workflow checks whether each library has existing genetic demultiplexing results, and skips genetic demultiplexing for libraries with existing results.
+    Using this flag will override that default behavior and repeat genetic demultiplexing even if the given library's results exist.
   + `--perform_celltyping`: Use this flag to perform cell type annotation, which is turned off by default.
   + `--repeat_celltyping`: Use this flag to repeat cell type annotation, even if results already exist.
     + By default, the workflow checks whether each library has existing cell type annotation results for `SingleR` and/or `CellAssign` (depending on references for that library).

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -116,8 +116,9 @@ process fry_quant_feature{
       --use-mtx \
       -t ${task.cpus} \
 
-    # remove large files
-    rm -f ${quant_dir}/*.rad ${quant_dir}/*.bin
+    # copy cmd_info and aux_info to quant directory for tracking
+    cp ${rad_dir}/cmd_info.json ${quant_dir}/cmd_info.json
+    cp -r ${rad_dir}/aux_info ${quant_dir}/aux_info
 
     echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -105,12 +105,12 @@ process fry_quant_feature{
 
     alevin-fry collate \
       --input-dir ${quant_dir} \
-      --rad-dir ${quant_dir} \
+      --rad-dir ${rad_dir} \
       -t ${task.cpus}
 
     alevin-fry quant \
       --input-dir ${quant_dir} \
-      --tg-map ${quant_dir}/t2g.tsv \
+      --tg-map ${rad_dir}/t2g.tsv \
       --resolution ${params.af_resolution} \
       -o ${quant_dir} \
       --use-mtx \

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -89,41 +89,44 @@ process fry_quant_feature{
   tag "${meta.run_id}-features"
   publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
   input:
-    tuple val(meta), path(run_dir), path(barcode_file)
+    tuple val(meta), path(rad_dir), path(barcode_file)
   output:
-    tuple val(meta), path(run_dir)
+    tuple val(meta), path(quant_dir)
   script:
+    quant_dir = rad_dir + '_quant'
     // get meta to write as file
     meta_json = Utils.makeJson(meta)
     """
     alevin-fry generate-permit-list \
-      -i ${run_dir} \
+      -i ${rad_dir} \
       --expected-ori fw \
-      -o ${run_dir} \
+      -o ${quant_dir} \
       --unfiltered-pl ${barcode_file}
 
     alevin-fry collate \
-      --input-dir ${run_dir} \
-      --rad-dir ${run_dir} \
+      --input-dir ${quant_dir} \
+      --rad-dir ${quant_dir} \
       -t ${task.cpus}
 
     alevin-fry quant \
-      --input-dir ${run_dir} \
-      --tg-map ${run_dir}/t2g.tsv \
+      --input-dir ${quant_dir} \
+      --tg-map ${quant_dir}/t2g.tsv \
       --resolution ${params.af_resolution} \
-      -o ${run_dir} \
+      -o ${quant_dir} \
       --use-mtx \
       -t ${task.cpus} \
 
     # remove large files
-    rm ${run_dir}/*.rad ${run_dir}/*.bin
+    rm -f ${quant_dir}/*.rad ${quant_dir}/*.bin
 
-    echo '${meta_json}' > ${run_dir}/scpca-meta.json
+    echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """
   stub:
+    quant_dir = rad_dir + '_quant'
     meta_json = Utils.makeJson(meta)
     """
-    echo '${meta_json}' > ${run_dir}/scpca-meta.json
+    mkdir -p '${quant_dir}'
+    echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """
 }
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -87,8 +87,9 @@ process fry_quant_rna{
       --use-mtx \
       -t ${task.cpus} \
 
-    # remove large files
-    rm -f ${quant_dir}/*.rad ${quant_dir}/*.bin
+    # copy cmd_info and aux_info to quant directory for tracking
+    cp ${rad_dir}/cmd_info.json ${quant_dir}/cmd_info.json
+    cp -r ${rad_dir}/aux_info ${quant_dir}/aux_info
 
     echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -64,9 +64,9 @@ process fry_quant_rna{
     tuple val(meta), path(quant_dir)
 
   script:
+    quant_dir = rad_dir + '_quant'
     // get meta to write as file
     meta_json = Utils.makeJson(meta)
-    quant_dir = rad_dir + "_quant"
     """
     alevin-fry generate-permit-list \
       -i ${rad_dir} \
@@ -93,10 +93,10 @@ process fry_quant_rna{
     echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """
   stub:
+    quant_dir = rad_dir + '_quant'
     meta_json = Utils.makeJson(meta)
-    quant_dir = rad_dir + "_quant"
     """
-    mkdir -p ${quant_dir}
+    mkdir -p '${quant_dir}'
     echo '${meta_json}' > ${quant_dir}/scpca-meta.json
     """
 }

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -163,7 +163,7 @@ workflow bulk_quant_rna {
       .groupTuple(by: 0)
       .map{[
         it[1][0], // meta; relevant data should all be the same by project, so take the first
-        it[2], // salmon directories
+        it[2].sort(), // salmon directories, sorted for consistency (we can do this because there is only one tuple element)
         file(it[1][0].t2g_bulk_path)
       ]}
 

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -6,18 +6,21 @@ process cluster_sce{
   input:
     tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
   output:
-    tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
+    tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(clustered_rds)
   script:
+    clustered_rds = "${processed_rds.baseName}_clustered.rds"
     """
     cluster_sce.R \
       --processed_sce_file ${processed_rds} \
+      --output_sce_file ${clustered_rds} \
       --cluster_algorithm ${params.cluster_algorithm} \
       --cluster_weighting ${params.cluster_weighting} \
       --nearest_neighbors ${params.nearest_neighbors} \
       ${params.seed ? "--random_seed ${params.seed}" : ""}
     """
   stub:
+    clustered_rds = "${processed_rds.baseName}_clustered.rds"
     """
-    touch ${processed_rds}
+    touch ${clustered_rds}
     """
 }

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -205,7 +205,7 @@ process post_process_sce{
     """
     post_process_sce.R \
       --filtered_sce_file ${filtered_rds} \
-      --out_filtered_sce_file ${filtered_rds} \
+      --out_filtered_sce_file ${filter_labeled_rds} \
       --out_processed_sce_file ${processed_rds} \
       --gene_cutoff ${params.gene_cutoff} \
       --n_hvg ${params.num_hvg} \

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -145,21 +145,21 @@ process genetic_demux_sce{
     tuple val(demux_meta), path(vireo_dir),
           val(meta), path(unfiltered_rds), path(filtered_rds)
   output:
-    tuple val(meta), path(unfiltered_rds), path(filtered_rds)
+    tuple val(meta), path(unfiltered_rds), path(demux_rds)
   script:
-    // output will be same as input, with replacement of the filtered_rds file
     // demultiplex results will be added to the SCE object colData
+    demux_rds = "${filtered_rds.baseName}_genetic-demux.rds"
     """
-    mv ${filtered_rds} filtered_nodemux.rds
     add_demux_sce.R \
-      --sce_file filtered_nodemux.rds \
-      --output_sce_file ${filtered_rds} \
+      --sce_file ${filtered_rds} \
+      --output_sce_file ${demux_rds} \
       --library_id ${meta.library_id} \
       --vireo_dir ${vireo_dir}
     """
   stub:
+    demux_rds = "${filtered_rds.baseName}_genetic-demux.rds"
     """
-    touch ${filtered_rds}
+    touch ${demux_rds}
     """
 }
 
@@ -171,23 +171,23 @@ process cellhash_demux_sce{
     tuple val(meta), path(unfiltered_rds), path(filtered_rds)
     path cellhash_pool_file
   output:
-    tuple val(meta), path(unfiltered_rds), path(filtered_rds)
+    tuple val(meta), path(unfiltered_rds), path(demux_rds)
   script:
-    // output will be same as input, with replacement of the filtered_rds file
     // demultiplex results will be added to the SCE object colData
+    demux_rds = "${filtered_rds.baseName}_cellhash-demux.rds"
     """
-    mv ${filtered_rds} filtered_nodemux.rds
     add_demux_sce.R \
-      --sce_file filtered_nodemux.rds \
-      --output_sce_file ${filtered_rds} \
+      --sce_file ${filtered_rds}  \
+      --output_sce_file ${demux_rds} \
       --library_id ${meta.library_id} \
       --cellhash_pool_file ${cellhash_pool_file} \
       --hash_demux \
       --seurat_demux
     """
   stub:
+    demux_rds = "${filtered_rds.baseName}_cellhash-demux.rds"
     """
-    touch ${filtered_rds}
+    touch ${demux_rds}
     """
 }
 
@@ -198,21 +198,25 @@ process post_process_sce{
   input:
     tuple val(meta), path(unfiltered_rds), path(filtered_rds)
   output:
-    tuple val(meta), path(unfiltered_rds), path(filtered_rds), path(processed_rds)
+    tuple val(meta), path(unfiltered_rds), path(filter_labeled_rds), path(processed_rds)
   script:
+    filter_labeled_rds = "${meta.library_id}_filtered_labeled.rds"
     processed_rds = "${meta.library_id}_processed.rds"
     """
     post_process_sce.R \
       --filtered_sce_file ${filtered_rds} \
-      --output_sce_file ${processed_rds} \
+      --out_filtered_sce_file ${filtered_rds} \
+      --out_processed_sce_file ${processed_rds} \
       --gene_cutoff ${params.gene_cutoff} \
       --n_hvg ${params.num_hvg} \
       --n_pcs ${params.num_pcs} \
       ${params.seed ? "--random_seed ${params.seed}" : ""}
     """
   stub:
+    filter_labeled_rds = "${meta.library_id}_filtered_labeled.rds"
     processed_rds = "${meta.library_id}_processed.rds"
     """
+    touch ${filter_labeled_rds}
     touch ${processed_rds}
     """
 }


### PR DESCRIPTION
Closes #480
Closes #505

Here I am changing inputs and outputs for a few different processes to make them different files and/or directories. 
In some cases this was accomplished by modifying the underlying scripts to write out new files rather than overwriting the inputs, which seems safer anyway.

In `fry-quant` processes, I modified the `alevin-fry` steps to copy over relevant `alevin` files into the new directory (keeping the input rad directory separate), rather than deleting `.rad` and `.bin` files.

The other big change is that in `modules/export-anndata.nf` I combined the moving of `logcounts` into the same process as the original anndata export, which saves any renaming and simplifies the workflow a bit (no `mix` needed, and no double-publishing of files). We had originally kept that separate with the idea that R and python could be different, but they are using the same docker image at this point, so it seemed easier to just combine them.

I have done initial checks to be sure the workflow still works as expected, but I am still running the demux version, just for completeness.

There are also a few little doc updates, mostly because I kept using the wrong option names when testing!
