### PR TITLE
Add cellassign organs to report

### DIFF
--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -253,8 +253,8 @@ calculate_plot_height <- function(
 
 ```{r, message = FALSE, warning = FALSE, echo = FALSE}
 # define library and sce object
-#library_id <- params$library
-#processed_sce <- params$processed_sce
+library_id <- params$library
+processed_sce <- params$processed_sce
 
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -253,8 +253,8 @@ calculate_plot_height <- function(
 
 ```{r, message = FALSE, warning = FALSE, echo = FALSE}
 # define library and sce object
-library_id <- params$library
-processed_sce <- params$processed_sce
+#library_id <- params$library
+#processed_sce <- params$processed_sce
 
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
@@ -339,18 +339,18 @@ if (has_singler) {
 }
 
 if (has_cellassign) {
-  tissue_type <- stringr::word(
-    # eg, "blood-compartment"
-    metadata(processed_sce)$cellassign_reference,
-    1,
-    sep = "-"
-  )
+  
+  organs <- metadata(processed_sce)$cellassign_reference_organs |>
+    stringr::str_to_lower()
+  # split up and add an `and` before the final organ
+  split_organs <- stringr::str_split_1(organs, pattern = ", ")
+  organs_string <- glue::glue_collapse(split_organs, sep = ", ", last = ", and ")
+  
 
   methods_text <- glue::glue(
     "{methods_text}
     * Annotations from [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)).
-    Marker genes associated with `{tissue_type}` tissue were obtained from [PanglaoDB](https://panglaodb.se/).\n
-    "
+    Marker genes associated with the following tissue types were obtained from [PanglaoDB](https://panglaodb.se/): {organs_string}.\n"
   )
 }
 


### PR DESCRIPTION
**Stacked on #608**
Closes #589

Here, I've updated the cell type report to include organs. It turns out our current parsing of the reference name would not work well for all of our new references (e.g. `adrenal-pancreas-reproductive` or `bone-and-soft-tissue`), so I decided to just scrap that code altogether, figuring the tissues/organs are more important than our internal reference name. Yes/no?

Here's a screen shot example of how this part of the cell type report now looks!

---

<img width="981" alt="Screenshot 2023-12-07 at 2 00 08 PM" src="https://github.com/AlexsLemonade/scpca-nf/assets/4701111/e76f7a7e-cccd-485c-8c41-10165fa8838c">
