### PR TITLE
Fail for missing mapping files, and other missing files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -112,7 +112,7 @@ workflow {
     log.info("Executing workflow for all runs in the run metafile.")
   }
 
-  ref_paths = Utils.readMeta(file(params.ref_json))
+  ref_paths = Utils.readMeta(file(params.ref_json, checkIfExists: true))
 
   unfiltered_runs_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
@@ -223,7 +223,7 @@ workflow {
       single: true
     }
   // apply cellhash demultiplexing
-  cellhash_demux_ch = cellhash_demux_sce(feature_sce_ch.cellhash, file(params.cellhash_pool_file))
+  cellhash_demux_ch = cellhash_demux_sce(feature_sce_ch.cellhash, file(params.cellhash_pool_file, checkIfExists: true))
   merged_sce_ch = cellhash_demux_ch.mix(feature_sce_ch.single)
 
   // join SCE outputs and branch by genetic multiplexing

--- a/main.nf
+++ b/main.nf
@@ -51,7 +51,12 @@ if (!file(params.run_metafile).exists()) {
   param_error = true
 }
 
-sample_metafile = file(params.sample_metafile)
+sample_metafile = file(params.sample_metafile) // we make this for passing into later processes
+if (!sample_metafile.exists()) {
+  log.error("The 'sample_metafile' file '${params.sample_metafile}' can not be found.")
+  param_error = true
+}
+
 if (!sample_metafile.exists()) {
   log.error("The 'sample_metafile' file '${params.sample_metafile}' can not be found.")
   param_error = true
@@ -73,6 +78,17 @@ if (params.perform_celltyping) {
     log.error("The 'celltype_ref_metadata' file '${params.celltype_ref_metadata}' can not be found.")
     param_error = true
   }
+
+  if (!file("${projectDir}/templates/qc_report/${celltype_report_template_file}").exists()) {
+    log.error("The 'celltype_report_template_file' file '${celltype_report_template_file}' can not be found.")
+    param_error = true
+  }
+}
+
+// QC report check
+if (!file("${projectDir}/templates/qc_report/${report_template_file}").exists()) {
+  log.error("The 'report_template_file' file '${report_template_file}' can not be found.")
+  param_error = true
 }
 
 if(param_error){

--- a/main.nf
+++ b/main.nf
@@ -118,7 +118,7 @@ workflow {
     log.info("Executing workflow for all runs in the run metafile.")
   }
 
-  ref_paths = Utils.readMeta(file(params.ref_json, checkIfExists: true))
+  ref_paths = Utils.readMeta(file(params.ref_json))
 
   unfiltered_runs_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')

--- a/main.nf
+++ b/main.nf
@@ -25,7 +25,7 @@ citeseq_techs = single_cell_techs.findAll{it.startsWith('CITEseq')}
 cellhash_techs = single_cell_techs.findAll{it.startsWith('cellhash')}
 
 // report template paths
-report_template_dir = file("${projectDir}/templates/qc_report", type: 'dir')
+report_template_dir = file("${projectDir}/templates/qc_report", type: 'dir', checkIfExists: true)
 report_template_file = "main_qc_report.rmd"
 celltype_report_template_file = "celltypes_supplemental_report.rmd"
 report_template_tuple = tuple(report_template_dir, report_template_file, celltype_report_template_file)

--- a/main.nf
+++ b/main.nf
@@ -68,6 +68,17 @@ if (!resolution_strategies.contains(params.af_resolution)) {
   param_error = true
 }
 
+if (params.cellhash_pool_file && !file(params.cellhash_pool_file).exists()){
+  log.error("The 'cellhash_pool_file' file ${cellhash_pool_file} can not be found.")
+  param_error = true
+}
+
+// QC report check
+if (!file("${projectDir}/templates/qc_report/${report_template_file}").exists()) {
+  log.error("The 'report_template_file' file '${report_template_file}' can not be found.")
+  param_error = true
+}
+
 // cell type annotation file checks
 if (params.perform_celltyping) {
   if (!file(params.project_celltype_metafile).exists()) {
@@ -85,11 +96,6 @@ if (params.perform_celltyping) {
   }
 }
 
-// QC report check
-if (!file("${projectDir}/templates/qc_report/${report_template_file}").exists()) {
-  log.error("The 'report_template_file' file '${report_template_file}' can not be found.")
-  param_error = true
-}
 
 if(param_error){
   System.exit(1)
@@ -223,7 +229,7 @@ workflow {
       single: true
     }
   // apply cellhash demultiplexing
-  cellhash_demux_ch = cellhash_demux_sce(feature_sce_ch.cellhash, file(params.cellhash_pool_file, checkIfExists: true))
+  cellhash_demux_ch = cellhash_demux_sce(feature_sce_ch.cellhash, file(params.cellhash_pool_file))
   merged_sce_ch = cellhash_demux_ch.mix(feature_sce_ch.single)
 
   // join SCE outputs and branch by genetic multiplexing

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -162,7 +162,7 @@ workflow map_quant_feature{
       .branch{
         make_rad: (
           // input files exist
-          file($it.files_directory, type: "dir").exists() && (
+          file(it.files_directory, type: "dir").exists() && (
             // and repeat has been requested
             params.repeat_mapping
             // or the feature rad file directory does not exist

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -169,7 +169,16 @@ workflow map_quant_feature{
             || !file(it.feature_rad_dir).exists()
           )
         )
-        has_rad: true
+        has_rad: file(it.feature_rad_dir).exists()
+        missing_inputs: true
+      }
+
+    // send run ids in feature_ch.missing_inputs to log
+    feature_ch.missing_inputs
+      .subscribe{
+        if(it){
+          log.error("The expected feature input fastq or rad files for ${it.run_id} are missing.")
+        }
       }
 
     // pull out files that need to be repeated

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -161,12 +161,13 @@ workflow map_quant_feature{
       }
       .branch{
         make_rad: (
-          // repeat has been requested
-          params.repeat_mapping
-          // the feature directory does not exist
-          || !file(it.feature_rad_dir).exists()
-          // the assembly has changed; if feature_dir doesn't exist, this line won't get hit
-          || Utils.getMetaVal(file("${it.feature_rad_dir}/scpca-meta.json"), "ref_assembly") != "${it.ref_assembly}"
+          // input files exist
+          file($it.files_directory, type: "dir").exists() && (
+            // and repeat has been requested
+            params.repeat_mapping
+            // or the feature rad file directory does not exist
+            || !file(it.feature_rad_dir).exists()
+          )
         )
         has_rad: true
       }

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -159,6 +159,8 @@ workflow map_quant_feature{
         meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
+      // branch based on whether mapping should be run (make_rad) or skipped (has_rad)
+      // if neither fastq or rad dir are present, run goes into missing_inputs branch
       .branch{
         make_rad: (
           // input files exist
@@ -176,9 +178,7 @@ workflow map_quant_feature{
     // send run ids in feature_ch.missing_inputs to log
     feature_ch.missing_inputs
       .subscribe{
-        if(it){
-          log.error("The expected feature input fastq or rad files for ${it.run_id} are missing.")
-        }
+        log.error("The expected feature input fastq or rad files for ${it.run_id} are missing.")
       }
 
     // pull out files that need to be repeated

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -198,7 +198,7 @@ workflow map_quant_feature{
     // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
     feature_rad_ch = feature_ch.has_rad
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.feature_rad_dir}/scpca-meta.json", checkIfExists: true)),
+        Utils.readMeta(file("${meta.feature_rad_dir}/scpca-meta.json")),
         file(meta.feature_rad_dir, type: 'dir', checkIfExists: true)
       )}
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -141,7 +141,7 @@ workflow map_quant_rna {
     rna_channel.missing_inputs
       .subscribe{
         if(it){
-          log.error("The expected input fastq or rad files for ${it.run_id} is missing.")
+          log.error("The expected input fastq or rad files for ${it.run_id} are missing.")
         }
       }
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -137,6 +137,16 @@ workflow map_quant_rna {
         missing_inputs: true
       }
 
+    // send run ids in rna_channel.missing_inputs to log
+    // TODO: We might like to only have this error logged if rna_channel.missing_inputs is not empty
+    missing_ch = rna_channel.missing_inputs
+      .map{it.run_id}
+      .toList()
+      .subscribe{
+        log.error("The expected input fastq or rad files for the following runs are missing: ${it}.")
+      }
+
+
     // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
     rna_reads_ch = rna_channel.make_rad
       .map{meta -> tuple(

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -123,14 +123,18 @@ workflow map_quant_rna {
        // branch based on whether mapping should be run (make_rad) or skipped (has_rad)
       .branch{
         make_rad: (
-          // repeat has been requested
-          params.repeat_mapping
-          // the rad directory does not exist
-          || !file(it.rad_dir).exists()
-          // the assembly has changed; if rad_dir doesn't exist, this line won't get hit
-          || Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") != "${it.ref_assembly}"
+          // input files exist
+          file($it.files_directory, type: "dir").exists() && (
+            // and repeat has been requested
+            params.repeat_mapping
+            // the rad directory does not exist
+            || !file(it.rad_dir).exists()
+            // the assembly has changed; if rad_dir doesn't exist, this line won't get hit
+            || Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") != "${it.ref_assembly}"
+          )
         )
-        has_rad: true
+        has_rad: file(it.rad_dir).exists()
+        missing_inputs: true
       }
 
     // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -127,7 +127,7 @@ workflow map_quant_rna {
           params.repeat_mapping
           // the rad directory does not exist
           || !file(it.rad_dir).exists()
-          // the assembly has changed
+          // the assembly has changed; if rad_dir doesn't exist, this line won't get hit
           || Utils.getMetaVal(file("${it.rad_dir}/scpca-meta.json"), "ref_assembly") != "${it.ref_assembly}"
         )
         has_rad: true

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -120,7 +120,7 @@ workflow map_quant_rna {
         meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
-       // branch based on whether mapping should be run (make_rad) or skipped (has_rad).
+       // branch based on whether mapping should be run (make_rad) or skipped (has_rad)
        // if neither fastq or rad dir are present, run goes into missing_inputs branch
       .branch{
         make_rad: (

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -138,14 +138,12 @@ workflow map_quant_rna {
       }
 
     // send run ids in rna_channel.missing_inputs to log
-    // TODO: We might like to only have this error logged if rna_channel.missing_inputs is not empty
-    missing_ch = rna_channel.missing_inputs
-      .map{it.run_id}
-      .toList()
+    rna_channel.missing_inputs
       .subscribe{
-        log.error("The expected input fastq or rad files for the following runs are missing: ${it}.")
+        if(it){
+          log.error("The expected input fastq or rad files for ${it.run_id} is missing.")
+        }
       }
-
 
     // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])
     rna_reads_ch = rna_channel.make_rad

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -159,7 +159,7 @@ workflow map_quant_rna {
     // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
     rna_rad_ch = rna_channel.has_rad
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json", checkIfExists: true)),
+        Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json")),
         file(meta.rad_dir, type: 'dir', checkIfExists: true) // fail if no rad directory
       )}
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -138,8 +138,8 @@ workflow map_quant_rna {
       .map{meta -> tuple(
         meta,
         // fail if the fastq files do not exist
-        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz").exists(),
-        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz").exists(),
+        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
+        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true),
         file(meta.salmon_splici_index, type: 'dir')
       )}
 
@@ -148,7 +148,7 @@ workflow map_quant_rna {
     rna_rad_ch = rna_channel.has_rad
       .map{meta -> tuple(
         Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json")),
-        file(meta.rad_dir, type: 'dir').exists() // fail if no rad directory
+        file(meta.rad_dir, type: 'dir', checkIfExists: true) // fail if no rad directory
       )}
 
     // run Alevin for mapping on libraries that don't have RAD directory already created

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -124,7 +124,7 @@ workflow map_quant_rna {
       .branch{
         make_rad: (
           // input files exist
-          file($it.files_directory, type: "dir").exists() && (
+          file(it.files_directory, type: "dir").exists() && (
             // and repeat has been requested
             params.repeat_mapping
             // the rad directory does not exist

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -147,7 +147,7 @@ workflow map_quant_rna {
     // create tuple of metdata map (read from output) and rad_directory to be used directly as input to alevin-fry quantification
     rna_rad_ch = rna_channel.has_rad
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json")),
+        Utils.readMeta(file("${meta.rad_dir}/scpca-meta.json", checkIfExists: true)),
         file(meta.rad_dir, type: 'dir', checkIfExists: true) // fail if no rad directory
       )}
 

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -120,7 +120,8 @@ workflow map_quant_rna {
         meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
-       // branch based on whether mapping should be run (make_rad) or skipped (has_rad)
+       // branch based on whether mapping should be run (make_rad) or skipped (has_rad).
+       // if neither fastq or rad dir are present, run goes into missing_inputs branch
       .branch{
         make_rad: (
           // input files exist
@@ -140,9 +141,7 @@ workflow map_quant_rna {
     // send run ids in rna_channel.missing_inputs to log
     rna_channel.missing_inputs
       .subscribe{
-        if(it){
-          log.error("The expected input fastq or rad files for ${it.run_id} are missing.")
-        }
+        log.error("The expected input fastq or rad files for ${it.run_id} are missing.")
       }
 
     // If we need to create rad files, create a new channel with tuple of (metadata map, [Read1 files], [Read2 files])

--- a/modules/bulk-pileup.nf
+++ b/modules/bulk-pileup.nf
@@ -59,8 +59,8 @@ workflow pileup_multibulk{
         ],
         it[4], // bamfiles
         it[5], // bamfile indexes
-        file(it[2][0].ref_fasta),
-        file(it[2][0].ref_fasta_index)
+        file(it[2][0].ref_fasta, checkIfExists: true),
+        file(it[2][0].ref_fasta_index, checkIfExists: true)
       ]}
 
     mpileup(pileup_ch)

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -137,16 +137,16 @@ workflow bulk_quant_rna {
     // create tuple of metadata map (read from output), salmon output directory to use as input to merge_bulk_quants
     quants_ch = bulk_channel.has_quants
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json")),
-        file(meta.salmon_results_dir, type: 'dir')
+        Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json", checkIfExists: true)),
+        file(meta.salmon_results_dir, type: 'dir', checkIfExists: true)
       )}
 
     // If we need to run salmon, create tuple of (metadata map, [Read 1 files], [Read 2 files])
     bulk_reads_ch = bulk_channel.make_quants
       .map{meta -> tuple(
         meta,
-        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
-        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz")
+        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
+        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true)
       )}
 
     // run fastp and salmon for libraries that are not skipping salmon
@@ -166,7 +166,7 @@ workflow bulk_quant_rna {
       .map{[
         it[1][0], // meta; relevant data should all be the same by project, so take the first
         it[2].sort(), // salmon directories, sorted for consistency (we can do this because there is only one tuple element)
-        file(it[1][0].t2g_bulk_path)
+        file(it[1][0].t2g_bulk_path, checkIfExists: true)
       ]}
 
     // create tsv file and combined metadata for each project containing all libraries

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -137,7 +137,7 @@ workflow bulk_quant_rna {
     // create tuple of metadata map (read from output), salmon output directory to use as input to merge_bulk_quants
     quants_ch = bulk_channel.has_quants
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json", checkIfExists: true)),
+        Utils.readMeta(file("${meta.salmon_results_dir}/scpca-meta.json")),
         file(meta.salmon_results_dir, type: 'dir', checkIfExists: true)
       )}
 

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -38,9 +38,9 @@ workflow star_bulk{
     bulk_reads_ch = bulk_channel
         .map{meta -> tuple(
           meta,
-          file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz"),
-          file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz"),
-          file(meta.star_index, type: 'dir')
+          file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
+          file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true),
+          file(meta.star_index, type: 'dir', checkIfExists: true)
         )}
     // map and index
     bulkmap_star(bulk_reads_ch) \

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -194,7 +194,7 @@ workflow annotate_celltypes {
         skip_singler: (
           !params.repeat_celltyping
           && file(it[0].singler_results_file).exists()
-          && Utils.getMetaVal(file("${it[0].singler_dir}/scpca-meta.json", checkIfExists: true), "singler_model_file") == "${it[0].singler_model_file}"
+          && Utils.getMetaVal(file("${it[0].singler_dir}/scpca-meta.json"), "singler_model_file") == "${it[0].singler_model_file}"
         )
         missing_ref: it[2].name == "NO_FILE"
         do_singler: true
@@ -222,7 +222,7 @@ workflow annotate_celltypes {
         skip_cellassign: (
           !params.repeat_celltyping
           && file(it[0].cellassign_predictions_file).exists()
-          && Utils.getMetaVal(file("${it[0].cellassign_dir}/scpca-meta.json", checkIfExists: true), "cellassign_reference_file") == "${it[0].cellassign_reference_file}"
+          && Utils.getMetaVal(file("${it[0].cellassign_dir}/scpca-meta.json"), "cellassign_reference_file") == "${it[0].cellassign_reference_file}"
         )
         missing_ref: it[2].name == "NO_FILE"
         do_cellassign: true

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -139,7 +139,7 @@ workflow annotate_celltypes {
       ]
     }
     .filter{it.is_cell_line}
-    .map{it.sample_id} 
+    .map{it.sample_id}
     .toList()
 
     // branch to cell type the non-cell line libraries only
@@ -149,7 +149,7 @@ workflow annotate_celltypes {
         // only run cell typing on tissue samples
         tissue: true
       }
-    
+
     // get just the meta and processed sce from the tissue (not cell line) samples
     processed_sce_channel = sce_files_channel_branched.tissue.map{[it[0], it[3]]}
 
@@ -188,13 +188,13 @@ workflow annotate_celltypes {
     // creates [meta, processed sce, singler model file]
     singler_input_ch = celltype_input_ch
       // add in singler model or empty file
-      .map{it.toList() + [file(it[0].singler_model_file ?: empty_file)]}
+      .map{it.toList() + [file(it[0].singler_model_file ?: empty_file, checkIfExists: true)]}
       // skip if no singleR model file or if singleR results are already present
       .branch{
         skip_singler: (
           !params.repeat_celltyping
           && file(it[0].singler_results_file).exists()
-          && Utils.getMetaVal(file("${it[0].singler_dir}/scpca-meta.json"), "singler_model_file") == "${it[0].singler_model_file}"
+          && Utils.getMetaVal(file("${it[0].singler_dir}/scpca-meta.json", checkIfExists: true), "singler_model_file") == "${it[0].singler_model_file}"
         )
         missing_ref: it[2].name == "NO_FILE"
         do_singler: true
@@ -207,22 +207,22 @@ workflow annotate_celltypes {
     // singleR output channel: [library_id, singler_results]
     singler_output_ch = singler_input_ch.skip_singler
       // provide existing singler results dir for those we skipped
-      .map{[it[0]["library_id"], file(it[0].singler_dir, type: 'dir')]}
+      .map{[it[0]["library_id"], file(it[0].singler_dir, type: 'dir', checkIfExists: true)]}
       // add empty file for missing ref samples
-      .mix(singler_input_ch.missing_ref.map{[it[0]["library_id"], file(empty_file)]} )
+      .mix(singler_input_ch.missing_ref.map{[it[0]["library_id"], file(empty_file, checkIfExists: true)]} )
       // add in channel outputs
       .mix(classify_singler.out)
 
     // create cellassign input channel: [meta, processed sce, cellassign reference file]
     cellassign_input_ch = celltype_input_ch
       // add in cellassign reference
-      .map{it.toList() + [file(it[0].cellassign_reference_file ?: empty_file)]}
+      .map{it.toList() + [file(it[0].cellassign_reference_file ?: empty_file, checkIfExists: true)]}
       // skip if no cellassign reference file or reference name is not defined
       .branch{
         skip_cellassign: (
           !params.repeat_celltyping
           && file(it[0].cellassign_predictions_file).exists()
-          && Utils.getMetaVal(file("${it[0].cellassign_dir}/scpca-meta.json"), "cellassign_reference_file") == "${it[0].cellassign_reference_file}"
+          && Utils.getMetaVal(file("${it[0].cellassign_dir}/scpca-meta.json", checkIfExists: true), "cellassign_reference_file") == "${it[0].cellassign_reference_file}"
         )
         missing_ref: it[2].name == "NO_FILE"
         do_cellassign: true
@@ -235,9 +235,9 @@ workflow annotate_celltypes {
     // cellassign output channel: [library_id, cellassign_dir]
     cellassign_output_ch = cellassign_input_ch.skip_cellassign
       // provide existing cellassign predictions dir for those we skipped
-      .map{[it[0]["library_id"], file(it[0].cellassign_dir, type: 'dir')]}
+      .map{[it[0]["library_id"], file(it[0].cellassign_dir, type: 'dir', checkIfExists: true)]}
       // add empty file for missing ref samples
-      .mix(cellassign_input_ch.missing_ref.map{[it[0]["library_id"], file(empty_file)]} )
+      .mix(cellassign_input_ch.missing_ref.map{[it[0]["library_id"], file(empty_file, checkIfExists: true)]} )
       // add in channel outputs
       .mix(classify_cellassign.out)
 

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -57,16 +57,11 @@ workflow genetic_demux_vireo{
     // construct demux output for skipped as [meta, vireo_dir] & join newly processed libraries
     demux_out = multiplex_ch.has_demux
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.vireo_dir}/scpca-meta.json")),
-        file(meta.vireo_dir, type: 'dir')
+        Utils.readMeta(file("${meta.vireo_dir}/scpca-meta.json", checkIfExists: true)),
+        file(meta.vireo_dir, type: 'dir', checkIfExists: true)
       )}
       .mix(cellsnp_vireo.out)
 
   emit:
     demux_out
 }
-
-
-
-
-

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -57,7 +57,7 @@ workflow genetic_demux_vireo{
     // construct demux output for skipped as [meta, vireo_dir] & join newly processed libraries
     demux_out = multiplex_ch.has_demux
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.vireo_dir}/scpca-meta.json", checkIfExists: true)),
+        Utils.readMeta(file("${meta.vireo_dir}/scpca-meta.json")),
         file(meta.vireo_dir, type: 'dir', checkIfExists: true)
       )}
       .mix(cellsnp_vireo.out)

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -233,17 +233,17 @@ workflow generate_sce {
   main:
 
     sce_ch = quant_channel
-      .map{it.toList() + [file(it[0].mito_file),
-                          file(it[0].ref_gtf),
+      .map{it.toList() + [file(it[0].mito_file, checkIfExists: true),
+                          file(it[0].ref_gtf, checkIfExists: true),
                           // either submitter cell type files, or empty file if not available
-                          file(it[0].submitter_cell_types_file ?: empty_file)
+                          file(it[0].submitter_cell_types_file ?: empty_file, checkIfExists: true)
                          ]}
 
     make_unfiltered_sce(sce_ch, sample_metafile)
 
     // provide empty feature barcode file, since no features here
     unfiltered_sce_ch = make_unfiltered_sce.out
-      .map{it.toList() + [file(empty_file)]}
+      .map{it.toList() + [file(empty_file, checkIfExists: true)]}
 
     filter_sce(unfiltered_sce_ch)
 
@@ -261,17 +261,17 @@ workflow generate_merged_sce {
 
     feature_sce_ch = feature_quant_channel
       // RNA meta is in the third slot here
-      .map{it.toList() + [file(it[2].mito_file),
-                          file(it[2].ref_gtf),
+      .map{it.toList() + [file(it[2].mito_file, checkIfExists: true),
+                          file(it[2].ref_gtf, checkIfExists: true),
                           // either submitter cell type files, or empty file if not available
-                          file(it[2].submitter_cell_types_file ?: empty_file)
+                          file(it[2].submitter_cell_types_file ?: empty_file, checkIfExists: true)
                          ]}
 
     make_merged_unfiltered_sce(feature_sce_ch, sample_metafile)
 
     // append the feature barcode file
     unfiltered_merged_sce_ch = make_merged_unfiltered_sce.out
-      .map{it.toList() + [file(it[0]["feature_meta"].feature_barcode_file ?: empty_file)]}
+      .map{it.toList() + [file(it[0]["feature_meta"].feature_barcode_file ?: empty_file, checkIfExists: true)]}
 
     filter_sce(unfiltered_merged_sce_ch)
 


### PR DESCRIPTION
Closes #639

This PR adds a whole bunch of checks for files existing, including the original scope of #639 and more spots that _seemed_ like they could use it.

#### Part 1: Mapping files

I changed the `has_rad` and `make_rad` order since that made more sense in my brain. Here's how I set it up in `af-rna.nf`:

- We set up to run mapping when (in order) the following are met. Otherwise we do not run mapping.
  - mapping is requested
  - there is no rad directory
  - the assembly has changed.
- If we _are_ mapping:
  - If fastq do not exist, then this will error out on lines 141-142
- If we are _not_ mapping:
  - There needs to be a rad directory that already exists. If it doesn't exist, then this will error out on line 151.

The one item I'm not sure I fully covered is ensuring the rad directory gets created if we are running mapping _and_ the rad directory does not exist (second condition in my initial list of when we run mapping). Is there something more that needs to be done here? I assumed running `alevin-fry` itself creates it, but am I wrong?

Are there any other logic foibles that I missed?


#### Part 2: The rest

I have a bunch of smaller-scope commits that add `checkIfExists: true` to a bunch of `file()` calls throughout, as well as a few checks at the top of `main.nf` for the existence of the report files. Please have a look at these and advise if they are reasonable to keep or should be reverted! I also "duplicated" the `af-rna.nf` changes in `af-features.nf`. I did not touch the spaceranger module, though, since I'm more hesitant to touch that file in general. Let me know if I should!
Edit* A note that I'm not _super sure_ about these checks for the `?: empty_file` places. I think maybe they are wrong, but put them out there for more eyes in case they are right!