### PR TITLE
Add y axis label for CellAssign probability plot

### DIFF
--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -749,7 +749,7 @@ ggplot(celltype_df) +
   ) +
   labs(
     x = "Probability of annotated cell type",
-    y = ""
+    y = "Cell type annotation"
   ) +
   scale_x_continuous(limits = c(0, 1)) +
   scale_y_continuous(expand = c(0.1, 0.1)) +


### PR DESCRIPTION
Here I just added a label for the y-axis for the CellAssign plot to mirror what we have in the SingleR delta median plot. 