### PR TITLE
Update colData merging based on altExps 😈 

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -155,10 +155,7 @@ if (opt$feature_dir != "") {
 
   # if CITE, add `adt_name` column to rowData with rownames
   if (opt$feature_name == "adt") {
-    rowdata_rownames <- altExp(unfiltered_sce, opt$feature_name) |>
-      rowData() |>
-      rownames()
-    rowData(altExp(unfiltered_sce, opt$feature_name))$adt_name <- rowdata_rownames
+    rowData(altExp(unfiltered_sce, "adt"))$adt_name <- rownames(rowData(altExp(unfiltered_sce, "adt")))
   }
 }
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -152,6 +152,14 @@ if (opt$feature_dir != "") {
   unfiltered_sce <- merge_altexp(unfiltered_sce, feature_sce, opt$feature_name)
   # add alt experiment features stats
   altExp(unfiltered_sce, opt$feature_name) <- scuttle::addPerFeatureQCMetrics(altExp(unfiltered_sce, opt$feature_name))
+
+  # if CITE, add `adt_name` column to rowData with rownames
+  if (opt$feature_name == "adt") {
+    rowdata_rownames <- altExp(unfiltered_sce, opt$feature_name) |>
+      rowData() |>
+      rownames()
+    rowData(altExp(unfiltered_sce, opt$feature_name))$adt_name <- rowdata_rownames
+  }
 }
 
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -153,9 +153,9 @@ if (opt$feature_dir != "") {
   # add alt experiment features stats
   altExp(unfiltered_sce, opt$feature_name) <- scuttle::addPerFeatureQCMetrics(altExp(unfiltered_sce, opt$feature_name))
 
-  # if CITE, add `adt_name` column to rowData with rownames
+  # if CITE, add `adt_id` column to rowData with rownames
   if (opt$feature_name == "adt") {
-    rowData(altExp(unfiltered_sce, "adt"))$adt_name <- rownames(rowData(altExp(unfiltered_sce, "adt")))
+    rowData(altExp(unfiltered_sce, "adt"))$adt_id <- rownames(rowData(altExp(unfiltered_sce, "adt")))
   }
 }
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -207,6 +207,7 @@ possible_columns <- c(
   "miQC_pass",
   "prob_compromised",
   "scpca_filter",
+  "additional_modalities",
   # cell type names
   "submitter_celltype_annotation",
   "singler_celltype_annotation",

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -258,7 +258,7 @@ if (is.null(adt_possible_columns) & length(adt_altexps) > 0) {
 }
 
 retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_columns, adt_present_columns))
-preserve_altexp_rowdata_list <- list("adt" = c("adt_name", "target_type"))
+preserve_altexp_rowdata_list <- list("adt" = c("adt_id", "target_type"))
 
 # Merge SCEs -------------------------------------------------------------------
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -210,9 +210,6 @@ if ("cellassign" %in% all_celltypes) {
 
 
 
-
-
-
 # Update some SCE information  -----------------------
 # - Add a new colData column with any additional modalities
 # - Remove cluster parameters from metadata

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -250,10 +250,10 @@ adt_present_columns <- sce_list |>
   # if input is empty, then there are no "adt" altExps anyways
   purrr::reduce(union, .init = NULL)
 
-# ensure that there are indeed no "adt" altExps if adt_possible_columns is empty
+# ensure that there are indeed no "adt" altExps if adt_present_columns is empty
 adt_altexps <- sce_list |>
   purrr::keep(\(sce) "adt" %in% altExpNames(sce))
-if (is.null(adt_possible_columns) & length(adt_altexps) > 0) {
+if (is.null(adt_present_columns) && length(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -178,12 +178,11 @@ if ("cellassign" %in% all_celltypes) {
 # - Remove cluster parameters from metadata
 sce_list <- sce_list |>
   purrr::map(\(sce){
-    # value will be adt, cellhash, or NA
     additional_modalities <- altExpNames(sce)
     if (length(additional_modalities) == 0) {
       additional_modalities <- NA
     }
-    sce$additional_modalities <- additional_modalities
+    sce$additional_modalities <- paste0(additional_modalities, collapse = ";")
 
     metadata(sce)$cluster_algorithm <- NULL
     metadata(sce)$cluster_weighting <- NULL

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -235,9 +235,7 @@ sce_list <- sce_list |>
 #  - retain cellhash main experiment column, if cellhash present in any library
 
 all_modalities <- sce_list |>
-  purrr::map(\(sce){
-    sce$additional_modalities
-  }) |>
+  purrr::map(altExpNames) |>
   purrr::reduce(union)
 
 # Set default values for input lists to NULL
@@ -256,13 +254,13 @@ if ("adt" %in% all_modalities) {
 
   # find all the adt columns and retain them
   adt_columns <- sce_list |>
-    # only consider altExps with "adt"
+    # only consider "adt" altExps
     purrr::keep(\(sce) "adt" %in% altExpNames(sce)) |>
-    purrr::map(\(sce) names(colData(altExp(sce)))) |>
+    purrr::map(\(sce) names(colData(altExp(sce, "adt")))) |>
     purrr::reduce(union)
 
-  retain_altexp_coldata_list <- list("adt" = adt_columns)
-  preserve_altexp_rowdata_list <- list("adt" = c("target_type"))
+  retain_altexp_coldata_list <- c(retain_altexp_coldata_list, list("adt" = adt_columns))
+  preserve_altexp_rowdata_list <- c(preserve_altexp_rowdata_list, list("adt" = c("adt_name", "target_type"))
 }
 
 if ("cellhash" %in% all_modalities) {

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -259,7 +259,16 @@ if ("adt" %in% all_modalities) {
 
 if ("cellhash" %in% all_modalities) {
   # determine which cellhash stats columns to keep of the possible columns which may exist
-  cellhash_possible <- c("hashedDrops_sampleID", "HTODemux_sampleID", "vireo_sampleid")
+  cellhash_possible <- c(
+    "hashedDrops_sampleID",
+    "HTODemux_sampleID",
+    "vireo_sampleid",
+    # Also consider cellhash stats columns, which will not get
+    # added in merge_sce_list since include_altexp will be FALSE
+    "altexps_cellhash_sum",
+    "altexps_cellhash_detected",
+    "altexps_cellhash_percent"
+  )
 
   coldata_present <- sce_list |>
     purrr::map(\(sce) names(colData(sce))) |>

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -228,10 +228,10 @@ possible_coldata <- c(
 )
 
 # Define colData columns to retain based on intersection with present columns
-retain_coldata_columns <- sce_list |>
+columns_present <- sce_list |>
   purrr::map(\(sce) names(colData(sce))) |>
-  purrr::reduce(union) |>
-  intersect(possible_coldata)
+  purrr::reduce(union)
+retain_coldata_columns <-  intersect(possible_coldata, columns_present)
 
 # Define altExp columns to retain/preserve, currently only for "adt"
 adt_possible_coldata <- c(
@@ -242,7 +242,7 @@ adt_possible_coldata <- c(
   "high.controls",
   "discard"
 )
-adt_possible_columns <- sce_list |>
+adt_columns_present <- sce_list |>
   # only consider "adt" altExps
   purrr::keep(\(sce) "adt" %in% altExpNames(sce)) |>
   purrr::map(\(sce) names(colData(altExp(sce, "adt")))) |>
@@ -257,7 +257,7 @@ if (is.null(adt_possible_columns) & length(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }
 
-retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_coldata, adt_possible_columns))
+retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_coldata, adt_columns_present))
 preserve_altexp_rowdata_list <- list("adt" = c("adt_name", "target_type"))
 
 # Merge SCEs -------------------------------------------------------------------

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -246,7 +246,13 @@ preserve_altexp_rowdata_list <- NULL
 
 if ("adt" %in% all_modalities) {
   # save adt filter info in main altexp
-  retain_coldata_columns <- c(retain_coldata_columns, "adt_scpca_filter")
+  retain_coldata_columns <- c(
+    retain_coldata_columns,
+    "adt_scpca_filter",
+    "altexps_adt_sum",
+    "altexps_adt_detected",
+    "altexps_adt_percent"
+  )
 
   # find all the adt columns and retain them
   adt_columns <- sce_list |>
@@ -265,8 +271,6 @@ if ("cellhash" %in% all_modalities) {
     "hashedDrops_sampleID",
     "HTODemux_sampleID",
     "vireo_sampleid",
-    # Also consider cellhash stats columns, which will not get
-    # added in merge_sce_list since include_altexp will be FALSE
     "altexps_cellhash_sum",
     "altexps_cellhash_detected",
     "altexps_cellhash_percent"

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -195,7 +195,7 @@ sce_list <- sce_list |>
 # Determine SCE columns to retain  ---------------------------------------------
 
 # Define all possible colData columns which we might want to retain
-possible_coldata <- c(
+possible_columns <- c(
   "barcodes",
   # RNA statistics and post-processing
   "sum",
@@ -228,13 +228,13 @@ possible_coldata <- c(
 )
 
 # Define colData columns to retain based on intersection with present columns
-columns_present <- sce_list |>
+present_columns <- sce_list |>
   purrr::map(\(sce) names(colData(sce))) |>
   purrr::reduce(union)
-retain_coldata_columns <-  intersect(possible_coldata, columns_present)
+retain_coldata_columns <- intersect(possible_columns, present_columns)
 
 # Define altExp columns to retain/preserve, currently only for "adt"
-adt_possible_coldata <- c(
+adt_possible_columns <- c(
   "zero.ambient",
   "high.ambient",
   "ambient.scale",
@@ -242,7 +242,7 @@ adt_possible_coldata <- c(
   "high.controls",
   "discard"
 )
-adt_columns_present <- sce_list |>
+adt_present_columns <- sce_list |>
   # only consider "adt" altExps
   purrr::keep(\(sce) "adt" %in% altExpNames(sce)) |>
   purrr::map(\(sce) names(colData(altExp(sce, "adt")))) |>
@@ -257,7 +257,7 @@ if (is.null(adt_possible_columns) & length(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }
 
-retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_coldata, adt_columns_present))
+retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_columns, adt_present_columns))
 preserve_altexp_rowdata_list <- list("adt" = c("adt_name", "target_type"))
 
 # Merge SCEs -------------------------------------------------------------------

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -234,7 +234,15 @@ retain_coldata_columns <- sce_list |>
   intersect(possible_coldata)
 
 # Define altExp columns to retain/preserve, currently only for "adt"
-adt_columns <- sce_list |>
+adt_possible_coldata <- c(
+  "zero.ambient",
+  "high.ambient",
+  "ambient.scale",
+  "sum.controls",
+  "high.controls",
+  "discard"
+)
+adt_possible_columns <- sce_list |>
   # only consider "adt" altExps
   purrr::keep(\(sce) "adt" %in% altExpNames(sce)) |>
   purrr::map(\(sce) names(colData(altExp(sce, "adt")))) |>
@@ -242,15 +250,14 @@ adt_columns <- sce_list |>
   # if input is empty, then there are no "adt" altExps anyways
   purrr::reduce(union, .init = NULL)
 
-# ensure that there are indeed no "adt" altExps if adt_columns is empty
-all_modalities <- sce_list |>
-  purrr::map(\(sce) sce$additional_modalities) |>
-  purrr::reduce(union)
-if ("adt" %in% all_modalities & is.null(adt_columns)) {
+# ensure that there are indeed no "adt" altExps if adt_possible_columns is empty
+adt_altexps <- sce_list |>
+  purrr::keep(\(sce) "adt" %in% altExpNames(sce))
+if (is.null(adt_possible_columns) & length(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }
 
-retain_altexp_coldata_list <- list("adt" = adt_columns)
+retain_altexp_coldata_list <- list("adt" = intersect(adt_possible_coldata, adt_possible_columns))
 preserve_altexp_rowdata_list <- list("adt" = c("adt_name", "target_type"))
 
 # Merge SCEs -------------------------------------------------------------------

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -264,7 +264,6 @@ merged_sce <- scpcaTools::merge_sce_list(
   retain_coldata_cols = retain_coldata_columns,
   include_altexp = opt$include_altexp,
   preserve_rowdata_cols = c("gene_symbol", "gene_ids"),
-  # altExp information to retain; values will be NULL unless there is CITE-seq
   retain_altexp_coldata_cols = retain_altexp_coldata_list,
   preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
 )

--- a/merge.nf
+++ b/merge.nf
@@ -127,16 +127,23 @@ workflow {
       .splitCsv(header: true, sep: '\t')
       // filter to only include specified project ids
       .filter{it.scpca_project_id in project_ids}
+      .map{[
+        seq_unit: it.seq_unit,
+        technology: it.technology,
+        project_id: it.scpca_project_id,
+        library_id: it.scpca_library_id,
+        sample_id: it.scpca_sample_id.split(";").sort().join(",")
+      ]}
 
     // get all projects that contain at least one library with CITEseq
     adt_projects = libraries_ch
       .filter{it.technology.startsWith('CITEseq')}
-      .collect{it.scpca_project_id}
+      .collect{it.project_id}
       .map{it.unique()}
 
     multiplex_projects = libraries_ch
       .filter{it.technology.startsWith('cellhash')}
-      .collect{it.scpca_project_id}
+      .collect{it.project_id}
       .map{it.unique()}
 
     grouped_libraries_ch = libraries_ch
@@ -144,9 +151,9 @@ workflow {
       .filter{it.seq_unit in ['cell', 'nucleus']}
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[
-        it.scpca_project_id,
-        it.scpca_library_id,
-        file("${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id.split(";").sort().join(",")}/${it.scpca_library_id}_processed.rds")
+        it.project_id,
+        it.library_id,
+        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
       ]}
       // only include libraries that have been processed through scpca-nf
       .filter{file(it[2]).exists()}

--- a/merge.nf
+++ b/merge.nf
@@ -146,7 +146,7 @@ workflow {
       .map{[
         it.scpca_project_id,
         it.scpca_library_id,
-        file("${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id}/${it.scpca_library_id}_processed.rds")
+        file("${params.results_dir}/${it.scpca_project_id}/${it.scpca_sample_id.split(";").sort().join(",")}/${it.scpca_library_id}_processed.rds")
       ]}
       // only include libraries that have been processed through scpca-nf
       .filter{file(it[2]).exists()}

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -29,7 +29,7 @@ process make_unfiltered_sce{
 
 
         # Only run script if annotations are available:
-        if [ ${submitter_cell_types_file.name} != "NO_FILE" ]; then
+        if [ "${submitter_cell_types_file.name}" != "NO_FILE" ]; then
           add_submitter_annotations.R \
             --sce_file "${unfiltered_rds}" \
             --library_id "${meta.library_id}" \

--- a/templates/merge-report.rmd
+++ b/templates/merge-report.rmd
@@ -69,8 +69,15 @@ batch_column <- params$batch_column
 
 # set adt/multiplex values
 # this tells us if at least one library contains either of these modalities
-has_adt <- "adt" %in% merged_sce$additional_modalities
-multiplexed <- "cellhash" %in% merged_sce$additional_modalities
+additional_modalities <- merged_sce$additional_modalities |>
+  purrr::map(
+    stringr::str_split_1,
+    pattern = ";"
+  ) |>
+  purrr::reduce(union)
+
+has_adt <- "adt" %in% additional_modalities
+multiplexed <- "cellhash" %in% additional_modalities
 ```
 
 ```{r, integration-warning, eval=FALSE}
@@ -146,7 +153,9 @@ adt_table <- coldata_df |>
   dplyr::select(library_id, additional_modalities) |>
   dplyr::distinct() |>
   dplyr::mutate(
-    contains_adt = ifelse(additional_modalities == "adt", "Contains ADT", "No ADT")
+    contains_adt = ifelse(
+      "adt" %in% additional_modalities, "Contains ADT", "No ADT"
+    )
   ) |>
   dplyr::count(contains_adt) |>
   dplyr::rename(
@@ -171,7 +180,9 @@ multiplex_table <- coldata_df |>
   dplyr::select(library_id, additional_modalities) |>
   dplyr::distinct() |>
   dplyr::mutate(
-    is_multiplexed = ifelse(additional_modalities == "cellhash", "Multiplexed", "No multiplexing")
+    is_multiplexed = ifelse(
+      "cellhash" %in% additional_modalities, "Multiplexed", "Not multiplexed"
+    )
   ) |>
   dplyr::count(is_multiplexed) |>
   dplyr::rename(

--- a/templates/merge-report.rmd
+++ b/templates/merge-report.rmd
@@ -70,11 +70,9 @@ batch_column <- params$batch_column
 # set adt/multiplex values
 # this tells us if at least one library contains either of these modalities
 additional_modalities <- merged_sce$additional_modalities |>
-  purrr::map(
-    stringr::str_split_1,
-    pattern = ";"
-  ) |>
-  purrr::reduce(union)
+  stringr::str_split(pattern = ";") |>
+  purrr::reduce(union) |>
+  sort()
 
 has_adt <- "adt" %in% additional_modalities
 multiplexed <- "cellhash" %in% additional_modalities


### PR DESCRIPTION
Closes #661 
I am opening this PR as a draft, since we are still working to finalize the `scpcaTools::merge_sce_list()` function updates https://github.com/AlexsLemonade/scpcaTools/pull/261 which this depends on. But, I have locally run the code with the current version of `merge_sce_list()` and it is working. If anyone wants to have a look at the code before I actually mark this ready for review, feel free!

First, I determine all modalities which are present. Then, handle columns which need to be included for each of `"adt"` and `"cellhash"`, if present. It also occurred to me that we should maybe keep the cellhash _stats_ columns, even though we aren't keeping the cellhash altExp itself (any disagreement?). We don't need to be explicit about those columns for `"adt"`, since `merge_sce_list()` will add them as part of altExp preparation. But, those steps won't be taken for `"cellhash"` since altExps will be skipped in the merge function.

FYI I rearranged a little bit too - I realized that by adding the `adt_scpca_filter` column within the existing `purrrr::map()`, we were going to keep readding it...and readding the vector...again and again for each SCE. So, this got moved out too.
