### PR TITLE
Add process for converting merged objects to AnnData

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -29,7 +29,7 @@ option_list <- list(
             the default is n_hvg = 2000"
   ),
   make_option(
-    opt_str = c("--include_alt_exp"),
+    opt_str = c("--include_altexp"),
     action = "store_true",
     default = FALSE,
     help = "Keep any altExp present in the merged object."
@@ -115,7 +115,7 @@ merged_sce <- scpcaTools::merge_sce_list(
   batch_column = "library_id",
   preserve_rowdata_cols = "gene_symbol",
   cell_id_column = "cell_id",
-  include_alt_exp = include_alt_exp
+  include_altexp = opt$include_altexp
 )
 
 

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.3.1'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/merge.nf
+++ b/merge.nf
@@ -46,7 +46,7 @@ process merge_sce {
       --input_sce_files "${input_sces}" \
       --output_sce_file "${merged_sce_file}" \
       --n_hvg ${params.num_hvg} \
-      "${has_adt ? "--include_alt_exp" : ''} \
+      ${has_adt ? "--include_altexp" : ''} \
       --threads ${task.cpus}
     """
   stub:
@@ -88,18 +88,18 @@ process merge_report {
 process export_anndata{
     container params.SCPCATOOLS_CONTAINER
     label 'mem_16'
-    tag "${project_id}"
+    tag "${merge_group}"
     publishDir "${params.results_dir}/merged/${merge_group}", mode: 'copy'
     input:
-      tuple val(project_id), val(has_adt), path(merged_sce_file)
+      tuple val(merge_group), val(has_adt), path(merged_sce_file)
     output:
-      tuple val(project_id), path("${project_id}_merged_*.hdf5")
+      tuple val(merge_group), path("${merge_group}_merged_*.hdf5")
     script:
-      rna_hdf5_file = "${project_id}_merged_rna.hdf5"
-      feature_hdf5_file = "${project_id}_merged_adt.hdf5"
+      rna_hdf5_file = "${merge_group}_merged_rna.hdf5"
+      feature_hdf5_file = "${merge_group}_merged_adt.hdf5"
       """
       sce_to_anndata.R \
-        --input_sce_file ${sce_file} \
+        --input_sce_file ${merged_sce_file} \
         --output_rna_h5 ${rna_hdf5_file} \
         --output_feature_h5 ${feature_hdf5_file} \
         ${has_adt ? "--feature_name adt" : ''}
@@ -109,8 +109,8 @@ process export_anndata{
       ${has_adt ? "move_counts_anndata.py --anndata_file ${feature_hdf5_file}" : ''}
       """
     stub:
-      rna_hdf5_file = "${project_id}_merged_rna.hdf5"
-      feature_hdf5_file = "${project_id}_merged_adt.hdf5"
+      rna_hdf5_file = "${merge_group}_merged_rna.hdf5"
+      feature_hdf5_file = "${merge_group}_merged_adt.hdf5"
       """
       touch ${rna_hdf5_file}
       ${has_adt ? "touch ${feature_hdf5_file}" : ''}


### PR DESCRIPTION
Closes #604 
⚠️ Stacked on #610 (Because this is slightly dependent on decisions made in #610, I'm going to wait to request review)

This PR adds a process to convert the merged SCE objects to an AnnData object. When converting to AnnData, I chose to use the same scripts that we use in the main workflow to convert the object and then move the counts. The reason for this is I think it's probably best to be consistent in how we format our objects. In particular, with the AnnData objects, we add the sample metadata as columns in the `colData` and do a little bit of renaming. I don't think there's any reason we shouldn't be doing that here. 

This process doesn't differ much from the conversion process in the main workflow, except here, we know that the only time we will have an altExp is if the `has_adt` value is `true`. I use that value to determine if the feature file should be created. 

Also, all of the objects are considered processed objects here, so I run `move_counts_anndata.py` for all HDF5 files. Again, I'm doing this so that how we name things is consistent with the other AnnData objects. 

The last idea I had was maybe we also want to add the sample metadata to the `colData` of the merged objects. That way, things like diagnosis, age, etc., would be easier to work with instead of living in a separate data frame in the `metadata`. What do we think? 