### PR TITLE
Retain filter columns when merging

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -165,8 +165,8 @@ if ("singler" %in% all_celltypes) {
     purrr::map(\(sce){
       metadata(sce)$singler_reference_label == "label.ont"
     }) |>
-    # avoid warning with unlist; can't use map_lgl above or reduce(any) below
-    #  the mapping would always need to return length 1
+    # avoid warning with unlist; can't use map_lgl since ^ would always need to
+    #  return length 1
     unlist() |>
     any()
 


### PR DESCRIPTION
This PR is related to this comment https://github.com/AlexsLemonade/scpca-docs/pull/237#discussion_r1457593604:

> And found something else we need to fix! Looks like merged objects are missing `scpca_filter` and `adt_scpca_filter` (if at least 1 library has cite). I feel pretty sure we want to keep those columns around! I'll file a PR in `scpca-nf` to retain those columns.

Here is that PR! Script runs locally ✅ 