### PR TITLE
Actually remove unclassified cells from heatmap

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -272,7 +272,7 @@ unclassified_methods <- c()
 
 # check for unclassified SingleR cells
 if (has_singler && any(celltype_df$singler_celltype_annotation == "Unclassified cell")) {
-  unclassified_methods <- c(unclassified_methods, "singler")
+  unclassified_methods <- c(unclassified_methods, "SingleR")
 
   # remove all unclassified cells
   celltype_df <- celltype_df |>
@@ -284,7 +284,7 @@ if (has_singler && any(celltype_df$singler_celltype_annotation == "Unclassified 
 
 # check for unclassified cellassign cells
 if (has_cellassign && any(celltype_df$cellassign_celltype_annotation == "Unclassified cell")) {
-  unclassified_methods <- c(unclassified_methods, "cellassign")
+  unclassified_methods <- c(unclassified_methods, "CellAssign")
 
   # remove unclassified cells
   celltype_df <- celltype_df |>

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -278,7 +278,8 @@ if (has_singler && any(celltype_df$singler_celltype_annotation == "Unclassified 
   celltype_df <- celltype_df |>
     dplyr::filter(
       singler_celltype_annotation != "Unclassified cell"
-    )
+    ) |>
+    forcats::fct_drop(only = "Unclassified cell")
 }
 
 # check for unclassified cellassign cells
@@ -289,7 +290,8 @@ if (has_cellassign && any(celltype_df$cellassign_celltype_annotation == "Unclass
   celltype_df <- celltype_df |>
     dplyr::filter(
       cellassign_celltype_annotation != "Unclassified cell"
-    )
+    ) |>
+    forcats::fct_drop(only = "Unclassified cell")
 }
 
 # print a warning if either singleR or cellAssign have any unclassified cells

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -44,16 +44,14 @@ create_celltype_df <- function(processed_sce) {
   }
 
   if ("singler_celltype_annotation" %in% names(celltype_df)) {
-    celltype_df <- prepare_automated_annotation_values(
-      celltype_df,
-      singler_celltype_annotation
-    )
+    celltype_df <- celltype_df |>
+      dplyr::filter(singler_celltype_annotation != "Unclassified cell") |>
+      prepare_automated_annotation_values(singler_celltype_annotation)
   }
   if ("cellassign_celltype_annotation" %in% names(celltype_df)) {
-    celltype_df <- prepare_automated_annotation_values(
-      celltype_df,
-      cellassign_celltype_annotation
-    )
+    celltype_df <- celltype_df |>
+      dplyr::filter(cellassign_celltype_annotation != "Unclassified cell") |>
+      prepare_automated_annotation_values(cellassign_celltype_annotation)
   }
 
   return(celltype_df)

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -44,14 +44,16 @@ create_celltype_df <- function(processed_sce) {
   }
 
   if ("singler_celltype_annotation" %in% names(celltype_df)) {
-    celltype_df <- celltype_df |>
-      dplyr::filter(singler_celltype_annotation != "Unclassified cell") |>
-      prepare_automated_annotation_values(singler_celltype_annotation)
+    celltype_df <- prepare_automated_annotation_values(
+      celltype_df,
+      singler_celltype_annotation
+    )
   }
   if ("cellassign_celltype_annotation" %in% names(celltype_df)) {
-    celltype_df <- celltype_df |>
-      dplyr::filter(cellassign_celltype_annotation != "Unclassified cell") |>
-      prepare_automated_annotation_values(cellassign_celltype_annotation)
+    celltype_df <- prepare_automated_annotation_values(
+      celltype_df,
+      cellassign_celltype_annotation
+    )
   }
 
   return(celltype_df)


### PR DESCRIPTION
When working on a plot for the paper, I noticed that we don't remove the `Unclassified cells` from the heatmaps, even though we have a nice little blue box that says we do. 