### PR TITLE
Deal with small numbers of cells and CellAssign

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -191,7 +191,7 @@ if (!is.null(opt$cellassign_predictions)) {
 
   # check that there are actually some predictions present
   # otherwise make a data frame with the celltype and prediction column as NA
-  if (length(colnames(predictions)) == 1 & colnames(predictions) == "barcode") {
+  if ((length(colnames(predictions)) == 1) & (colnames(predictions) == "barcode")) {
     celltype_assignments <- predictions |>
       dplyr::mutate(
         celltype = NA,

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -190,15 +190,8 @@ if (!is.null(opt$cellassign_predictions)) {
   predictions <- readr::read_tsv(opt$cellassign_predictions)
 
   # if the only column is the barcode column then CellAssign didn't complete successfully
-  # create data frame with celltype and prediction as NA
-  # celltype will later get converted to Unclassified cell
-  if (colnames(predictions) == "barcode") {
-    celltype_assignments <- predictions |>
-      dplyr::mutate(
-        celltype = NA,
-        prediction = NA
-      )
-  } else {
+  # otherwise add in cell type annotations and metadata to SCE
+  if (colnames(predictions) != "barcode") {
     # get cell type with maximum prediction value for each cell
     celltype_assignments <- predictions |>
       tidyr::pivot_longer(
@@ -209,45 +202,48 @@ if (!is.null(opt$cellassign_predictions)) {
       dplyr::group_by(barcode) |>
       dplyr::slice_max(prediction, n = 1) |>
       dplyr::ungroup()
+
+    # join by barcode to make sure assignments are in the right order
+    celltype_assignments <- data.frame(barcode = sce$barcodes) |>
+      dplyr::left_join(celltype_assignments, by = "barcode") |>
+      # any cells that are NA were not classified by cellassign
+      dplyr::mutate(celltype = ifelse(is.na(celltype), "Unclassified cell", celltype))
+
+    # add cell type and prediction to colData
+    sce$cellassign_celltype_annotation <- celltype_assignments$celltype
+    sce$cellassign_max_prediction <- celltype_assignments$prediction
+
+    # get reference name, source and version
+    cellassign_ref_info <- get_ref_info(
+      ref_filename = opt$cellassign_ref_file,
+      extension = "\\.tsv"
+    )
+
+    # add entire predictions matrix, ref name, and version to metadata
+    metadata(sce)$cellassign_predictions <- predictions
+    metadata(sce)$cellassign_reference <- cellassign_ref_info[["ref_name"]]
+    metadata(sce)$cellassign_reference_source <- cellassign_ref_info[["ref_source"]]
+    metadata(sce)$cellassign_reference_version <- cellassign_ref_info[["ref_version"]]
+
+    # add cellassign as celltype method
+    # note that if `metadata(sce)$celltype_methods` doesn't exist yet, this will
+    #  come out to just the string "cellassign"
+    metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "cellassign")
+
+    # add cellassign reference organs to metadata
+    cellassign_organs <- opt$celltype_ref_metafile |>
+      readr::read_tsv() |>
+      dplyr::filter(celltype_ref_name == cellassign_ref_info[["ref_name"]]) |>
+      dplyr::pull(organs)
+
+    if (cellassign_organs == "" | is.na(cellassign_organs)) {
+      stop("Failed to obtain CellAssign reference organ list.")
+    }
+    metadata(sce)$cellassign_reference_organs <- cellassign_organs
+  } else {
+    # if failed then note that in the cell type column
+    sce$cellassign_celltype_annotation <- "CellAssign unable to assign cell types."
   }
-
-  # join by barcode to make sure assignments are in the right order
-  celltype_assignments <- data.frame(barcode = sce$barcodes) |>
-    dplyr::left_join(celltype_assignments, by = "barcode") |>
-    # any cells that are NA were not classified by cellassign
-    dplyr::mutate(celltype = ifelse(is.na(celltype), "Unclassified cell", celltype))
-
-  # add cell type and prediction to colData
-  sce$cellassign_celltype_annotation <- celltype_assignments$celltype
-  sce$cellassign_max_prediction <- celltype_assignments$prediction
-
-  # get reference name, source and version
-  cellassign_ref_info <- get_ref_info(
-    ref_filename = opt$cellassign_ref_file,
-    extension = "\\.tsv"
-  )
-
-  # add entire predictions matrix, ref name, and version to metadata
-  metadata(sce)$cellassign_predictions <- predictions
-  metadata(sce)$cellassign_reference <- cellassign_ref_info[["ref_name"]]
-  metadata(sce)$cellassign_reference_source <- cellassign_ref_info[["ref_source"]]
-  metadata(sce)$cellassign_reference_version <- cellassign_ref_info[["ref_version"]]
-
-  # add cellassign as celltype method
-  # note that if `metadata(sce)$celltype_methods` doesn't exist yet, this will
-  #  come out to just the string "cellassign"
-  metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "cellassign")
-
-  # add cellassign reference organs to metadata
-  cellassign_organs <- opt$celltype_ref_metafile |>
-    readr::read_tsv() |>
-    dplyr::filter(celltype_ref_name == cellassign_ref_info[["ref_name"]]) |>
-    dplyr::pull(organs)
-
-  if (cellassign_organs == "" | is.na(cellassign_organs)) {
-    stop("Failed to obtain CellAssign reference organ list.")
-  }
-  metadata(sce)$cellassign_reference_organs <- cellassign_organs
 }
 
 # export annotated object with cellassign assignments

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -189,16 +189,26 @@ if (!is.null(opt$cellassign_predictions)) {
 
   predictions <- readr::read_tsv(opt$cellassign_predictions)
 
-  # get cell type with maximum prediction value for each cell
-  celltype_assignments <- predictions |>
-    tidyr::pivot_longer(
-      !barcode,
-      names_to = "celltype",
-      values_to = "prediction"
-    ) |>
-    dplyr::group_by(barcode) |>
-    dplyr::slice_max(prediction, n = 1) |>
-    dplyr::ungroup()
+  # check that there are actually some predictions present
+  # otherwise make a data frame with the celltype and prediction column as NA
+  if (length(colnames(predictions)) == 1 & colnames(predictions) == "barcode") {
+    celltype_assignments <- predictions |>
+      dplyr::mutate(
+        celltype = NA,
+        prediction = NA
+      )
+  } else {
+    # get cell type with maximum prediction value for each cell
+    celltype_assignments <- predictions |>
+      tidyr::pivot_longer(
+        !barcode,
+        names_to = "celltype",
+        values_to = "prediction"
+      ) |>
+      dplyr::group_by(barcode) |>
+      dplyr::slice_max(prediction, n = 1) |>
+      dplyr::ungroup()
+  }
 
   # join by barcode to make sure assignments are in the right order
   celltype_assignments <- data.frame(barcode = sce$barcodes) |>

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -189,26 +189,16 @@ if (!is.null(opt$cellassign_predictions)) {
 
   predictions <- readr::read_tsv(opt$cellassign_predictions)
 
-  # check that there are actually some predictions present
-  # otherwise make a data frame with the celltype and prediction column as NA
-  if ((length(colnames(predictions)) == 1) & (colnames(predictions) == "barcode")) {
-    celltype_assignments <- predictions |>
-      dplyr::mutate(
-        celltype = NA,
-        prediction = NA
-      )
-  } else {
-    # get cell type with maximum prediction value for each cell
-    celltype_assignments <- predictions |>
-      tidyr::pivot_longer(
-        !barcode,
-        names_to = "celltype",
-        values_to = "prediction"
-      ) |>
-      dplyr::group_by(barcode) |>
-      dplyr::slice_max(prediction, n = 1) |>
-      dplyr::ungroup()
-  }
+  # get cell type with maximum prediction value for each cell
+  celltype_assignments <- predictions |>
+    tidyr::pivot_longer(
+      !barcode,
+      names_to = "celltype",
+      values_to = "prediction"
+    ) |>
+    dplyr::group_by(barcode) |>
+    dplyr::slice_max(prediction, n = 1) |>
+    dplyr::ungroup()
 
   # join by barcode to make sure assignments are in the right order
   celltype_assignments <- data.frame(barcode = sce$barcodes) |>

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -191,7 +191,10 @@ if (!is.null(opt$cellassign_predictions)) {
 
   # if the only column is the barcode column then CellAssign didn't complete successfully
   # otherwise add in cell type annotations and metadata to SCE
-  if (colnames(predictions) != "barcode") {
+  if (colnames(predictions) == "barcode") {
+    # if failed then note that in the cell type column
+    sce$cellassign_celltype_annotation <- "Not run"
+  } else {
     # get cell type with maximum prediction value for each cell
     celltype_assignments <- predictions |>
       tidyr::pivot_longer(
@@ -240,9 +243,6 @@ if (!is.null(opt$cellassign_predictions)) {
       stop("Failed to obtain CellAssign reference organ list.")
     }
     metadata(sce)$cellassign_reference_organs <- cellassign_organs
-  } else {
-    # if failed then note that in the cell type column
-    sce$cellassign_celltype_annotation <- "CellAssign unable to assign cell types."
   }
 }
 

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -99,8 +99,8 @@ lib_size = annotated_adata.X.sum(1)
 subset_adata.obs["size_factor"] = lib_size / np.mean(lib_size)
 
 # set training size
-if subset_adata.obs < 10:
-    train_size = subset_adata.obs * 0.01
+if subset_adata.n_obs < 10:
+    train_size = round(subset_adata.n_obs * 0.01 - 0.01, 2)
 else:
     train_size = 0.9
 

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -93,7 +93,7 @@ annotated_adata = adata.read_h5ad(args.input_hdf5_file)
 shared_genes = list(set(ref_matrix.index) & set(annotated_adata.var_names))
 
 # check that shared_genes actually has some genes
-if len(shared_genes) == 0:
+if not shared_genes:
     raise ValueError(
         "--reference does not include any genes found in the provided --input_hdf5_file."
     )

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -98,12 +98,18 @@ subset_adata.X = subset_adata.X.tocsr()
 lib_size = annotated_adata.X.sum(1)
 subset_adata.obs["size_factor"] = lib_size / np.mean(lib_size)
 
-# only if there are genes still remaining, subset
+# set training size
+if subset_adata.obs < 10:
+    train_size = subset_adata.obs * 0.01
+else:
+    train_size = 0.9
+
+# only if there are genes still remaining
 if subset_adata.n_vars != 0:
     # train and assign cell types
     scvi.external.CellAssign.setup_anndata(subset_adata, size_factor_key="size_factor")
     model = CellAssign(subset_adata, ref_matrix)
-    model.train()
+    model.train(train_size=train_size)
     predictions = model.predict()
     predictions["barcode"] = subset_adata.obs_names
 else:

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -99,7 +99,7 @@ lib_size = annotated_adata.X.sum(1)
 subset_adata.obs["size_factor"] = lib_size / np.mean(lib_size)
 
 # only if there are genes still remaining, subset
-if subset_adata.n_vars > 0:
+if subset_adata.n_vars != 0:
     # train and assign cell types
     scvi.external.CellAssign.setup_anndata(subset_adata, size_factor_key="size_factor")
     model = CellAssign(subset_adata, ref_matrix)

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -86,8 +86,6 @@ ref_matrix = pd.read_csv(args.reference, sep="\t", index_col="ensembl_id")
 
 # file path to annotated sce
 annotated_adata = adata.read_h5ad(args.input_hdf5_file)
-# make sure that barcodes are obs names
-annotated_adata.obs_names = annotated_adata.obs._index
 
 # subset anndata to contain only genes in the reference file
 # note that the gene names must be the rownames of the reference matrix

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -107,17 +107,17 @@ lib_size = annotated_adata.X.sum(1)
 subset_adata.obs["size_factor"] = lib_size / np.mean(lib_size)
 
 # only run CellAssign if enough cells
-if subset_adata.n_obs >= 30:
+if subset_adata.n_obs < 30:
+    # make a predictions file that just has the barcode column
+    barcodes_column = subset_adata.obs_names.to_list()
+    predictions = pd.DataFrame(barcodes_column, columns=["barcode"])
+else:
     # train and assign cell types
     scvi.external.CellAssign.setup_anndata(subset_adata, size_factor_key="size_factor")
     model = CellAssign(subset_adata, ref_matrix)
     model.train()
     predictions = model.predict()
     predictions["barcode"] = subset_adata.obs_names
-else:
-    # make a predictions file that just has the barcodes column
-    barcodes_column = subset_adata.obs_names.to_list()
-    predictions = pd.DataFrame(barcodes_column, columns=["barcode"])
 
 
 # write out predictions as tsv


### PR DESCRIPTION
So I went to run the next set of projects and pretty quickly `CellAssign` failed for `SCPCL000784`. I did some digging and this processed object only has 6 cells, which seems to be part of the reason it's failing. I think with so few cells, the default values that define the training set don't work. After doing some googling of the errors that I was seeing (which were slightly different locally vs. on Nextflow), I saw a lot of mention of the default training size not working with fewer items. So I went through the [CellAssign docs](https://docs.scvi-tools.org/en/stable/api/reference/scvi.external.CellAssign.html#scvi.external.CellAssign.train), and noticed that if I set the `train_size` to be smaller, then it worked. With 6 cells, `train_size=0.6` does not work, but `train_size=0.5` does work.

I went ahead and implemented a check that if there are < 10 cells (from my interpretation that's when we would have issues), then we adjust the `train_size`. Another idea is that we don't even run `CellAssign` in this case and skip it. Thoughts? 

Also, when I was working on this, I thought it was an issue with the genes not overlapping the reference, but that turned out to be me loading in the wrong reference set. But I think we may want to add a check to make sure that we actually have genes left, because that also failed to run CellAssign. So I added an error if none of the genes in the reference are also in the provided AnnData object. 


For some added additional context, this was the error I was getting in Nextflow: 

```
‘SummarizedExperiment’ 
  Registered S3 methods overwritten by 'zellkonverter':
    method                                             from      
    py_to_r.numpy.ndarray                              reticulate
    py_to_r.pandas.core.arrays.categorical.Categorical reticulate
  /usr/local/lib/python3.10/dist-packages/scvi/_settings.py:63: UserWarning: Since v1.0.0, scvi-tools no longer uses a random seed by default. Run `scvi.settings.seed = 0` to reproduce results from previous versions.
    self.seed = seed
  /usr/local/lib/python3.10/dist-packages/scvi/_settings.py:70: UserWarning: Setting `dl_pin_memory_gpu_training` is deprecated in v1.0 and will be removed in v1.1. Please pass in `pin_memory` to the data loaders instead.
    self.dl_pin_memory_gpu_training = (
  Global seed set to 2021
  No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
  GPU available: False, used: False
  TPU available: False, using: 0 TPU cores
  IPU available: False, using: 0 IPUs
  HPU available: False, using: 0 HPUs
  /usr/local/lib/python3.10/dist-packages/lightning/pytorch/loops/fit_loop.py:281: PossibleUserWarning: The number of training batches (1) is smaller than the logging interval Trainer(log_every_n_steps=10). Set a lower value for log_every_n_steps if you want to see logs for the training epoch.
    rank_zero_warn(
  Traceback (most recent call last):
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/connectors/data_connector.py", line 391, in _check_dataloader_iterable
      iter(dataloader)  # type: ignore[call-overload]
  TypeError: 'NoneType' object is not iterable
  During handling of the above exception, another exception occurred:
  Traceback (most recent call last):
    File "/home/nextflow-bin/predict_cellassign.py", line 106, in <module>
      model.train()
    File "/usr/local/lib/python3.10/dist-packages/scvi/external/cellassign/_model.py", line 231, in train
      return runner()
    File "/usr/local/lib/python3.10/dist-packages/scvi/train/_trainrunner.py", line 99, in __call__
      self.trainer.fit(self.training_plan, self.data_splitter)
    File "/usr/local/lib/python3.10/dist-packages/scvi/train/_trainer.py", line 186, in fit
      super().fit(*args, **kwargs)
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/trainer.py", line 532, in fit
      call._call_and_handle_interrupt(
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/call.py", line 43, in _call_and_handle_interrupt
      return trainer_fn(*args, **kwargs)
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/trainer.py", line 571, in _fit_impl
      self._run(model, ckpt_path=ckpt_path)
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/trainer.py", line 980, in _run
      results = self._run_stage()
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/trainer.py", line 1023, in _run_stage
      self.fit_loop.run()
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/loops/fit_loop.py", line 198, in run
      self.on_run_start()
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/loops/fit_loop.py", line 309, in on_run_start
      self.epoch_loop.val_loop.setup_data()
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/loops/evaluation_loop.py", line 168, in setup_data
      _check_dataloader_iterable(dl, source, trainer_fn)
    File "/usr/local/lib/python3.10/dist-packages/lightning/pytorch/trainer/connectors/data_connector.py", line 407, in _check_dataloader_iterable
      raise TypeError(
  TypeError: An invalid dataloader was returned from `DataSplitter.val_dataloader()`. Found None.
```

And then this was the error I was getting when running through the cellassign script locally: 


```
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
HPU available: False, using: 0 HPUs
/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/configuration_validator.py:376: LightningDeprecationWarning: The `Callback.on_batch_end` hook was deprecated in v1.6 and will be removed in v1.8. Please use `Callback.on_train_batch_end` instead.
  rank_zero_deprecation(
/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py:1933: PossibleUserWarning: The number of training batches (1) is smaller than the logging interval Trainer(log_every_n_steps=10). Set a lower value for log_every_n_steps if you want to see logs for the training epoch.
  rank_zero_warn(
/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/utilities/data.py:127: UserWarning: Total length of `AnnDataLoader` across ranks is zero. Please make sure this was your intention.
  rank_zero_warn(
Epoch 1/400:   0%|                                                                                                         | 0/400 [00:00<?, ?it/s]Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/scvi/external/cellassign/_model.py", line 223, in train
    return runner()
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/scvi/train/_trainrunner.py", line 74, in __call__
    self.trainer.fit(self.training_plan, self.data_splitter)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/scvi/train/_trainer.py", line 188, in fit
    super().fit(*args, **kwargs)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 770, in fit
    self._call_and_handle_interrupt(
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 723, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 811, in _fit_impl
    results = self._run(model, ckpt_path=self.ckpt_path)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 1236, in _run
    results = self._run_stage()
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 1323, in _run_stage
    return self._run_train()
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 1353, in _run_train
    self.fit_loop.run()
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/loops/base.py", line 205, in run
    self.on_advance_end()
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/loops/fit_loop.py", line 294, in on_advance_end
    self.trainer._call_callback_hooks("on_train_epoch_end")
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/trainer/trainer.py", line 1636, in _call_callback_hooks
    fn(self, self.lightning_module, *args, **kwargs)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/callbacks/early_stopping.py", line 179, in on_train_epoch_end
    self._run_early_stopping_check(trainer)
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/callbacks/early_stopping.py", line 190, in _run_early_stopping_check
    if trainer.fast_dev_run or not self._validate_condition_metric(  # disable early_stopping with fast_dev_run
  File "/Users/allyhawkins/miniconda3/envs/scvi/lib/python3.10/site-packages/pytorch_lightning/callbacks/early_stopping.py", line 145, in _validate_condition_metric
    raise RuntimeError(error_msg)
RuntimeError: Early stopping conditioned on metric `elbo_validation` which is not available. Pass in or modify your `EarlyStopping` callback to use any of the following: `train_loss`, `train_loss_step`, `train_loss_epoch`, `elbo_train`, `kl_global_train`, `kl_local_train`, `reconstruction_loss_train`
```