### PR TITLE
Skip sample metadata addition to colData if cellhash is present

### DIFF
--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -165,9 +165,9 @@ if (!is.null(opt$feature_name)) {
       # warn that the altExp cannot be converted
       warning(
         glue::glue("
-        Only 1 row found in altExp named: {opt$feature_name}.
-        This altExp will not be converted to an AnnData object.
-      ")
+          Only 1 row found in altExp named: {opt$feature_name}.
+          This altExp will not be converted to an AnnData object.
+        ")
       )
     }
   }

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -128,40 +128,46 @@ scpcaTools::sce_to_anndata(
 # AltExp to AnnData -----------------------------------------------------------
 
 # if feature data exists, grab it and export to AnnData
-if (!is.null(opt$feature_name) & (opt$feature_name != "cellhash")) {
-  # make sure the feature data is present
-  if (!(opt$feature_name %in% altExpNames(sce))) {
-    stop("feature_name must match name of altExp in provided SCE object.")
-  }
-
-  # check for output file
-  if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
-    stop("output feature file name must end in .hdf5 or .h5")
-  }
-
-  # extract altExp
-  alt_sce <- altExp(sce, opt$feature_name)
-
-  # only convert altExp with > 1 rows
-  if (nrow(alt_sce) > 1) {
-    # add sample metadata from main sce to alt sce metadata
-    metadata(alt_sce)$sample_metadata <- sample_metadata
-
-    # make sce czi compliant
-    alt_sce <- format_czi(alt_sce)
-
-    # export altExp sce as anndata object
-    scpcaTools::sce_to_anndata(
-      alt_sce,
-      anndata_file = opt$output_feature_h5
-    )
+if (!is.null(opt$feature_name)) {
+  # if the feature name is cell hash, skip conversion
+  if (opt$feature_name != "cellhash") {
+    warning("Conversion of altExp data from multiplexed data is not supported.
+             The altExp will not be converted.")
   } else {
-    # warn that the altExp cannot be converted
-    message(
-      glue::glue("
+    # make sure the feature data is present
+    if (!(opt$feature_name %in% altExpNames(sce))) {
+      stop("feature_name must match name of altExp in provided SCE object.")
+    }
+
+    # check for output file
+    if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
+      stop("output feature file name must end in .hdf5 or .h5")
+    }
+
+    # extract altExp
+    alt_sce <- altExp(sce, opt$feature_name)
+
+    # only convert altExp with > 1 rows
+    if (nrow(alt_sce) > 1) {
+      # add sample metadata from main sce to alt sce metadata
+      metadata(alt_sce)$sample_metadata <- sample_metadata
+
+      # make sce czi compliant
+      alt_sce <- format_czi(alt_sce)
+
+      # export altExp sce as anndata object
+      scpcaTools::sce_to_anndata(
+        alt_sce,
+        anndata_file = opt$output_feature_h5
+      )
+    } else {
+      # warn that the altExp cannot be converted
+      message(
+        glue::glue("
         Only 1 row found in altExp named: {opt$feature_name}.
         This altExp will not be converted to an AnnData object.
       ")
-    )
+      )
+    }
   }
 }

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -63,11 +63,14 @@ format_czi <- function(sce) {
   # need this column to join in the sample metadata with the colData
   sce$library_id <- metadata(sce)$library_id
 
-  # add sample metadata to colData sce
-  sce <- scpcaTools::metadata_to_coldata(
-    sce,
-    join_columns = "library_id"
-  )
+  # only move sample metadata if not a multiplexed library
+  if (!("cellhash" %in% altExpNames(sce))) {
+    # add sample metadata to colData sce
+    sce <- scpcaTools::metadata_to_coldata(
+      sce,
+      join_columns = "library_id"
+    )
+  }
 
   # modify colData to be AnnData and CZI compliant
   coldata_df <- colData(sce) |>
@@ -125,7 +128,7 @@ scpcaTools::sce_to_anndata(
 # AltExp to AnnData -----------------------------------------------------------
 
 # if feature data exists, grab it and export to AnnData
-if (!is.null(opt$feature_name)) {
+if (!is.null(opt$feature_name) & (opt$feature_name != "cellhash")) {
   # make sure the feature data is present
   if (!(opt$feature_name %in% altExpNames(sce))) {
     stop("feature_name must match name of altExp in provided SCE object.")

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -130,7 +130,7 @@ scpcaTools::sce_to_anndata(
 # if feature data exists, grab it and export to AnnData
 if (!is.null(opt$feature_name)) {
   # if the feature name is cell hash, skip conversion
-  if (opt$feature_name != "cellhash") {
+  if (opt$feature_name == "cellhash") {
     warning("Conversion of altExp data from multiplexed data is not supported.
              The altExp will not be converted.")
   } else {

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -129,16 +129,17 @@ scpcaTools::sce_to_anndata(
 
 # if feature data exists, grab it and export to AnnData
 if (!is.null(opt$feature_name)) {
-  # if the feature name is cell hash, skip conversion
-  if (opt$feature_name == "cellhash") {
+  # make sure the feature data is present
+  if (!(opt$feature_name %in% altExpNames(sce))) {
+    stop("feature_name must match name of altExp in provided SCE object.")
+
+    # if the feature name is cell hash, skip conversion
+  } else if (opt$feature_name == "cellhash") {
     warning("Conversion of altExp data from multiplexed data is not supported.
              The altExp will not be converted.")
-  } else {
-    # make sure the feature data is present
-    if (!(opt$feature_name %in% altExpNames(sce))) {
-      stop("feature_name must match name of altExp in provided SCE object.")
-    }
 
+    # convert altExp
+  } else {
     # check for output file
     if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
       stop("output feature file name must end in .hdf5 or .h5")
@@ -162,7 +163,7 @@ if (!is.null(opt$feature_name)) {
       )
     } else {
       # warn that the altExp cannot be converted
-      message(
+      warning(
         glue::glue("
         Only 1 row found in altExp named: {opt$feature_name}.
         This altExp will not be converted to an AnnData object.


### PR DESCRIPTION
When running the multiplexed samples through the workflow, I was getting the following error: 

```
Command error:
  Warning message:
  replacing previous import ‘S4Arrays::makeNindexFromArrayViewport’ by ‘DelayedArray::makeNindexFromArrayViewport’ when loading ‘SummarizedExperiment’ 
  Error in scpcaTools::metadata_to_coldata(sce, join_columns = "library_id") : 
    The specified `join_columns` are producing multiple matches, but only one match is allowed.
  Calls: format_czi -> <Anonymous>
  Execution halted

```

This is because we are using the `sce_to_anndata.R` script to convert all objects to AnnData prior to running `CellAssign`. In a separate process, we use this same script to do the conversion to produce the final AnnData output. However, in that process, we are skipping any multiplexed samples and when running `CellAssign`, we are keeping multiplexed samples. The issue here is that we have a step in the `format_czi` function that merges the `colData` with the `sample_metadata` using `library_id` as the join column. This won't work when trying to convert an SCE that contains multiplexed data since the `library_id` will match up with multiple samples. 

To get around this, I added a check in the `format_czi` function to make sure that `cellhash` is not an `altExp` found in the SCE object. If so, no sample metadata is added to the `colData`. I also updated the check for converting `altExp` objects to only convert if the feature name was not `cellhash`. 