### PR TITLE
Add multiplex warnings to QC report

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -191,7 +191,7 @@ umap_df <- lump_celltypes(celltype_df)
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
   <div class=\"alert alert-secondary\">
-    This library contains multiple samples that have not been integrated, which may confound clustering assignments.
+    This library contains multiple samples without batch-correction, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -191,7 +191,7 @@ umap_df <- lump_celltypes(celltype_df)
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
   <div class=\"alert alert-info\">
-    This library contains multiple samples that have not undergone batch correction, which may confound clustering assignments.
+    This library contains multiple samples that have not undergone batch correction, so clustering assignments may be confounded.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -191,7 +191,7 @@ umap_df <- lump_celltypes(celltype_df)
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
   <div class=\"alert alert-secondary\">
-    This library contains multiple samples without batch-correction, which may confound clustering assignments.
+    This library contains multiple samples without batch correction, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -191,7 +191,7 @@ umap_df <- lump_celltypes(celltype_df)
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
   <div class=\"alert alert-info\">
-    This library contains multiple samples that have not undergone batch correction, so clustering assignments may be confounded.
+    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -190,7 +190,7 @@ umap_df <- lump_celltypes(celltype_df)
 
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
-  <div class=\"alert alert-info\">
+  <div class=\"alert alert-secondary\">
     This library contains multiple samples that have not been integrated, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -187,6 +187,17 @@ umap_df <- lump_celltypes(celltype_df)
 
 
 <!-- First UMAP: clusters -->
+
+```{r, eval = has_multiplex, results='asis'}
+glue::glue("
+  <div class=\"alert alert-info\">
+    This library contains multiple samples that have not been integrated, which may confound clustering assignments.
+    Please use caution when interpreting these results.
+  </div>
+")
+```
+
+
 ```{r message=FALSE, warning=FALSE}
 clusters_plot <- plot_umap(
   umap_df,

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -190,8 +190,8 @@ umap_df <- lump_celltypes(celltype_df)
 
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
-  <div class=\"alert alert-secondary\">
-    This library contains multiple samples without batch correction, which may confound clustering assignments.
+  <div class=\"alert alert-info\">
+    This library contains multiple samples that have not undergone batch correction, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -8,8 +8,6 @@ author: "Childhood Cancer Data Lab"
 date: "`r params$date`"
 output:
   html_document:
-    theme:
-      version: 5
     toc: true
     toc_depth: 2
     toc_float:
@@ -26,7 +24,6 @@ knitr::opts_chunk$set(
 
 library(SingleCellExperiment)
 library(ggplot2)
-library(bslib)
 
 # Set default ggplot theme
 theme_set(
@@ -379,7 +376,7 @@ High agreement between methods qualitatively indicates higher confidence in the 
 <!-- If multiplexed, show info alert instead of this heatmap --> 
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
- <div class=\"alert alert-secondary\">
+ <div class=\"alert alert-info\">
 
   No heatmap comparing cluster and cell type annotation labels is shown because the presence of multiple samples may confound cluster assignment.
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -8,6 +8,8 @@ author: "Childhood Cancer Data Lab"
 date: "`r params$date`"
 output:
   html_document:
+    theme:
+      version: 5
     toc: true
     toc_depth: 2
     toc_float:
@@ -24,6 +26,7 @@ knitr::opts_chunk$set(
 
 library(SingleCellExperiment)
 library(ggplot2)
+library(bslib)
 
 # Set default ggplot theme
 theme_set(
@@ -376,7 +379,7 @@ High agreement between methods qualitatively indicates higher confidence in the 
 <!-- If multiplexed, show info alert instead of this heatmap --> 
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
- <div class=\"alert alert-info\">
+ <div class=\"alert alert-secondary\">
 
   No heatmap comparing cluster and cell type annotation labels is shown because the presence of multiple samples may confound cluster assignment.
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -375,13 +375,29 @@ The Jaccard index reflects the degree of overlap between the two labels and rang
 High agreement between methods qualitatively indicates higher confidence in the cell type annotation.
 
 
-## Unsupervised clustering
-
-Here we show the labels from unsupervised clustering compared to cell type annotations.
-Cluster assignment was performed using the `r metadata(processed_sce)$cluster_algorithm` algorithm.
 
 
-```{r}
+
+<!-- If multiplexed, show info alert instead of this heatmap --> 
+```{r, eval = has_multiplex, results='asis'}
+glue::glue("
+ <div class=\"alert alert-info\">
+
+  No heatmap is shown for comparing cluster and cell type annnotation labels because the presence multiple samples may confound cluster assignment.
+
+  </div>
+")
+```
+
+<!-- If not multiplexed, show the header, text, and heatmap --> 
+```{r, eval = !has_multiplex, results='asis'}
+glue::glue("
+  ## Unsupervised clustering
+
+  Here we show the labels from unsupervised clustering compared to cell type annotations.
+  Cluster assignment was performed using the `r metadata(processed_sce)$cluster_algorithm` algorithm.
+")
+
 # Calculate all jaccard matrices of interest for input to heatmap
 jaccard_cluster_matrices <- available_celltypes |>
   stringr::str_to_lower() |>
@@ -406,7 +422,7 @@ plot_height <- calculate_plot_height(
 ```
 
 
-```{r, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
+```{r, eval = !has_multiplex, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters",

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -275,29 +275,34 @@ available_celltypes <- c(
 #  need to define this variable to prevent errors, but this value will never
 #  actually be used.
 plot_height <- 1
-```
 
-<!-- If multiplexed, open with warning  --> 
-```{r, results='asis'}
-# determine if library is multiplexed, and print warning if so
+# Determine if library is multiplexed:
+#  sample_id should be defined with length > 1
+has_multiplex <- FALSE
 sample_id <- metadata(processed_sce)$sample_id
 if (!is.null(sample_id)) {
   if (length(sample_id) > 1) {
-    # convert sample id to bullet separated list
-    multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
-    glue::glue("
-      <div class=\"alert alert-warning\">
-
-      This library is multiplexed and contains data from more than one sample.
-      Data from the following samples are included in this library:
-
-      {multiplex_samples}
-
-      </div>
-    ")
+    has_multiplex <- TRUE
   }
 }
 ```
+
+<!-- If multiplexed, open with warning  --> 
+```{r, eval = has_multiplex, results='asis'}
+# convert sample id to bullet separated list
+multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
+glue::glue("
+ <div class=\"alert alert-warning\">
+
+ This library is multiplexed and contains data from more than one sample.
+ Data from the following samples are included in this library:
+
+    {multiplex_samples}
+
+  </div>
+")
+```
+
 This report contains a summary of cell type annotation results for library `r library_id`.
 The goal of this report is to provide more detailed information about cell type annotation results as an initial evaluation of their quality and reliability.
 
@@ -399,6 +404,7 @@ plot_height <- calculate_plot_height(
   length(jaccard_cluster_matrices) - 1
 )
 ```
+
 
 ```{r, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -266,16 +266,15 @@ available_celltypes <- c(
   na.omit() |>
   as.character()
 
-# These variables need to be defined for edge conditions when certain cell types
+# This variable need to be defined for edge conditions when certain cell types
 #  aren't available:
 #  When we have chunks with `eval=<has_method>`, knitr seems to need all other
 #  variables used in chunk params defined, including plot dimension variables
 #  which would have only been created in chunks which also had an associated
 #  eval=<has_method>`. Since those chunks won't have been eval'd if FALSE, we
-#  need to define these variables to prevent errors. BUT THEY ARE NOT USED WITH
-#  THESE VALUES.
+#  need to define this variable to prevent errors, but this value will never
+#  actually be used.
 plot_height <- 1
-heatmap_height <- 1
 ```
 
 
@@ -374,14 +373,14 @@ all_celltypes <- jaccard_cluster_matrices |>
   purrr::map(colnames) |>
   unlist()
 
-heatmap_height <- calculate_plot_height(
+plot_height <- calculate_plot_height(
   all_celltypes,
   unique(celltype_df$cluster),
   length(jaccard_cluster_matrices) - 1
 )
 ```
 
-```{r, fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
+```{r, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters",
@@ -433,14 +432,14 @@ all_celltypes <- jaccard_submitter_matrices |>
   purrr::map(colnames) |>
   unlist()
 
-heatmap_height <- calculate_plot_height(
+plot_height <- calculate_plot_height(
   all_celltypes,
   unique(celltype_df$submitter_celltype_annotation),
   length(jaccard_submitter_matrices) - 1
 )
 ```
 
-```{r, eval = has_submitter & (has_cellassign | has_singler), fig.height = heatmap_height, fig.width = 8.5, warning = FALSE}
+```{r, eval = has_submitter & (has_cellassign | has_singler), fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_submitter_matrices |>
   create_heatmap_list(
     column_title = "Submitter-provided annotations",
@@ -465,7 +464,7 @@ Note that due to different annotations references, these methods may use differe
 
 # Set plot dimensions based on number of SingleR cell types
 all_celltypes <- levels(celltype_df$singler_celltype_annotation)
-heatmap_height <- calculate_plot_height(
+plot_height <- calculate_plot_height(
   unique(celltype_df$singler_celltype_annotation),
   unique(celltype_df$cellassign_celltype_annotation),
   0
@@ -473,7 +472,7 @@ heatmap_height <- calculate_plot_height(
 ```
 
 
-```{r, eval = has_cellassign & has_singler, fig.height = heatmap_height, fig.width = 8.5}
+```{r, eval = has_cellassign & has_singler, fig.height = plot_height, fig.width = 8.5}
 # Calculate jaccard matrix
 singler_cellassign_matrix <- make_jaccard_matrix(
   celltype_df,

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -277,7 +277,27 @@ available_celltypes <- c(
 plot_height <- 1
 ```
 
+<!-- If multiplexed, open with warning  --> 
+```{r, results='asis'}
+# determine if library is multiplexed, and print warning if so
+sample_id <- metadata(processed_sce)$sample_id
+if (!is.null(sample_id)) {
+  if (length(sample_id) > 1) {
+    # convert sample id to bullet separated list
+    multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
+    glue::glue("
+      <div class=\"alert alert-warning\">
 
+      This library is multiplexed and contains data from more than one sample.
+      Data from the following samples are included in this library:
+
+      {multiplex_samples}
+
+      </div>
+    ")
+  }
+}
+```
 This report contains a summary of cell type annotation results for library `r library_id`.
 The goal of this report is to provide more detailed information about cell type annotation results as an initial evaluation of their quality and reliability.
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -280,11 +280,7 @@ plot_height <- 1
 #  sample_id should be defined with length > 1
 has_multiplex <- FALSE
 sample_id <- metadata(processed_sce)$sample_id
-if (!is.null(sample_id)) {
-  if (length(sample_id) > 1) {
-    has_multiplex <- TRUE
-  }
-}
+has_multiplex <- length(sample_id) > 1
 ```
 
 <!-- If multiplexed, open with warning  --> 
@@ -383,7 +379,7 @@ High agreement between methods qualitatively indicates higher confidence in the 
 glue::glue("
  <div class=\"alert alert-info\">
 
-  No heatmap is shown for comparing cluster and cell type annnotation labels because the presence multiple samples may confound cluster assignment.
+  No heatmap comparing cluster and cell type annotation labels is shown because the presence of multiple samples may confound cluster assignment.
 
   </div>
 ")

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -278,7 +278,6 @@ plot_height <- 1
 
 # Determine if library is multiplexed:
 #  sample_id should be defined with length > 1
-has_multiplex <- FALSE
 sample_id <- metadata(processed_sce)$sample_id
 has_multiplex <- length(sample_id) > 1
 ```


### PR DESCRIPTION
Closes #519 

As discussed*, I've added heatmap alerts - `warning` for the top of the celltype report, and `info` for the other spots. 

*Slight wording tweak but very happy to backtrack to the original suggestion in Slack for the UMAP text! I went ahead and added "confounded" in there, which is a concept I like to emphasize, but it might be getting too much in the weeds. Please suggest rephrasing wherever you see fit!

I also got changed all the `heatmap_height`s to also be `plot_height`, for simplicity, while I was here. No need for 2 unused variable definitions when we could just have the 1, I figured.

Here are screenshots of the relevant rendered parts!

-----------------------

<img width="450" alt="Screenshot 2023-11-16 at 12 25 26 PM" src="https://github.com/AlexsLemonade/scpca-nf/assets/4701111/e153d7c1-566a-45ee-a882-9c9b75e81cf5">

-----------------------

<img width="450" alt="Screenshot 2023-11-16 at 12 25 33 PM" src="https://github.com/AlexsLemonade/scpca-nf/assets/4701111/3795d5d1-01cd-4b31-8005-038b5abc582d">

------------------------

<img width="450" alt="Screenshot 2023-11-16 at 12 25 39 PM" src="https://github.com/AlexsLemonade/scpca-nf/assets/4701111/7191491e-12f1-4596-bace-05d6ba4f662d">

