### PR TITLE
Compress AnnData output

### DIFF
--- a/bin/move_counts_anndata.py
+++ b/bin/move_counts_anndata.py
@@ -22,14 +22,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 # compile extension regex
-file_ext = re.compile(r"\.hdf5$|.h5$", re.IGNORECASE)
+file_ext = re.compile(r"\.hdf5$|.h5$|.h5ad$", re.IGNORECASE)
 
 # check that input file exists, if it does exist, make sure it's an h5 file
 if not os.path.exists(args.anndata_file):
     raise FileExistsError("`input_anndata` does not exist.")
 elif not file_ext.search(args.anndata_file):
     raise ValueError(
-        "--input_anndata must end in either .hdf5 or .h5 and contain a processed AnnData object."
+        "--input_anndata must end in either .hdf5, .h5, or .h5ad, and contain a processed AnnData object."
     )
 
 # read in anndata
@@ -44,4 +44,4 @@ if "logcounts" in object.layers:
     object.uns["X_name"] = "logcounts"
 
     # export object
-    object.write_h5ad(args.anndata_file)
+    object.write_h5ad(args.anndata_file, compression="gzip")

--- a/bin/move_counts_anndata.py
+++ b/bin/move_counts_anndata.py
@@ -18,6 +18,13 @@ parser.add_argument(
     required=True,
     help="Path to HDF5 file with processed AnnData object",
 )
+parser.add_argument(
+    "-u",
+    "--uncompressed",
+    dest="compress",
+    action="store_false",
+    help="Output an uncompressed HDF5 file",
+)
 
 args = parser.parse_args()
 
@@ -44,4 +51,4 @@ if "logcounts" in object.layers:
     object.uns["X_name"] = "logcounts"
 
     # export object
-    object.write_h5ad(args.anndata_file, compression="gzip")
+    object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)

--- a/bin/move_counts_anndata.py
+++ b/bin/move_counts_anndata.py
@@ -22,7 +22,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 # compile extension regex
-file_ext = re.compile(r"\.hdf5$|.h5$|.h5ad$", re.IGNORECASE)
+file_ext = re.compile(r"\.hdf5$|\.h5$|\.h5ad$", re.IGNORECASE)
 
 # check that input file exists, if it does exist, make sure it's an h5 file
 if not os.path.exists(args.anndata_file):

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -32,7 +32,7 @@ option_list <- list(
     opt_str = c("--output_feature_h5"),
     type = "character",
     help = "path to output hdf5 file to store feature counts as AnnData object.
-    Only used if the input SCE contains an altExp. Must end in .hdf5 or .h5"
+    Only used if the input SCE contains an altExp. Must end in .hdf5, .h5, or .h5ad"
   ),
   make_option(
     opt_str = c("--compress_output"),
@@ -52,8 +52,8 @@ if (!file.exists(opt$input_sce_file)) {
 }
 
 # check that output file is h5
-if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5"))) {
-  stop("output rna file name must end in .hdf5 or .h5")
+if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5|.h5ad"))) {
+  stop("output rna file name must end in .hdf5, .h5, or .h5ad")
 }
 
 # CZI compliance function ------------------------------------------------------
@@ -141,8 +141,8 @@ if (!is.null(opt$feature_name)) {
   }
 
   # check for output file
-  if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
-    stop("output feature file name must end in .hdf5 or .h5")
+  if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5|.h5ad"))) {
+    stop("output feature file name must end in .hdf5, .h5, or .h5ad")
   }
 
   # extract altExp
@@ -159,7 +159,8 @@ if (!is.null(opt$feature_name)) {
     # export altExp sce as anndata object
     scpcaTools::sce_to_anndata(
       alt_sce,
-      anndata_file = opt$output_feature_h5
+      anndata_file = opt$output_feature_h5,
+      compression = ifelse(opt$compress_output, "gzip", "none")
     )
   } else {
     # warn that the altExp cannot be converted

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -33,6 +33,12 @@ option_list <- list(
     type = "character",
     help = "path to output hdf5 file to store feature counts as AnnData object.
     Only used if the input SCE contains an altExp. Must end in .hdf5 or .h5"
+  ),
+  make_option(
+    opt_str = c("--compress_output"),
+    action = "store_true",
+    default = FALSE,
+    help = "Compress the HDF5 file containing the AnnData object"
   )
 )
 
@@ -114,12 +120,19 @@ sample_metadata <- metadata(sce)$sample_metadata
 # make main sce czi compliant
 sce <- format_czi(sce)
 
+if (opt$compress_output) {
+  compression <- "gzip"
+} else {
+  compression <- "none"
+}
+
 # export sce as anndata object
 # this function will also remove any R-specific object types from the SCE metadata
 #   before converting to AnnData
 scpcaTools::sce_to_anndata(
   sce,
-  anndata_file = opt$output_rna_h5
+  anndata_file = opt$output_rna_h5,
+  compression = compression
 )
 
 # AltExp to AnnData -----------------------------------------------------------

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -67,7 +67,9 @@ format_czi <- function(sce) {
 
   # add library_id as an sce colData column
   # need this column to join in the sample metadata with the colData
-  sce$library_id <- metadata(sce)$library_id
+  if (!("library_id" %in% colnames(colData(sce)))) {
+    sce$library_id <- metadata(sce)$library_id
+  }
 
   # add sample metadata to colData sce
   sce <- scpcaTools::metadata_to_coldata(
@@ -89,7 +91,7 @@ format_czi <- function(sce) {
   # add colData back to sce object
   colData(sce) <- DataFrame(
     coldata_df,
-    row.names = coldata_df$barcodes
+    row.names = rownames(colData(sce))
   )
 
   # remove sample metadata from sce metadata, otherwise conflicts with converting object

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -122,19 +122,13 @@ sample_metadata <- metadata(sce)$sample_metadata
 # make main sce czi compliant
 sce <- format_czi(sce)
 
-if (opt$compress_output) {
-  compression <- "gzip"
-} else {
-  compression <- "none"
-}
-
 # export sce as anndata object
 # this function will also remove any R-specific object types from the SCE metadata
 #   before converting to AnnData
 scpcaTools::sce_to_anndata(
   sce,
   anndata_file = opt$output_rna_h5,
-  compression = compression
+  compression = ifelse(opt$compress_output, "gzip", "none")
 )
 
 # AltExp to AnnData -----------------------------------------------------------

--- a/merge.nf
+++ b/merge.nf
@@ -30,7 +30,7 @@ if(param_error){
 // merge individual SCE objects into one SCE object
 process merge_sce {
   container params.SCPCATOOLS_CONTAINER
-  label 'mem_16'
+  label 'mem_32'
   publishDir "${params.results_dir}/merged/${merge_group_id}"
   input:
     tuple val(merge_group_id), val(has_adt), val(library_ids), path(scpca_nf_file)
@@ -87,7 +87,7 @@ process merge_report {
 
 process export_anndata{
     container params.SCPCATOOLS_CONTAINER
-    label 'mem_16'
+    label 'mem_32'
     tag "${merge_group}"
     publishDir "${params.results_dir}/merged/${merge_group}", mode: 'copy'
     input:

--- a/merge.nf
+++ b/merge.nf
@@ -102,7 +102,8 @@ process export_anndata{
         --input_sce_file ${merged_sce_file} \
         --output_rna_h5 ${rna_hdf5_file} \
         --output_feature_h5 ${feature_hdf5_file} \
-        ${has_adt ? "--feature_name adt" : ''}
+        ${has_adt ? "--feature_name adt" : ''} \
+        --compress_output
 
       # move normalized counts to X in AnnData
       move_counts_anndata.py --anndata_file ${rna_hdf5_file}

--- a/merge.nf
+++ b/merge.nf
@@ -102,8 +102,7 @@ process export_anndata{
         --input_sce_file ${merged_sce_file} \
         --output_rna_h5 ${rna_hdf5_file} \
         --output_feature_h5 ${feature_hdf5_file} \
-        ${has_adt ? "--feature_name adt" : ''} \
-        --compress_output
+        ${has_adt ? "--feature_name adt" : ''} 
 
       # move normalized counts to X in AnnData
       move_counts_anndata.py --anndata_file ${rna_hdf5_file}

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -18,7 +18,8 @@ process export_anndata{
         --input_sce_file ${sce_file} \
         --output_rna_h5 ${rna_hdf5_file} \
         --output_feature_h5 ${feature_hdf5_file} \
-        ${feature_present ? "--feature_name ${meta.feature_type}" : ''}
+        ${feature_present ? "--feature_name ${meta.feature_type}" : ''} \
+        ${file_type != "processed" ? "--compress_output" : ''}
 
       # move any normalized counts to X in AnnData
       if [ "${file_type}" = "processed" ]; then


### PR DESCRIPTION
Closes #616 

This PR adds a new flag, `--compress_output` to the script for converting objects from SCE to AnnData. This means that by default we set compression to `none`, unless the flag is used. This allows us to specify compressing only for files that are not processed. 

For zipping the processed files, I added the argument to the `object.writeH5AD()` function. 

I did not change the extension of the HDF5 files here, because that change doesn't just affect us. I think if we want to do that we should do that separately. 

I tested both the main and merging workflow to be sure that the new additions work. 