### PR TITLE
Account for feature data when merging objects

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -29,6 +29,12 @@ option_list <- list(
             the default is n_hvg = 2000"
   ),
   make_option(
+    opt_str = c("--include_alt_exp"),
+    action = "store_true",
+    default = FALSE,
+    help = "Keep any altExp present in the merged object."
+  ),
+  make_option(
     opt_str = c("-t", "--threads"),
     type = "integer",
     default = 1,
@@ -108,7 +114,8 @@ merged_sce <- scpcaTools::merge_sce_list(
   sce_list,
   batch_column = "library_id",
   preserve_rowdata_cols = "gene_symbol",
-  cell_id_column = "cell_id"
+  cell_id_column = "cell_id",
+  include_alt_exp = include_alt_exp
 )
 
 

--- a/merge.nf
+++ b/merge.nf
@@ -33,13 +33,13 @@ process merge_sce {
   label 'mem_16'
   publishDir "${params.results_dir}/merged/${project_id}"
   input:
-    tuple val(project_id), val(has_adt), val(library_ids), path(scpca_nf_file)
+    tuple val(merge_group_id), val(has_adt), val(library_ids), path(scpca_nf_file)
   output:
-    tuple val(project_id), val(has_adt), path(merged_sce_file)
+    tuple val(merge_group_id), val(has_adt), path(merged_sce_file)
   script:
     input_library_ids = library_ids.join(',')
     input_sces = scpca_nf_file.join(',')
-    merged_sce_file = "${project_id}_merged.rds"
+    merged_sce_file = "${merge_group_id}_merged.rds"
     """
     merge_sces.R \
       --input_library_ids "${input_library_ids}" \
@@ -63,23 +63,23 @@ process merge_report {
   publishDir "${params.results_dir}/merged/${merge_group}"
   label 'mem_16'
   input:
-    tuple val(merge_group), path(merged_sce_file)
+    tuple val(merge_group_id), path(merged_sce_file)
     path(report_template)
   output:
     path(merge_report)
   script:
-    merge_report = "${merge_group}_summary_report.html"
+    merge_report = "${merge_group_id}_summary_report.html"
     """
     Rscript -e "rmarkdown::render( \
       '${report_template}', \
       output_file = '${merge_report}', \
-      params = list(merge_group = '${merge_group}', \
+      params = list(merge_group = '${merge_group_id}', \
                     merged_sce = '${merged_sce_file}', \
                     batch_column = 'library_id') \
       )"
     """
   stub:
-    merge_report = "${merge_group}_summary_report.html"
+    merge_report = "${merge_group_id}_summary_report.html"
     """
     touch ${merge_report}
     """


### PR DESCRIPTION
Closes #595 

This PR accounts for libraries that have feature data before merging. Specifically, any libraries that have ADT/CITE-seq data will retain the `altExp` in the object, while any libraries with cell hashing will not include the `altExp` in the merged object. I made the following changes: 

- To the script for merging SCE's, I added an option to `--include_alt_exp`. This mirrors the argument being added in https://github.com/AlexsLemonade/scpcaTools/pull/243, but here I am setting the default to be false. So by default the `altExp` will not be included unless the data specifically has CITE-seq/adt data. 
- I create a list of all project ids that have at least one library with CITE-seq data. For each project being processed, I created a `has_adt` value that gets passed to the process for merging. If `has_adt` is true, then the `--include_alt_exp` flag is used. For all other cases, no altExp data will be kept. 
- This means we do not explicitly check for multiplexed data, but I don't think we need that information since they will be treated like regular single-cell/ single-nuclei where no `altExp` will be kept. 
- This approach also implies that if a project has some libraries with CITE/hashing and some libraries without, that will be handled within the function in https://github.com/AlexsLemonade/scpcaTools/pull/243. My understanding of that PR is that is true. 
- The other thing I did was change the `publishDir` for the merge step. Now that we are only producing the merged objects and not integrating, we want to make sure we output this. 

The last thing I want to note is that previously there was a question about why we were including a filter for `seq_unit in ["cell", "nucleus"]` and the `unique` call. On working on this, I realized that CITE/cell hashing data will have two libraries that have `seq_unit` equal to `cell` or `nucleus`.  However the contents of the `tecnology` column will be different. So the first filter is to just remove bulk and spatial data from being merged. The `unique` is to remove duplicates because of CITE/ cell hashing for the same library. I updated the comments here to reflect that. 