### PR TITLE
Update batch profile to set max aws retries and On Demand queue

### DIFF
--- a/config/profile_awsbatch_auto.config
+++ b/config/profile_awsbatch_auto.config
@@ -3,10 +3,10 @@ workDir = 's3://nextflow-ccdl-data/work'
 aws{
   batch{
     cliPath = '/home/ec2-user/miniconda/bin/aws'
-    maxTransferAttempts = 2
     volumes = [
       '/ebs-autoscale:/tmp'
     ]
+    maxTransferAttempts = 2
     maxSpotAttempts = 2
   }
   region = 'us-east-1'

--- a/config/profile_awsbatch_auto.config
+++ b/config/profile_awsbatch_auto.config
@@ -15,5 +15,5 @@ aws{
 
 process{
   executor = 'awsbatch'
-  queue = { task.attempt < 2 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'}
+  queue = { task.attempt < 3 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'}
 }

--- a/config/profile_awsbatch_auto.config
+++ b/config/profile_awsbatch_auto.config
@@ -7,6 +7,7 @@ aws{
     volumes = [
       '/ebs-autoscale:/tmp'
     ]
+    maxSpotAttempts = 2
   }
   region = 'us-east-1'
 }
@@ -14,5 +15,5 @@ aws{
 
 process{
   executor = 'awsbatch'
-  queue = 'nextflow-batch-autoscale-queue'
+  queue = { task.attempt < 2 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'}
 }


### PR DESCRIPTION
Closes #623 

Here I updated the `batch` profile to use `maxSpotsAttempts = 2`, instead of the default of 5. 
I also udpated the `queue` so that for the first two tries we use the auto scale queue we have been using, but for the third retry we use an On Demand queue. 

I think we might want to actually test this with a few libraries before we merge this in? 

Also, I'm merging this into main so that we can release this along with any CPU changes that may happen before processing the projects through CellAssign again. 