### PR TITLE
Create faceted UMAPs by cell type

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -118,7 +118,6 @@ plot_umap <- function(
 #'
 #' @return ggplot object containing a faceted UMAP where each cell type is a facet.
 #'   In each panel, the cell type of interest is colored and all other cells are grey.
-
 faceted_umap <- function(umap_df,
                          annotation_column) {
   # color by the annotation column but only color one cell type at a time
@@ -320,7 +319,7 @@ if (length(levels(umap_df$cluster)) <= 8) {
 knitr::asis_output(
   'Next, we show UMAPs colored by cell types.
 For each cell typing method, we show a separate faceted UMAP.
-In each panel, cells that correspond to a single cell type are colored, while all other cells are in grey.
+In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.
 
 For legibility, only the seven most common cell types are shown.
 All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell type" which represents cells that could not be classified).

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -131,7 +131,7 @@ faceted_umap <- function(umap_df,
       data = select(
         umap_df, -{{ annotation_column }}
       ),
-      color = "grey",
+      color = "gray80",
       alpha = 0.5,
       size = 0.3
     ) +

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -50,12 +50,12 @@ format_celltype_n_table <- function(df) {
 #' @param n_celltypes Number of groups to lump into, with rest put into "Other" group. Default is 7.
 #'
 #' @return Updated df with new column of lumped celltypes for each present method
-lump_celltypes <- function(df, n_celltypes = 7) {
+lump_celltypes <- function(df, n_celltypes = 8) {
   df <- df |>
     dplyr::mutate(
       across(
         ends_with("_celltype_annotation"),
-        \(x) forcats::fct_lump_n(x, n_celltypes, other_level = "All remaining cell types"),
+        \(x) forcats::fct_lump_n(x, n_celltypes, other_level = "All remaining cell types", ties.method = "first"),
         .names = "{.col}_lumped"
       )
     )
@@ -108,6 +108,74 @@ plot_umap <- function(
       legend.position = "bottom",
       aspect.ratio = 1
     )
+}
+
+
+#' Create a UMAP panel showing cells that belong to a specific cell type
+#'
+#' @param umap_df Data frame with UMAP1 and UMAP2 columns
+#' @param annotation_column Column containing cell type annotations
+#' @param celltype Cell type to indicate on UMAP. All cells of this cell type will be colored with red.
+#'
+#' @return ggplot object containing a UMAP where all cells of the specified
+#'   `celltype` are colored in red and all other cells are grey.
+
+make_umap_panels <- function(umap_df,
+                             annotation_column,
+                             celltype) {
+  # add a new column indicating how cells should be colored
+  # only keep the cell type of interest and label the rest as other
+  color_umap_df <- umap_df |>
+    dplyr::mutate(
+      color_column = ifelse(get({{ annotation_column }}) == {{ celltype }}, celltype, "Other"),
+      # make sure Other is the second level
+      color_column = forcats::fct_relevel(color_column, "Other", after = Inf)
+    )
+
+  umap_panel <- ggplot(color_umap_df) +
+    aes(
+      x = UMAP1,
+      y = UMAP2,
+      color = color_column
+    ) +
+    geom_point(
+      size = 0.3,
+      alpha = 0.5
+    ) +
+    # remove axis numbers and background grid
+    scale_x_continuous(labels = NULL, breaks = NULL) +
+    scale_y_continuous(labels = NULL, breaks = NULL) +
+    theme(
+      # no legend here
+      legend.position = "None"
+    ) +
+    # celltype will be red, other will be grey
+    scale_color_manual(values = c("red", "grey")) +
+    labs(title = celltype)
+
+  return(umap_panel)
+}
+
+
+#' Generate a list of top cell types found in a given column
+#'
+#' @param celltype_df Data frame with cell types
+#' @param celltype_column Column containing cell type annotations
+#' @param num_celltypes Number of cell types to keep
+#'
+#' @return A list of the top cell types, with the last element being "All remaining cell types"
+
+list_celltypes <- function(celltype_df,
+                           celltype_column,
+                           num_celltypes = 8) {
+  celltype_list <- create_celltype_n_table(celltype_df, !!sym(celltype_column)) |>
+    dplyr::mutate(`Annotated cell type` = as.character(`Annotated cell type`)) |>
+    dplyr::slice_max(`Number of cells`, n = num_celltypes, with_ties = FALSE) |>
+    dplyr::pull(`Annotated cell type`)
+
+  celltype_list <- c(celltype_list, "All remaining cell types")
+
+  return(celltype_list)
 }
 ```
 
@@ -278,37 +346,77 @@ All other cell types are grouped together and labeled "All remaining cell types"
 
 <!-- Now, UMAPs of cell types, where present -->
 
-```{r eval = has_submitter && has_umap, message=FALSE, warning=FALSE}
-plot_umap(
-  umap_df,
-  submitter_celltype_annotation_lumped,
-  "Cell types",
-  legend_nrow = 4
-) +
-  ggtitle("UMAP colored by submitter-provided annotations") +
-  scale_color_brewer(palette = "Dark2")
+
+```{r, eval = has_umap && has_submitter}
+knitr::asis_output(
+  "### UMAPs colored by submitter-provided annotations"
+)
+```
+
+```{r, eval = has_submitter && has_umap, message=FALSE, warning=FALSE, fig.height = 9, fig.width=9}
+# get list of cell types for CellAssign
+submitter_celltypes <- list_celltypes(celltype_df,
+  celltype_column = "submitter_celltype_annotation"
+)
+# plot CellAssign UMAPs
+submitter_celltypes |>
+  purrr::map(\(celltype){
+    make_umap_panels(umap_df,
+      annotation_column = "submitter_celltype_annotation_lumped",
+      celltype
+    )
+  }) |>
+  patchwork::wrap_plots(all_umaps)
 ```
 
 
-```{r eval=has_singler && has_umap, message=FALSE, warning=FALSE}
-plot_umap(
-  umap_df,
-  singler_celltype_annotation_lumped,
-  "Cell types",
-  legend_nrow = 4
-) +
-  ggtitle("UMAP colored by SingleR annotations") +
-  scale_color_brewer(palette = "Dark2")
+
+```{r, eval = has_umap && has_singler}
+knitr::asis_output(
+  "### UMAPs colored by SingleR annotations"
+)
+```
+
+```{r, eval=has_singler && has_umap, message=FALSE, warning=FALSE, fig.height=9, fig.width=9}
+# get list of cell types for CellAssign
+singler_celltypes <- list_celltypes(celltype_df,
+  celltype_column = "singler_celltype_annotation"
+)
+# plot CellAssign UMAPs
+singler_celltypes |>
+  purrr::map(\(celltype){
+    make_umap_panels(umap_df,
+      annotation_column = "singler_celltype_annotation_lumped",
+      celltype
+    )
+  }) |>
+  patchwork::wrap_plots(all_umaps,
+    nrow = 3,
+    ncol = 3
+  )
 ```
 
 
-```{r, eval = has_cellassign && has_umap, message=FALSE, warning=FALSE}
-plot_umap(
-  umap_df,
-  cellassign_celltype_annotation_lumped,
-  "Cell types",
-  legend_nrow = 4
-) +
-  ggtitle("UMAP colored by CellAssign annotations") +
-  scale_color_brewer(palette = "Dark2")
+
+
+```{r, eval = has_umap && has_cellassign}
+knitr::asis_output(
+  "### UMAPs colored by CellAssign annotations"
+)
+```
+
+```{r, eval = has_cellassign && has_umap, message=FALSE, warning=FALSE, fig.height = 9, fig.width=9}
+# get list of cell types for CellAssign
+cellassign_celltypes <- list_celltypes(celltype_df,
+  celltype_column = "cellassign_celltype_annotation"
+)
+# plot CellAssign UMAPs
+cellassign_celltypes |>
+  purrr::map(\(celltype){
+    make_umap_panels(umap_df,
+      annotation_column = "cellassign_celltype_annotation_lumped",
+      celltype
+    )
+  }) |>
+  patchwork::wrap_plots(all_umaps)
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -50,7 +50,7 @@ format_celltype_n_table <- function(df) {
 #' @param n_celltypes Number of groups to lump into, with rest put into "Other" group. Default is 7.
 #'
 #' @return Updated df with new column of lumped celltypes for each present method
-lump_celltypes <- function(df, n_celltypes = 8) {
+lump_celltypes <- function(df, n_celltypes = 7) {
   df <- df |>
     dplyr::mutate(
       across(
@@ -111,71 +111,53 @@ plot_umap <- function(
 }
 
 
-#' Create a UMAP panel showing cells that belong to a specific cell type
+#' Create a faceted UMAP panel where each panel has only one cell type colored
 #'
 #' @param umap_df Data frame with UMAP1 and UMAP2 columns
 #' @param annotation_column Column containing cell type annotations
-#' @param celltype Cell type to indicate on UMAP. All cells of this cell type will be colored with red.
 #'
-#' @return ggplot object containing a UMAP where all cells of the specified
-#'   `celltype` are colored in red and all other cells are grey.
+#' @return ggplot object containing a faceted UMAP where each cell type is a facet.
+#'   In each panel, the cell type of interest is colored and all other cells are grey.
 
-make_umap_panels <- function(umap_df,
-                             annotation_column,
-                             celltype) {
-  # add a new column indicating how cells should be colored
-  # only keep the cell type of interest and label the rest as other
-  color_umap_df <- umap_df |>
-    dplyr::mutate(
-      color_column = ifelse(get({{ annotation_column }}) == {{ celltype }}, celltype, "Other"),
-      # make sure Other is the second level
-      color_column = forcats::fct_relevel(color_column, "Other", after = Inf)
-    )
-
-  umap_panel <- ggplot(color_umap_df) +
-    aes(
-      x = UMAP1,
-      y = UMAP2,
-      color = color_column
-    ) +
+faceted_umap <- function(umap_df,
+                         annotation_column) {
+  # color by the annotation column but only color one cell type at a time
+  faceted_umap <- ggplot(
+    umap_df,
+    aes(x = UMAP1, y = UMAP2, color = {{ annotation_column }})
+  ) +
+    # set points for all "other" points
     geom_point(
-      size = 0.3,
-      alpha = 0.5
+      data = select(
+        umap_df, -{{ annotation_column }}
+      ),
+      color = "grey",
+      alpha = 0.5,
+      size = 0.3
     ) +
+    # set points for desired cell type
+    geom_point(size = 0.3, alpha = 0.5) +
+    facet_wrap(vars({{ annotation_column }})) +
+    scale_color_brewer(palette = "Dark2") +
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) +
     scale_y_continuous(labels = NULL, breaks = NULL) +
-    theme(
-      # no legend here
-      legend.position = "None"
+    guides(
+      color = guide_legend(
+        title = "Cell types",
+        nrow = 2,
+        # more visible points in legend
+        override.aes = list(
+          alpha = 1,
+          size = 1.5
+        )
+      )
     ) +
-    # celltype will be red, other will be grey
-    scale_color_manual(values = c("red", "grey")) +
-    labs(title = celltype)
+    theme(
+      legend.position = "bottom"
+    )
 
-  return(umap_panel)
-}
-
-
-#' Generate a list of top cell types found in a given column
-#'
-#' @param celltype_df Data frame with cell types
-#' @param celltype_column Column containing cell type annotations
-#' @param num_celltypes Number of cell types to keep
-#'
-#' @return A list of the top cell types, with the last element being "All remaining cell types"
-
-list_celltypes <- function(celltype_df,
-                           celltype_column,
-                           num_celltypes = 8) {
-  celltype_list <- create_celltype_n_table(celltype_df, !!sym(celltype_column)) |>
-    dplyr::mutate(`Annotated cell type` = as.character(`Annotated cell type`)) |>
-    dplyr::slice_max(`Number of cells`, n = num_celltypes, with_ties = FALSE) |>
-    dplyr::pull(`Annotated cell type`)
-
-  celltype_list <- c(celltype_list, "All remaining cell types")
-
-  return(celltype_list)
+  return(faceted_umap)
 }
 ```
 
@@ -336,7 +318,8 @@ if (length(levels(umap_df$cluster)) <= 8) {
 ```{r, eval = has_umap}
 knitr::asis_output(
   'Next, we show UMAPs colored by cell types.
-A separate UMAP is shown for each cell typing method used.
+For each cell typing method, we show a separate faceted UMAP.
+In each panel, cells that correspond to a single cell type are colored, while all other cells are in grey.
 
 For legibility, only the seven most common cell types are shown.
 All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell type" which represents cells that could not be classified).
@@ -346,77 +329,32 @@ All other cell types are grouped together and labeled "All remaining cell types"
 
 <!-- Now, UMAPs of cell types, where present -->
 
-
-```{r, eval = has_umap && has_submitter}
-knitr::asis_output(
-  "### UMAPs colored by submitter-provided annotations"
-)
-```
-
 ```{r, eval = has_submitter && has_umap, message=FALSE, warning=FALSE, fig.height = 9, fig.width=9}
-# get list of cell types for CellAssign
-submitter_celltypes <- list_celltypes(celltype_df,
-  celltype_column = "submitter_celltype_annotation"
-)
-# plot CellAssign UMAPs
-submitter_celltypes |>
-  purrr::map(\(celltype){
-    make_umap_panels(umap_df,
-      annotation_column = "submitter_celltype_annotation_lumped",
-      celltype
-    )
-  }) |>
-  patchwork::wrap_plots(all_umaps)
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  submitter_celltype_annotation_lumped
+) +
+  ggtitle("UMAP colored by submitter-provided annotations")
 ```
 
-
-
-```{r, eval = has_umap && has_singler}
-knitr::asis_output(
-  "### UMAPs colored by SingleR annotations"
-)
-```
 
 ```{r, eval=has_singler && has_umap, message=FALSE, warning=FALSE, fig.height=9, fig.width=9}
-# get list of cell types for CellAssign
-singler_celltypes <- list_celltypes(celltype_df,
-  celltype_column = "singler_celltype_annotation"
-)
-# plot CellAssign UMAPs
-singler_celltypes |>
-  purrr::map(\(celltype){
-    make_umap_panels(umap_df,
-      annotation_column = "singler_celltype_annotation_lumped",
-      celltype
-    )
-  }) |>
-  patchwork::wrap_plots(all_umaps,
-    nrow = 3,
-    ncol = 3
-  )
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  singler_celltype_annotation_lumped
+) +
+  ggtitle("UMAP colored by CellAssign annotations")
 ```
 
 
-
-
-```{r, eval = has_umap && has_cellassign}
-knitr::asis_output(
-  "### UMAPs colored by CellAssign annotations"
-)
-```
 
 ```{r, eval = has_cellassign && has_umap, message=FALSE, warning=FALSE, fig.height = 9, fig.width=9}
-# get list of cell types for CellAssign
-cellassign_celltypes <- list_celltypes(celltype_df,
-  celltype_column = "cellassign_celltype_annotation"
-)
-# plot CellAssign UMAPs
-cellassign_celltypes |>
-  purrr::map(\(celltype){
-    make_umap_panels(umap_df,
-      annotation_column = "cellassign_celltype_annotation_lumped",
-      celltype
-    )
-  }) |>
-  patchwork::wrap_plots(all_umaps)
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  cellassign_celltype_annotation_lumped
+) +
+  ggtitle("UMAP colored by CellAssign annotations")
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -145,7 +145,6 @@ faceted_umap <- function(umap_df,
     guides(
       color = guide_legend(
         title = "Cell types",
-        nrow = 2,
         # more visible points in legend
         override.aes = list(
           alpha = 1,
@@ -154,7 +153,9 @@ faceted_umap <- function(umap_df,
       )
     ) +
     theme(
-      legend.position = "bottom"
+      legend.position = c(.9, 0),
+      legend.justification = c("right", "bottom"),
+      legend.title.align = 0.5
     )
 
   return(faceted_umap)
@@ -345,7 +346,7 @@ faceted_umap(
   umap_df,
   singler_celltype_annotation_lumped
 ) +
-  ggtitle("UMAP colored by CellAssign annotations")
+  ggtitle("UMAP colored by SingleR annotations")
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -339,19 +339,18 @@ if (has_singler) {
 }
 
 if (has_cellassign) {
-  
   organs <- metadata(processed_sce)$cellassign_reference_organs |>
     stringr::str_to_lower()
   # split up and add an `and` before the final organ
-  organs_string <- stringr::str_split_1(organs, pattern = ", ") |> 
+  organs_string <- stringr::str_split_1(organs, pattern = ", ") |>
     stringr::str_flatten_comma(last = ", and ")
-  
+
   ref_name <- metadata(processed_sce)$cellassign_reference
 
   methods_text <- glue::glue(
     "{methods_text}
     * Annotations from [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)).
-    Marker genes for cell types were obtained from [PanglaoDB](https://panglaodb.se/) and compiled into a reference named `{ref_name}`. 
+    Marker genes for cell types were obtained from [PanglaoDB](https://panglaodb.se/) and compiled into a reference named `{ref_name}`.
     This reference includes the following organs and tissue compartments: {organs_string}.\n"
   )
 }
@@ -528,8 +527,8 @@ singler_cellassign_matrix <- make_jaccard_matrix(
 
 create_single_heatmap(
   singler_cellassign_matrix,
-  row_title = "SingleR annotations",
-  column_title = "CellAssign annotations",
+  row_title = "CellAssign annotations",
+  column_title = "SingleR annotations",
   labels_font_size = find_label_size(all_celltypes),
   keep_legend_name = "SingleR annotations",
   col_fun = heatmap_col_fun,


### PR DESCRIPTION
Closes #611 
Closes #612 

In evaluating some of the reports from running cell typing, I noticed that it was hard to discern which cell belonged to which cell type because of the colors we were using. I tried some other color palettes, including `Okabe-Ito`, and it improved the colors, but there are definitely still some issues with discerning cells in the plot. After talking through this with Stephanie on Slack, we decided to try a different approach and make a panel of UMAPs. Here, each UMAP shows the cell type of interest in red and all other cells in grey. We are still limiting it to only show the top cell types, but I actually think this is a lot more clear and easier to distinguish cells. To accomplish this I did the following: 

- I created a new function for producing each of the UMAP panels. For each cell type, we have to make a new column designating if the cell belongs to the cell type of interest or other cells. That column is used to color the UMAP. 
- I also created a function to generate the list of top cell types. I tried just pulling the unique labels from the `celltype_annotation_lumped` column, but doing that pulled them in a random order and I want the UMAPs to be in order of cell type frequency. I also want `All remaining cell types` to be the last plot. 
- For each of the top cell types, I generate a UMAP panel and then use `patchwork::wrap_plots` to combine them. 
- I updated the number of cell types to keep before lumping all the rest to be 8. We were previously only showing 7 because we were limited by color palettes. Now by using 8 + the `All remaining cell types`, we have a 3x3 grid for the UMAPs. 

While working on this, I also switched the axes labels for the automated annotations heatmap to address #611. 

A few other notes: 

- I was seeing cases where we had ties, so the `lump_celltypes` was actually returning more than the specified cell type number. I updated that to always take the first match. 
- I did hard code the figure height and width for the UMAP plots to be 9 x 9. I don't imagine very many scenarios where we have fewer cell types, because I haven't really seen that when looking at some of the reports. However, that doesn't mean that can't happen. Do we want to try and adjust the number of cols, rows, and then figure height and width based on the number of cell types?
- I didn't adjust the text yet, because I want to make sure we like these plots. Then I can update the explanatory text for interpreting the plots in another PR.

Here's an example of the updated plots.
<img width="568" alt="Screenshot 2023-12-11 at 1 27 48 PM" src="https://github.com/AlexsLemonade/scpca-nf/assets/54039191/9493a304-6997-4356-85bc-63dffc4c10b9">

And an updated report. 
[main_qc_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/13640139/main_qc_report.html.zip)


