### PR TITLE
Add missing semicolon

### DIFF
--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -148,7 +148,7 @@ workflow annotate_celltypes {
         meta.singler_model_file = singler_model_file;
         meta.cellassign_reference_file = cellassign_reference_file;
         meta.singler_results_file = "${meta.singler_dir}/singler_results.rds";
-        meta.cellassign_predictions_file = "${meta.cellassign_dir}/cellassign_predictions.tsv"
+        meta.cellassign_predictions_file = "${meta.cellassign_dir}/cellassign_predictions.tsv";
         // return simplified input:
         [meta, processed_sce]
       }


### PR DESCRIPTION
Somewhere along the line a semicolon was lost. The wayward semicolon was sad, shivering in the dark, but now it has been found and returned to its rightful home on line 151, near its semicolon friends. 

This did not affect any code, but seemed worth fixing.