### PR TITLE
Keep cell type columns when merging

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -142,6 +142,15 @@ if ("submitter" %in% all_celltypes) {
     retain_coldata_columns,
     "submitter_celltype_annotation"
   )
+
+  # Add `"Submitter-excluded"` value to any libraries without submitter
+  sce_list <- sce_list |>
+    purrr::map(\(sce){
+      if (!"submitter_celltype_annotation" %in% names(sce(colData))) {
+        colData(sce)$submitter_celltype_annotation <- "Submitter-excluded"
+      }
+      return(sce)
+    })
 }
 if ("singler" %in% all_celltypes) {
   # Check if the label used for annotation was ontology in at least 1 SCE

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -146,7 +146,7 @@ if ("submitter" %in% all_celltypes) {
   # Add `"Submitter-excluded"` value to any libraries without submitter
   sce_list <- sce_list |>
     purrr::map(\(sce){
-      if (!"submitter_celltype_annotation" %in% names(sce(colData))) {
+      if (!"submitter" %in% metadata(sce)$celltype_methods) {
         colData(sce)$submitter_celltype_annotation <- "Submitter-excluded"
       }
       return(sce)

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -197,9 +197,7 @@ if ("cellassign" %in% all_celltypes) {
     purrr::map(\(sce){
       if (!"cellassign" %in% metadata(sce)$celltype_methods) {
         colData(sce)$cellassign_celltype_annotation <- "Cell type annotation not performed"
-        if (use_ontology) {
-          colData(sce)$cellassign_max_prediction <- NA_real_
-        }
+        colData(sce)$cellassign_max_prediction <- NA_real_
       }
       return(sce)
     })

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -116,10 +116,64 @@ if (!all(sce_checks)) {
   )
 }
 
+# check if any SCEs have cell types; if so, we want to retain those colData columns
+all_celltypes <- sce_list |>
+  purrr::map(\(sce) {
+    metadata(sce)$celltype_methods
+  }) |>
+  purrr::reduce(union)
+
+# Default vector of colData columns to retain from
+# https://github.com/AlexsLemonade/scpcaTools/blob/2ebdc4f4dfc4233fad97805f9a9a5e3bc6919f1e/R/merge_sce_list.R
+retain_coldata_columns <- c(
+  "sum",
+  "detected",
+  "total",
+  "subsets_mito_sum",
+  "subsets_mito_detected",
+  "subsets_mito_percent",
+  "miQC_pass",
+  "prob_compromised",
+  "barcodes"
+)
+# add relevant cell type columns to `retain_coldata_columns`
+if ("submitter" %in% all_celltypes) {
+  retain_coldata_columns <- c(
+    retain_coldata_columns,
+    "submitter_celltype_annotation"
+  )
+}
+if ("singler" %in% all_celltypes) {
+  # Check if the label used for annotation was ontology in at least 1 SCE
+  use_ontology <- sce_list |>
+    purrr::map(\(sce){
+      metadata(sce)$singler_reference_label == "label.ont"
+    }) |>
+    # avoid warning with unlist; can't use map_lgl since ^ would always need to
+    #  return length 1
+    unlist() |>
+    any()
+
+  retain_coldata_columns <- c(
+    retain_coldata_columns,
+    "singler_celltype_annotation",
+    # only use ontology if TRUE
+    ifelse(use_ontology, "singler_celltype_ontology", NULL)
+  )
+}
+if ("cellassign" %in% all_celltypes) {
+  retain_coldata_columns <- c(
+    retain_coldata_columns,
+    "cellassign_celltype_annotation",
+    "cellassign_max_prediction"
+  )
+}
+
+
+# Add a new column with any additional modalities
 sce_list <- sce_list |>
   purrr::map(\(sce){
-    # add a new column with any additional modalities
-    # will be adt, cellhash, or NA
+    # value will be adt, cellhash, or NA
     additional_modalities <- altExpNames(sce)
     if (length(additional_modalities) == 0) {
       additional_modalities <- NA
@@ -132,6 +186,7 @@ sce_list <- sce_list |>
 merged_sce <- scpcaTools::merge_sce_list(
   sce_list,
   batch_column = "library_id",
+  retain_coldata_cols = retain_coldata_columns,
   preserve_rowdata_cols = "gene_symbol",
   cell_id_column = "cell_id",
   include_altexp = opt$include_altexp

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -169,6 +169,18 @@ if ("singler" %in% all_celltypes) {
     # only use ontology if TRUE
     ifelse(use_ontology, "singler_celltype_ontology", NULL)
   )
+
+  # Add `"Cell type annotation not performed"` string to libraries without SingleR
+  sce_list <- sce_list |>
+    purrr::map(\(sce){
+      if (!"singler" %in% metadata(sce)$celltype_methods) {
+        colData(sce)$singler_celltype_annotation <- "Cell type annotation not performed"
+        if (use_ontology) {
+          colData(sce)$singler_celltype_ontology <- "Cell type annotation not performed"
+        }
+      }
+      return(sce)
+    })
 }
 if ("cellassign" %in% all_celltypes) {
   retain_coldata_columns <- c(
@@ -176,6 +188,19 @@ if ("cellassign" %in% all_celltypes) {
     "cellassign_celltype_annotation",
     "cellassign_max_prediction"
   )
+
+  # Add `"Cell type annotation not performed"` string to libraries without CellAssign,
+  #  and make the max prediction `NA_real_` for safety
+  sce_list <- sce_list |>
+    purrr::map(\(sce){
+      if (!"cellassign" %in% metadata(sce)$celltype_methods) {
+        colData(sce)$cellassign_celltype_annotation <- "Cell type annotation not performed"
+        if (use_ontology) {
+          colData(sce)$cellassign_max_prediction <- NA_real_
+        }
+      }
+      return(sce)
+    })
 }
 
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -100,7 +100,7 @@ if (opt$threads > 1) {
   bp_param <- BiocParallel::SerialParam()
 }
 
-# Merge SCEs -------------------------------------------------------------------
+# Read in SCEs -------------------------------------------------------------------
 
 # get list of sces
 sce_list <- purrr::map(input_sce_files, readr::read_rds)
@@ -115,6 +115,8 @@ if (!all(sce_checks)) {
     "All input files must contain a `SingleCellExperiment` object."
   )
 }
+
+# Check for cell type annotation columns -----------------------------------------
 
 # check if any SCEs have cell types; if so, we want to retain those colData columns
 all_celltypes <- sce_list |>
@@ -203,6 +205,8 @@ if ("cellassign" %in% all_celltypes) {
     })
 }
 
+
+# Merge SCEs -------------------------------------------------------------------
 
 # Add a new column with any additional modalities
 sce_list <- sce_list |>

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -192,7 +192,7 @@ if ("cellassign" %in% all_celltypes) {
   )
 
   # Add `"Cell type annotation not performed"` string to libraries without CellAssign,
-  #  and make the max prediction `NA_real_` for safety
+  #  and make the max prediction `NA_real_` for extra safety
   sce_list <- sce_list |>
     purrr::map(\(sce){
       if (!"cellassign" %in% metadata(sce)$celltype_methods) {


### PR DESCRIPTION
Closes #655 

Now in the correct repo! This PR updated `merge_sces.R` to handle cell type columns better:

- Find all the cell types that are present in _any_ SCE
- Define a baseline (taken from `scpcaTools` default) set of columns to keep as `retain_coldata_columns`
- For each cell type that is present in at least 1 SCE, add the relevant cell type columns into `retain_coldata_columns`
  - For SingleR, I only add `singler_celltype_ontology` if ontology labels were used for at least one library 
- Finally, tell `merge_sce_list` about the `retain_coldata_columns` vector
 
Moreover, here's how I handle libraries without the given cell type method, but where that method exists in other project libraries:

- Submitter
  - Add the column `submitter_celltype_annotation` with the value `"Submitter-excluded"`
- SingleR
  - Add the column  `singler_celltype_annotation` with the value `"Cell type annotation not performed`"
  - If ontologies were used, then I do the same for `singler_celltype_ontology`
- CellAssign
  - Add the column  `cellassign_celltype_annotation` with the value `"Cell type annotation not performed`"
  - Add the column  `cellassign_max_prediction` with the value `NA_real_`, just to be safe. This is probably overkill since the merge function will add this column with `NA`s anyways, but I like that it's specifically `NA_real_` here

I've tested the code with an SCE list where some, but not all, have cell types and it works as expected! 

Let me know what you think of some of those string choices I made. I'll note the conclusions from this PR over in `scpca-docs` in the issue about merged contents - https://github.com/AlexsLemonade/scpca-docs/issues/219