### PR TITLE
Don't rename rowdata `gene_ids` column

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -240,7 +240,7 @@ merged_sce <- scpcaTools::merge_sce_list(
   sce_list,
   batch_column = "library_id",
   retain_coldata_cols = retain_coldata_columns,
-  preserve_rowdata_cols = "gene_symbol",
+  preserve_rowdata_cols = c("gene_symbol", "gene_ids"),
   cell_id_column = "cell_id",
   include_altexp = opt$include_altexp
 )


### PR DESCRIPTION
Another merging fix, as the PR title says! Currently we have objects as - 

```
> rowData(sce)
DataFrame with 60319 rows and 10 columns
                SCPCL000001-gene_ids gene_symbol SCPCL000001-mean
                         <character> <character>        <numeric>
ENSG00000223972      ENSG00000223972     DDX11L1       0.00247619
ENSG00000243485      ENSG00000243485 MIR1302-2HG       0.00225397
ENSG00000284332      ENSG00000284332   MIR1302-2       0.00000000
ENSG00000268020      ENSG00000268020      OR4G4P       0.00000000
ENSG00000240361      ENSG00000240361     OR4G11P       0.00000000
...                              ...         ...              ...
ENSG00000225491      ENSG00000225491   UBE2Q2P4Y      0.002476190
ENSG00000185894      ENSG00000185894       BPY2C      0.000000000
ENSG00000228296      ENSG00000228296      TTTY4C      0.000216749
ENSG00000273496      ENSG00000273496          NA      0.008040854
ENSG00000274175      ENSG00000274175          NA      0.000000000
                SCPCL000001-detected SCPCL000002-gene_ids SCPCL000002-mean
                           <numeric>          <character>        <numeric>
ENSG00000223972             0.609524      ENSG00000223972      0.000000000
ENSG00000243485             0.533333      ENSG00000243485      0.000659413
ENSG00000284332             0.000000      ENSG00000284332      0.000000000
ENSG00000268020             0.000000      ENSG00000268020      0.000000000
ENSG00000240361             0.000000      ENSG00000240361      0.000000000
...                              ...                  ...              ...
```

`gene_symbol` is correctly unaffected, but `gene_ids` should also be unaffected. I added that rowData column here.