### PR TITLE
Add new references for cell type annotation

### DIFF
--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -3,11 +3,16 @@ BlueprintEncodeData	celldex	SingleR	NA
 DatabaseImmuneCellExpressionData	celldex	SingleR	NA
 HumanPrimaryCellAtlasData	celldex	SingleR	NA
 MonacoImmuneData	celldex	SingleR	NA
-blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
-muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle
-brain-compartment	PanglaoDB	CellAssign	Brain, Immune system
-adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system
-kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system
-eye-compartment	PanglaoDB	CellAssign	Eye, Immune system
-adrenal-reproductive-compartment	PanglaoDB	CellAssign	Adrenal glands, Smooth muscle, Pancreas, Reproductive, Immune system
-soft-tissue-compartment	PanglaoDB	CellAssign	Kidney, Bone, Smooth muscle, Connective tissue, Liver, Lungs, Immune system
+blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system, Vasculature
+muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle, Vasculature
+brain-compartment	PanglaoDB	CellAssign	Brain, Immune system, Vasculature
+adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Vasculature
+kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system, Vasculature
+eye-compartment	PanglaoDB	CellAssign	Eye, Immune system, Vasculature
+adrenal-reproductive-compartment	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Smooth muscle, Pancreas, Reproductive, Immune system, Vasculature
+bone-and-soft-tissue-compartment	PanglaoDB	CellAssign	Bone, Smooth muscle, Connective tissue, Immune system, Vasculature
+reproductive-compartment	PanglaoDB	CellAssign	Reproductive, Immune system, Vasculature
+pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Immune system, Vasculature
+lung-compartment	PanglaoDB	CellAssign	Lungs, Immune system, Vasculature
+liver-compartment	PanglaoDB	CellAssign	Liver, Immune system, Vasculature
+bone-compartment	PanglaoDB	CellAssign	Bone, Immune system, Vasculature

--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -6,3 +6,8 @@ MonacoImmuneData	celldex	SingleR	NA
 blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
 muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle
 brain-compartment	PanglaoDB	CellAssign	Brain, Immune system
+adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system
+kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system
+eye-compartment	PanglaoDB	CellAssign	Eye, Immune system
+adrenal-reproductive-compartment	PanglaoDB	CellAssign	Adrenal glands, Smooth muscle, Pancreas, Reproductive, Immune system
+soft-tissue-compartment	PanglaoDB	CellAssign	Kidney, Bone, Smooth muscle, Connective tissue, Liver, Lungs, Immune system

--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -1,18 +1,20 @@
 celltype_ref_name	celltype_ref_source	celltype_method	organs
-adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Vasculature
-adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Smooth muscle, Pancreas, Reproductive, Immune system, Vasculature
+adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Embryo, Vasculature
+adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Embryo, Immune system, Pancreas, Reproductive, Smooth muscle, Vasculature
+all-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Mammary gland, Olfactory system, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
 blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
 BlueprintEncodeData	celldex	SingleR	NA
-bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Smooth muscle, Connective tissue, Immune system, Vasculature
+bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
 bone-compartment	PanglaoDB	CellAssign	Bone, Connective tissue, Immune system, Vasculature
-brain-compartment	PanglaoDB	CellAssign	Brain, Immune system, Vasculature
+brain-compartment	PanglaoDB	CellAssign	Brain, Embryo, Immune system, Vasculature
 DatabaseImmuneCellExpressionData	celldex	SingleR	NA
-eye-compartment	PanglaoDB	CellAssign	Eye, Immune system, Vasculature
+eye-compartment	PanglaoDB	CellAssign	Embryo, Eye, Immune system, Vasculature
 HumanPrimaryCellAtlasData	celldex	SingleR	NA
-kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system, Vasculature
-liver-compartment	PanglaoDB	CellAssign	Liver, Connective tissue, Immune system, Vasculature
-lung-compartment	PanglaoDB	CellAssign	Lungs, Connective tissue, Immune system, Vasculature
+kidney-compartment	PanglaoDB	CellAssign	Embyro, Immune system, Kidney, Vasculature
+liver-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Liver, Vasculature
+lung-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Lungs, Vasculature
 MonacoImmuneData	celldex	SingleR	NA
-muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle, Vasculature
-pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Connective tissue, Immune system, Vasculature
-reproductive-compartment	PanglaoDB	CellAssign	Reproductive, Immune system, Vasculature
+muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Skeletal muscle, Smooth muscle, Vasculature
+pancreas-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Pancreas, Vasculature
+pediatric-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
+reproductive-compartment	PanglaoDB	CellAssign	Embryo, Immune system, Reproductive, Vasculature

--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -1,18 +1,18 @@
 celltype_ref_name	celltype_ref_source	celltype_method	organs
-BlueprintEncodeData	celldex	SingleR	NA
-DatabaseImmuneCellExpressionData	celldex	SingleR	NA
-HumanPrimaryCellAtlasData	celldex	SingleR	NA
-MonacoImmuneData	celldex	SingleR	NA
-blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
-muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle, Vasculature
-brain-compartment	PanglaoDB	CellAssign	Brain, Immune system, Vasculature
 adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Vasculature
-kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system, Vasculature
-eye-compartment	PanglaoDB	CellAssign	Eye, Immune system, Vasculature
 adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Smooth muscle, Pancreas, Reproductive, Immune system, Vasculature
+blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
+BlueprintEncodeData	celldex	SingleR	NA
 bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Smooth muscle, Connective tissue, Immune system, Vasculature
-reproductive-compartment	PanglaoDB	CellAssign	Reproductive, Immune system, Vasculature
-pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Connective tissue, Immune system, Vasculature
-lung-compartment	PanglaoDB	CellAssign	Lungs, Connective tissue, Immune system, Vasculature
-liver-compartment	PanglaoDB	CellAssign	Liver, Connective tissue, Immune system, Vasculature
 bone-compartment	PanglaoDB	CellAssign	Bone, Connective tissue, Immune system, Vasculature
+brain-compartment	PanglaoDB	CellAssign	Brain, Immune system, Vasculature
+DatabaseImmuneCellExpressionData	celldex	SingleR	NA
+eye-compartment	PanglaoDB	CellAssign	Eye, Immune system, Vasculature
+HumanPrimaryCellAtlasData	celldex	SingleR	NA
+kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system, Vasculature
+liver-compartment	PanglaoDB	CellAssign	Liver, Connective tissue, Immune system, Vasculature
+lung-compartment	PanglaoDB	CellAssign	Lungs, Connective tissue, Immune system, Vasculature
+MonacoImmuneData	celldex	SingleR	NA
+muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle, Vasculature
+pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Connective tissue, Immune system, Vasculature
+reproductive-compartment	PanglaoDB	CellAssign	Reproductive, Immune system, Vasculature

--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -3,18 +3,18 @@ adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immu
 adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Embryo, Immune system, Pancreas, Reproductive, Smooth muscle, Vasculature
 all-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Mammary gland, Olfactory system, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
 blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
-BlueprintEncodeData	celldex	SingleR	NA
 bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
 bone-compartment	PanglaoDB	CellAssign	Bone, Connective tissue, Immune system, Vasculature
 brain-compartment	PanglaoDB	CellAssign	Brain, Embryo, Immune system, Vasculature
-DatabaseImmuneCellExpressionData	celldex	SingleR	NA
 eye-compartment	PanglaoDB	CellAssign	Embryo, Eye, Immune system, Vasculature
-HumanPrimaryCellAtlasData	celldex	SingleR	NA
 kidney-compartment	PanglaoDB	CellAssign	Embyro, Immune system, Kidney, Vasculature
 liver-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Liver, Vasculature
 lung-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Lungs, Vasculature
-MonacoImmuneData	celldex	SingleR	NA
 muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Skeletal muscle, Smooth muscle, Vasculature
 pancreas-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Pancreas, Vasculature
 pediatric-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
 reproductive-compartment	PanglaoDB	CellAssign	Embryo, Immune system, Reproductive, Vasculature
+BlueprintEncodeData	celldex	SingleR	NA
+DatabaseImmuneCellExpressionData	celldex	SingleR	NA
+HumanPrimaryCellAtlasData	celldex	SingleR	NA
+MonacoImmuneData	celldex	SingleR	NA

--- a/references/celltype-reference-metadata.tsv
+++ b/references/celltype-reference-metadata.tsv
@@ -3,16 +3,16 @@ BlueprintEncodeData	celldex	SingleR	NA
 DatabaseImmuneCellExpressionData	celldex	SingleR	NA
 HumanPrimaryCellAtlasData	celldex	SingleR	NA
 MonacoImmuneData	celldex	SingleR	NA
-blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system, Vasculature
+blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
 muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Immune system, Skeletal muscle, Smooth muscle, Vasculature
 brain-compartment	PanglaoDB	CellAssign	Brain, Immune system, Vasculature
 adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Vasculature
 kidney-compartment	PanglaoDB	CellAssign	Kidney, Immune system, Vasculature
 eye-compartment	PanglaoDB	CellAssign	Eye, Immune system, Vasculature
-adrenal-reproductive-compartment	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Smooth muscle, Pancreas, Reproductive, Immune system, Vasculature
-bone-and-soft-tissue-compartment	PanglaoDB	CellAssign	Bone, Smooth muscle, Connective tissue, Immune system, Vasculature
+adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Smooth muscle, Pancreas, Reproductive, Immune system, Vasculature
+bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Smooth muscle, Connective tissue, Immune system, Vasculature
 reproductive-compartment	PanglaoDB	CellAssign	Reproductive, Immune system, Vasculature
-pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Immune system, Vasculature
-lung-compartment	PanglaoDB	CellAssign	Lungs, Immune system, Vasculature
-liver-compartment	PanglaoDB	CellAssign	Liver, Immune system, Vasculature
-bone-compartment	PanglaoDB	CellAssign	Bone, Immune system, Vasculature
+pancreas-compartment	PanglaoDB	CellAssign	Pancreas, Connective tissue, Immune system, Vasculature
+lung-compartment	PanglaoDB	CellAssign	Lungs, Connective tissue, Immune system, Vasculature
+liver-compartment	PanglaoDB	CellAssign	Liver, Connective tissue, Immune system, Vasculature
+bone-compartment	PanglaoDB	CellAssign	Bone, Connective tissue, Immune system, Vasculature


### PR DESCRIPTION
Closes #416 

This PR adds additional references to use with `CellAssign`, using the organs available in the PanglaoDB marker gene list. 

- I included all references we may need to run each project (see https://github.com/AlexsLemonade/ScPCA-admin/pull/713). This includes two references that combine organs: 
  - `adrenal-reproductive-compartment`, which includes the adrenal gland, pancreas, and reproductive tissue to account for the project that contains both Adrenal corticocarcinoma and a germ cell tumor. 
  - `bone-and-soft-tissue-compartment`, which includes bone, smooth muscle, and connective tissue to account for the projects that contain samples that come from various bone and soft tissue areas in the body. 
 - I also added some extra references for various organs that we might want to use by themselves at some point, like `lung-compartment` and `liver-compartment`. 
 - The last thing I did was add `vasculature` to the list of organs used to build each reference. We want to include immune cells in each reference, but it would also be important to include anything related to blood vessels that might be in tumors. Specifically, the `vasculature` organ in the database only contains endothelial cells (and some subtypes of endothelial cells. These are commonly found in solid tumors, so it's important to include them and err on the side of building a broader reference. 

I'm going to request two reviewers here, because it's important to get extra eyes on the decisions regarding which organs go in each reference and the names that I chose. 