### PR TITLE
Make sure dimensions for UMAPs exist

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -401,9 +401,14 @@ All other cell types are grouped together and labeled "All remaining cell types"
 
 <!-- Now, UMAPs of cell types, where present -->
 
-```{r, eval = has_submitter && has_umap}
-submitter_n_celltypes <- length(levels(umap_df$submitter_celltype_annotation_lumped))
-submitter_dims <- determine_umap_dimensions(submitter_n_celltypes)
+```{r}
+if (has_submitter & has_umap) {
+  submitter_n_celltypes <- length(levels(umap_df$submitter_celltype_annotation_lumped))
+  submitter_dims <- determine_umap_dimensions(submitter_n_celltypes)
+} else {
+  # set fake dims for evaluating next chunk
+  submitter_dims <- c(1, 1)
+}
 ```
 
 ```{r, eval = has_submitter && has_umap, message=FALSE, warning=FALSE, fig.width = submitter_dims[1], fig.height = submitter_dims[2], fig.align = "center"}
@@ -417,9 +422,14 @@ faceted_umap(
 ```
 
 
-```{r, eval = has_singler && has_umap}
-singler_n_celltypes <- length(levels(umap_df$singler_celltype_annotation_lumped))
-singler_dims <- determine_umap_dimensions(singler_n_celltypes)
+```{r}
+if (has_singler & has_umap) {
+  singler_n_celltypes <- length(levels(umap_df$singler_celltype_annotation_lumped))
+  singler_dims <- determine_umap_dimensions(singler_n_celltypes)
+} else {
+  # set fake dims for evaluating next chunk
+  singler_dims <- c(1, 1)
+}
 ```
 
 
@@ -434,9 +444,14 @@ faceted_umap(
 ```
 
 
-```{r, eval = has_cellassign && has_umap}
-cellassign_n_celltypes <- length(levels(umap_df$cellassign_celltype_annotation_lumped))
-cellassign_dims <- determine_umap_dimensions(cellassign_n_celltypes)
+```{r}
+if (has_cellassign & has_umap) {
+  cellassign_n_celltypes <- length(levels(umap_df$cellassign_celltype_annotation_lumped))
+  cellassign_dims <- determine_umap_dimensions(cellassign_n_celltypes)
+} else {
+  # set fake dims for evaluating next chunk
+  cellassign_dims <- c(1, 1)
+}
 ```
 
 ```{r, eval = has_cellassign && has_umap, message=FALSE, warning=FALSE, fig.width = cellassign_dims[1], fig.height = cellassign_dims[2], fig.align = "center"}


### PR DESCRIPTION
When trying to generate the test data, I came across this error in the cell type report, where the dimensions set in the chunk options don't always exist. For each cell type annotation method, we have a chunk that is evaluated _only_ if that method exists. Here was where we were defining the dimensions to use to create the UMAP in the following chunk. The problem with this approach is that if a method doesn't exist, then the dimensions don't get assigned to a variable. Then in the chunk where we create the UMAP we define the figure height and width with variables that don't exist. So here I'm just setting all the dimensions to a dummy set of dimensions in the event that a cell type method wasn't used. That way the variable exists when going to the UMAP chunk, even if that chunk doesn't get evaluated. 