### PR TITLE
Update example file docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,13 @@ This directory contains the following example files:
 
 These files provide examples of expected formatting and content, but note that the specific values in these files may not be applicable or sufficient for running `scpca-nf` directly on your system.
 
+Note that `example_run_metadata.tsv` additionally refers to several example files, whose descriptions can be found as follows:
+
+- The format for the `example_barcode_files/cite_barcodes.tsv` file is described in the [ADT processing section of `external-instructions.md`](../external-instructions.md#libraries-with-additional-feature-data-adt-or-cellhash).
+- The format for the `example_barcode_files/cellhash_barcodes.tsv` file is described in the [multiplexed libraries section of `external-instructions.md`](../external-instructions.md#multiplexed-cellhash-libraries).
+- The format for the `example_metadata_files/submitter_celltypes.tsv` file is described in the [cell type annotation section of `external-instructions.md`](../external-instructions.md#providing-existing-cell-type-labels).
+
+
 ## Testing your setup with example data
 
 :warning: These instructions are only intended to be used to test accurate set up of a configuration file.

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -545,8 +545,12 @@ To support demultiplexing, we currently require _ALL_ of the following for multi
 
 - A single-cell RNA-seq run of the pooled samples
 - A matched cellhash sequencing run for the pooled samples
-- A TSV file, `feature_barcode_file`, defining the cellhash barcode sequences.
+- A TSV file, `feature_barcode_file`, defining the cellhash barcode sequences
+  - This file should have one line per barcode and no header.
+  The first column should contain the cellhash barcode ID, and the second column should contain the barcode nucleotide sequence.
 - A TSV file, `cellhash_pool_file` that defines the sample-barcode relationship for each library/pool of samples
+  - This file should have one line per pool and no header.
+  The first column should contain the cellhash pool ID, and the second column should contain the barcode nucleotide sequence.
 
 For genetic demultiplexing, we also require:
 


### PR DESCRIPTION
Closes #570 

Two changes:

- In `external_instructions.md`, I added some bullets to actually describe what goes into the TSV files. But, do we want to link out to third party format, and if so where specifically to link out to? Is all the wording ok as is, too?
- In `examples/README.md`, I tell readers to go look at those file descriptions. Is this info in an ok place?