### PR TITLE
Account for missing project ids

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,7 @@ workflow {
     // projects will use all runs in the project & supersede run_ids
     run_ids = []
     // allow for processing of multiple projects at once
-    project_ids = params.project?.tokenize(',')
+    project_ids = params.project?.tokenize(',') ?: []
   }else{
     run_ids = params.run_ids?.tokenize(',') ?: []
     project_ids = []


### PR DESCRIPTION
Went to do a test run with just a single sample and had an error that we didn't define `project_ids`. I fixed that here. I'll make the same change to `development`. 