### PR TITLE
Update CPU and mem requests for CellAssign

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -51,6 +51,6 @@ def check_memory(memory){
 
 def check_cpus(cpus, max_cpus){
   cpus = cpus as int
-  def max_cpus = max_cpus as int
+  max_cpus = max_cpus as int
   cpus < max_cpus ? cpus : max_cpus
 }

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -22,7 +22,7 @@ process{
     memory = {check_memory(32.GB * task.attempt)}
   }
   withLabel: mem_96 {
-    memory = {check_memory(96.GB * task.attempt)}
+    memory = {check_memory(48.GB  + 48.GB * task.attempt)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -10,19 +10,19 @@ process{
   maxErrors = '-1'
 
   withLabel: mem_8 {
-    memory = {check_memory(8.GB * task.attempt)}
+    memory = {check_memory(8.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_16 {
-    memory = {check_memory(16.GB * task.attempt)}
+    memory = {check_memory(16.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_24 {
-    memory = {check_memory(24.GB * task.attempt)}
+    memory = {check_memory(24.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_32 {
-    memory = {check_memory(32.GB * task.attempt)}
+    memory = {check_memory(32.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_96 {
-    memory = {check_memory(48.GB  + 48.GB * task.attempt)}
+    memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}
@@ -43,9 +43,9 @@ process{
 
 
 // Resource check functions
-def check_memory(memory){
+def check_memory(memory, max_memory){
   memory = memory as nextflow.util.MemoryUnit
-  def max_memory = params.max_memory as nextflow.util.MemoryUnit
+  max_memory = max_memory as nextflow.util.MemoryUnit
   memory < max_memory ? memory : max_memory
 }
 

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -3,7 +3,7 @@ params.max_cpus = 24
 params.max_memory = 96.GB
 
 process{
-  memory = {check_memory(4.GB * task.attempt)}
+  memory = {check_memory(4.GB * task.attempt, params.max_memory)}
 
   errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 2

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -25,19 +25,19 @@ process{
     memory = {check_memory(48.GB  + 48.GB * task.attempt)}
   }
   withLabel: cpus_2  {
-    cpus = {check_cpus(2)}
+    cpus = {check_cpus(2, params.max_cpus)}
   }
   withLabel: cpus_4  {
-    cpus = {check_cpus(4)}
+    cpus = {check_cpus(4, params.max_cpus)}
   }
   withLabel: cpus_8  {
-    cpus = {check_cpus(8)}
+    cpus = {check_cpus(8, params.max_cpus)}
   }
   withLabel: cpus_12 {
-    cpus = {check_cpus(12)}
+    cpus = {check_cpus(12, params.max_cpus)}
   }
   withLabel: cpus_24 {
-    cpus = {check_cpus(24)}
+    cpus = {check_cpus(24, params.max_cpus)}
   }
 }
 
@@ -49,8 +49,8 @@ def check_memory(memory){
   memory < max_memory ? memory : max_memory
 }
 
-def check_cpus(cpus){
+def check_cpus(cpus, max_cpus){
   cpus = cpus as int
-  def max_cpus = params.max_cpus as int
+  def max_cpus = max_cpus as int
   cpus < max_cpus ? cpus : max_cpus
 }

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -21,8 +21,8 @@ process{
   withLabel: mem_32 {
     memory = {check_memory(32.GB * task.attempt)}
   }
-  withLabel: mem_128 {
-    memory = {check_memory(128.GB * task.attempt)}
+  withLabel: mem_96 {
+    memory = {check_memory(96.GB * task.attempt)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2)}

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -16,4 +16,7 @@ params{
   // cell type references
   project_celltype_metafile = "s3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv"
 
+  // set max cpus and memory for internal use
+  max_cpus = 64
+  max_memory = 256.GB
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -45,8 +45,8 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_128'
-  label 'cpus_24'
+  label 'mem_96'
+  label 'cpus_12'
   tag "${meta.library_id}"
   input:
     tuple val(meta), path(processed_rds), path(cellassign_reference_file)


### PR DESCRIPTION
Based on what we found in #622, we want to use 96 GB and 12 cpus for classifying with CellAssign. This PR adds a new label for 96, removing the old 128 GB label. And then updates the process to use the desired resources. 