### PR TITLE
Fix merge.nf workflow adt and multiplex check

### DIFF
--- a/merge.nf
+++ b/merge.nf
@@ -157,8 +157,8 @@ workflow {
       // add in boolean for if project contains samples with adt
       .map{project_id, library_id_list, sce_file_list -> tuple(
         project_id,
-        project_id in adt_projects, // determines if altExp should be included in the merged object
-        project_id in multiplex_projects, // determines if sample metadata should be added to colData and to skip anndata
+        project_id in adt_projects.getVal(), // determines if altExp should be included in the merged object
+        project_id in multiplex_projects.getVal(), // determines if sample metadata should be added to colData and to skip anndata
         library_id_list,
         sce_file_list
       )}

--- a/merge.nf
+++ b/merge.nf
@@ -132,12 +132,12 @@ workflow {
     adt_projects = libraries_ch
       .filter{it.technology.startsWith('CITEseq')}
       .collect{it.scpca_project_id}
-      .unique()
+      .map{it.unique()}
 
     multiplex_projects = libraries_ch
       .filter{it.technology.startsWith('cellhash')}
       .collect{it.scpca_project_id}
-      .unique()
+      .map{it.unique()}
 
     grouped_libraries_ch = libraries_ch
       // only include single-cell/single-nuclei which ensures we don't try to merge libraries from spatial or bulk data
@@ -162,7 +162,7 @@ workflow {
         library_id_list,
         sce_file_list
       )}
-
+      
     merge_sce(grouped_libraries_ch)
 
     // generate merge report


### PR DESCRIPTION
This PR fixes a silly 🐛 in `merge.nf` where checking the project was adt or multiplex was not working correctly, because of nextflow syntax. This bug was discovered b/c a CITE-seq project's merged object contained no `adt` altExp. Turns out the code told the process that merges SCEs that there was no adt, so at least the subsequent logic works well!

It's running now with the fix, but should work. Here's what the incoming channel to the merge process now looks like. Note that the second item is `true`, correctly reflecting that it _has ADT_.

```
[SCPCP000003, true, false, [SCPCL000050, SCPCL000051, SCPCL000074, SCPCL000697, SCPCL000698, SCPCL000700, SCPCL000702, SCPCL000705, SCPCL000706, SCPCL000713], [/nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000053/SCPCL000050_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000055/SCPCL000051_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000084/SCPCL000074_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000050/SCPCL000697_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000051/SCPCL000698_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000067/SCPCL000700_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000069/SCPCL000702_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000054/SCPCL000705_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000099/SCPCL000706_processed.rds, /nextflow-ccdl-results/scpca/processed/results/SCPCP000003/SCPCS000057/SCPCL000713_processed.rds]]
```