### PR TITLE
Repurpose integration workflow to be specifically for merging

### DIFF
--- a/merge.nf
+++ b/merge.nf
@@ -109,7 +109,7 @@ workflow {
       // make sure we don't have any duplicates of the same library ID hanging around
       // this shouldn't be the case since we removed CITE-seq and cell-hashing
       .unique()
-      // grouped tuple of [merge_group, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
+      // group tuple by project id, [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
       .groupTuple(by: 0)
 
     merge_sce(grouped_libraries_ch)

--- a/merge.nf
+++ b/merge.nf
@@ -98,10 +98,12 @@ workflow {
       .filter{it.seq_unit in ['cell', 'nucleus']}
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[
-        project_id: it.scpca_project_id,
-        library_id: it.scpca_library_id,
-        scpca_nf_file: "${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
+        it.scpca_project_id,
+        it.scpca_library_id,
+        "${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
       ]}
+      // only include samples that have been processed through scpca-nf
+      .filter{file(it[2]).exists()}
       // make sure we don't have any duplicates of the same library ID hanging around
       // this shouldn't be the case since we removed CITE-seq and cell-hashing
       .unique()

--- a/merge.nf
+++ b/merge.nf
@@ -94,7 +94,7 @@ workflow {
       .splitCsv(header: true, sep: '\t')
       // filter to only include specified project ids
       .filter{it.scpca_project_id in project_ids}
-      // only include single-cell/single-nuclei and make sure no CITE-seq/ hashing libraries
+      // only include single-cell/single-nuclei which already contain processed altexps, and ensure we don't try to merge libraries from spatial or bulk data
       .filter{it.seq_unit in ['cell', 'nucleus']}
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[

--- a/merge.nf
+++ b/merge.nf
@@ -102,12 +102,12 @@ workflow {
         it.scpca_library_id,
         "${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds"
       ]}
-      // only include samples that have been processed through scpca-nf
+      // only include libraries that have been processed through scpca-nf
       .filter{file(it[2]).exists()}
       // make sure we don't have any duplicates of the same library ID hanging around
       // this shouldn't be the case since we removed CITE-seq and cell-hashing
       .unique()
-      // group tuple by project id, [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
+      // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
       .groupTuple(by: 0)
 
     merge_sce(grouped_libraries_ch)

--- a/merge.nf
+++ b/merge.nf
@@ -17,13 +17,9 @@ if(!params.project) {
   param_error = true
 }
 
+// check for provided run file
 if (!file(params.run_metafile).exists()) {
   log.error("The 'run_metafile' file '${params.run_metafile}' can not be found.")
-  param_error = true
-}
-
-if (!file(params.merge_metafile).exists()) {
-  log.error("The 'merge_metafile' file '${params.merge_metafile}' can not be found.")
   param_error = true
 }
 
@@ -37,13 +33,13 @@ process merge_sce {
   label 'mem_16'
   publishDir "${params.checkpoints_dir}/merged"
   input:
-    tuple val(merge_group), val(library_ids), path(scpca_nf_file)
+    tuple val(project_id), val(library_ids), path(scpca_nf_file)
   output:
-    tuple val(merge_group), path(merged_sce_file)
+    tuple val(project_id), path(merged_sce_file)
   script:
     input_library_ids = library_ids.join(',')
     input_sces = scpca_nf_file.join(',')
-    merged_sce_file = "${merge_group}_merged.rds"
+    merged_sce_file = "${project_id}_merged.rds"
     """
     merge_sces.R \
       --input_library_ids "${input_library_ids}" \


### PR DESCRIPTION
Closes #593 

This PR completes the steps needed to repurpose the integration workflow to be for merging. 

- I removed the parameters for the`merge_metafile` and the `merge_group`. I also removed the part of the workflow that reads in the `merge_metafile` and joins it with the `run_metafile`. 
- Instead, we want to merge all libraries by project. I required the `project` parameter to be provided and filter the `run_metafile` to only contain libraries in the specified project. 
- Before merging, I group by the project ID so that each merged object contains all libraries for a given project. 

These changes were pretty straightforward, but I haven't had a chance to test them yet. I'm using all the resources to run CellAssign, so I'll request a review once I have the chance to test this. 