### PR TITLE
Include example output in release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: Release checklist
 about: Prepare for a new release version of scpca-nf
-title: Prepare for scpca-nf release vX.X.X
+title: Prepare for scpca-nf release `vX.X.X`
 labels: release
 assignees: ''
 
@@ -13,15 +13,20 @@ assignees: ''
 
 - [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those on ZenHub.
 - [ ] Update code and documentation with the latest version number in the `development` branch:
-  - [ ] [nextflow.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config)
-  - [ ] [internal-instructions.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/internal-instructions.md)
-  - [ ] [external-instructions.md](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-instructions.md)
+  - [ ] [`nextflow.config`](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config)
+  - [ ] [`internal-instructions.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/internal-instructions.md)
+  - [ ] [`external-instructions.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-instructions.md)
 - [ ] Test that the workflow is in good working order with `nextflow run alexslemonade/scpca-nf -latest -r development`
 - [ ] File a PR from the `development` branch to the `main` branch. This should include all of the changes that will be associated with the next release.
+- [ ] (Optional) Generate new example `scpca-nf` output files.
+If updating the example output is not necessary for this release, check these boxes off for free.
+  - [ ] [Re-process the example data](https://github.com/AlexsLemonade/scpca-nf/blob/main/internal-instructions.md#processing-example-data) through the `scpca-nf` workflow and ensure it looks correct.
+  - [ ] Compress the example output in `scpca_out` to create `scpca_out.zip`, as described in the instructions.
+
 
 ### Creating a release
 - [ ] On the [releases page](https://github.com/AlexsLemonade/scpca-nf/releases), choose `Draft a new release`.
-- [ ] In `Choose a tag`, type a new release number using semantic versioning (vX.X.X) (you did update the title of this issue to match, right?), then click `Create a new tag: vX.X.X on publish`.
+- [ ] In `Choose a tag`, type a new release number using semantic versioning (`vX.X.X`) (you did update the title of this issue to match, right?), then click `Create a new tag: vX.X.X on publish`.
 - [ ] Write a description of the major changes in this release. You may want to start with the auto-generated release notes to save time.
 - [ ] Optional: If not all issues have been addressed, save a draft to return to later.
 - [ ] Publish the release!

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -48,3 +48,4 @@ UMI
 uri
 Visium
 VS
+ZenHub


### PR DESCRIPTION
Closes #585 

Here, I've added a little checklist for the example output into the release template.

Note that instead of what I've done here, we could also have a different issue template for this, if we think it's too much of a burden on whoever is assigned to the release issue?

I also made some other text changes for spell check appeasement. FYI this change (added backticks) can be reverted, but we'd have to add `vX` to the dictionary. Any preference?
```
title: Prepare for scpca-nf release `vX.X.X`
```