### PR TITLE
Bump initial memory and cpu request for CellAssign

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -36,8 +36,8 @@ process{
   withLabel: cpus_12 {
     cpus = {check_cpus(12)}
   }
-  withLabel: cpus_32 {
-    cpus = {check_cpus(32)}
+  withLabel: cpus_24 {
+    cpus = {check_cpus(24)}
   }
 }
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -46,7 +46,7 @@ process classify_cellassign {
       pattern: "${cellassign_dir}"
     )
   label 'mem_128'
-  label 'cpus_32'
+  label 'cpus_24'
   tag "${meta.library_id}"
   input:
     tuple val(meta), path(processed_rds), path(cellassign_reference_file)


### PR DESCRIPTION
In attempting to run the first two projects through CellAssign, I am noticing a few things: 

- The first is that most of the samples are failing in the initial two attempts for running CellAssign, and are more successful on the third attempt (although not always). This tells me we should be initially requesting more memory. I think I would also bump up the cpus so that hopefully this takes less time and is less likely to get killed. 
- The second is that, every run has been killed by the external system after ~5-7 hours. In some cases, CellAssign has completed and in others none of the processes have completed. I'm not entirely sure what else we can do other than bump up requests? I wonder if there is a time out that's happening? 

Below is a copy of the error that I'm consistently getting: 
<img width="354" alt="Screenshot 2023-12-07 at 9 38 51 AM" src="https://github.com/AlexsLemonade/scpca-nf/assets/54039191/4531546e-ba1a-4fdf-84ef-486ea4f87fc3">

I've also attached the log file so that you can see the complete output. 
[nextflow.log](https://github.com/AlexsLemonade/scpca-nf/files/13602054/nextflow.1.log)

