### PR TITLE
Update plot dimensions

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -93,7 +93,6 @@ plot_umap <- function(
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) +
     scale_y_continuous(labels = NULL, breaks = NULL) +
-    coord_fixed() +
     guides(
       color = guide_legend(
         title = legend_title,
@@ -105,7 +104,10 @@ plot_umap <- function(
         )
       )
     ) +
-    theme(legend.position = "bottom")
+    theme(
+      legend.position = "bottom", 
+      aspect.ratio = 1
+    )
 }
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -223,13 +223,15 @@ find_label_size <- function(input_labels) {
 #' @param col_names Vector of column names
 #' @param n_spacers Number of spacers between stacked heatmaps
 #' @param spacer_size Spacer size in inches
+#' @param min_height Minimize height required. Default 4"
 #'
 #' @return Heatmap height in inches
 calculate_plot_height <- function(
     row_names,
     col_names,
     n_spacers,
-    spacer_size = heatmap_padding) {
+    spacer_size = heatmap_padding, 
+    min_height = 4) {
   # first, based on number of cells in row_names:
   #   6 cell types to an inch
   heat_height <- length(row_names) / 6
@@ -242,7 +244,9 @@ calculate_plot_height <- function(
   # finally, add in any padding
   heat_height <- heat_height + n_spacers * spacer_size
 
-  return(heat_height)
+  return( 
+    max(c(min_height, heat_height))
+  )
 }
 ```
 
@@ -390,7 +394,7 @@ glue::glue("
   ## Unsupervised clustering
 
   Here we show the labels from unsupervised clustering compared to cell type annotations.
-  Cluster assignment was performed using the `r metadata(processed_sce)$cluster_algorithm` algorithm.
+  Cluster assignment was performed using the `{metadata(processed_sce)$cluster_algorithm}` algorithm.
 ")
 
 # Calculate all jaccard matrices of interest for input to heatmap
@@ -627,7 +631,7 @@ delta_median_confident_df <- delta_median_df |>
 plot_height <- length(unique(delta_median_df$celltype)) / 2.5
 ```
 
-```{r, eval = has_singler, warning=FALSE, message=FALSE, fig.height = plot_height, fig.width = 6.5}
+```{r, eval = has_singler, warning=FALSE, message=FALSE, fig.height = plot_height, fig.width = 8}
 # Plot delta_median across celltypes colored by pruning
 ggplot(delta_median_df) +
   aes(
@@ -697,7 +701,7 @@ plot_height <- ceiling(length(unique(celltype_df$cellassign_celltype_annotation)
 ```
 
 
-```{r, eval = has_cellassign, warning=FALSE, message=FALSE, fig.height = plot_height, fig.width = 6}
+```{r, eval = has_cellassign, warning=FALSE, message=FALSE, fig.height = plot_height, fig.width = 8}
 # define bandwidth for all calculations
 density_bw <- 0.03
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -744,7 +744,8 @@ ggplot(celltype_df) +
     x = "Probability of annotated cell type",
     y = ""
   ) +
-  coord_cartesian(xlim = c(0, 1)) +
+  #coord_cartesian(xlim = c(0, 1)) +
+  scale_x_continuous(limits = c(0, 1)) +
   scale_y_continuous(expand = c(0.1, 0.1)) +
   scale_alpha_identity() +
   facet_grid(

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -744,7 +744,6 @@ ggplot(celltype_df) +
     x = "Probability of annotated cell type",
     y = ""
   ) +
-  #coord_cartesian(xlim = c(0, 1)) +
   scale_x_continuous(limits = c(0, 1)) +
   scale_y_continuous(expand = c(0.1, 0.1)) +
   scale_alpha_identity() +

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -14,10 +14,10 @@ scater::plotUMAP(
   # remove axis numbers and background grid
   scale_x_continuous(labels = NULL, breaks = NULL) +
   scale_y_continuous(labels = NULL, breaks = NULL) +
-  coord_fixed() +
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
-  )
+  ) + 
+  theme(aspect.ratio = 1)
 ```
 
 ### Expression of highly variable genes
@@ -89,8 +89,8 @@ if (!is.null(processed_meta$highly_variable_genes)) {
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) +
     scale_y_continuous(labels = NULL, breaks = NULL) +
-    coord_fixed() +
     theme(
+      aspect.ratio = 1,
       legend.position = "bottom",
       axis.title = element_text(size = 9, color = "black"),
       strip.text = element_text(size = 8),


### PR DESCRIPTION
This PR addresses some QC report things identified in #469 we'd like to fix.

- Use `theme(aspect.ratio = 1)` instead of `coord_fixed()` for UMAPs
- Bigger width for diagnostic cell type plots
- Ensure heatmaps are at least 4" tall (related to #541)
- Bonus, fix a bug introduced in https://github.com/AlexsLemonade/scpca-nf/pull/574/files
  - We moved some text into an `as_is` chunk with `glue::glue()`, so need to use `{}` for variables, not \``r stuff`\`
 