### PR TITLE
Make sure cell type report file name matches the docs

### DIFF
--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -28,7 +28,7 @@ process sce_qc_report{
     // check for cell types
     // only provide report template if cell typing was performed and either singler or cellassign was used
     has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
-    celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
+    celltype_report = "${meta.library_id}_cell_type_report.html" // rendered HTML
     celltype_template_path = "${template_dir}/${celltype_template_file}" // template input
 
     """


### PR DESCRIPTION
I noticed that we show the filename of the cell type report in the [screenshots](https://github.com/AlexsLemonade/scpca-docs/blob/sjspielman/celltype-release/docs/images/sample-download-folder.png) and in the[ download section of the docs](https://github.com/AlexsLemonade/scpca-docs/blob/sjspielman/celltype-release/docs/download_files.md) and it doesn't match up with the filename that we are using here. 

I updated the output file to be `SCPCL000000_cell_type_report.html` to be consistent with how we named it in the docs. 