### PR TITLE
Add doctoc to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
         language: fail
         files: '(?i)\.(Rhistory|RData|rds)$'
         # `exclude: <regex>` to allow committing specific files
+  - repo: https://github.com/thlorenz/doctoc
+    # Update TOCs
+    rev: v2.2.0
+    hooks:
+      - id: doctoc
+        args: [--update-only]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff for linting and formatting python
     rev: v0.1.5


### PR DESCRIPTION
Does what it says! 
Set to only update existing TOCs.

Inspired by https://github.com/AlexsLemonade/scpca-nf/pull/502#discussion_r1391789864