### PR TITLE
Accommodate running multiple projects

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -73,6 +73,8 @@ workflow {
   if (params.project){
     // projects will use all runs in the project & supersede run_ids
     run_ids = []
+    // allow for processing of multiple projects at once
+    project_ids = params.project?.tokenize(',')
   }else{
     run_ids = params.run_ids?.tokenize(',') ?: []
   }
@@ -127,8 +129,8 @@ workflow {
              || (it.run_id in run_ids)
              || (it.library_id in run_ids)
              || (it.sample_id in run_ids)
-             || (it.submitter == params.project)
-             || (it.project_id == params.project)
+             || (it.submitter in project_ids)
+             || (it.project_id in project_ids)
             }
      .branch{
        bulk: it.technology in bulk_techs


### PR DESCRIPTION
This has been bothering me for a while, but right now we don't support running multiple project ids at once. I think for scenarios like having to re-run everything quickly, being able to at least group multiple projects together would be really helpful. 

Here, I made a few small adjustments to account for multiple projects being run at the same time. If you don't like this change, I can remove it. 