### PR TITLE
Add sample type to metadata and associated QC box

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -197,7 +197,7 @@ sample_type <- sample_metadata_df |>
 if (length(sample_type) == 1) {
   sample_type <- unname(sample_type)
 }
-metadata(unfiltered_sce) <- sample_type
+metadata(unfiltered_sce)$sample_type <- sample_type
 
 # write to rds
 readr::write_rds(unfiltered_sce, opt$unfiltered_file, compress = "gz")

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -279,7 +279,12 @@ if (has_singler && any(celltype_df$singler_celltype_annotation == "Unclassified 
     dplyr::filter(
       singler_celltype_annotation != "Unclassified cell"
     ) |>
-    forcats::fct_drop(only = "Unclassified cell")
+    dplyr::mutate(
+      singler_celltype_annotation = forcats::fct_drop(
+        singler_celltype_annotation,
+        only = "Unclassified cell"
+      )
+    )
 }
 
 # check for unclassified cellassign cells
@@ -291,7 +296,12 @@ if (has_cellassign && any(celltype_df$cellassign_celltype_annotation == "Unclass
     dplyr::filter(
       cellassign_celltype_annotation != "Unclassified cell"
     ) |>
-    forcats::fct_drop(only = "Unclassified cell")
+    dplyr::mutate(
+      cellassign_celltype_annotation = forcats::fct_drop(
+        cellassign_celltype_annotation,
+        only = "Unclassified cell"
+      )
+    )
 }
 
 # print a warning if either singleR or cellAssign have any unclassified cells

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -148,7 +148,7 @@ if (metadata(unfiltered_sce)$sample_type == "patient-derived xenograft") {
     <div class=\"alert alert-info\">
 
     This library comes from a cell line sample.
-    Please be aware that no cell type annotation if performed for cell line samples.
+    Please be aware that no cell type annotation is performed for cell line samples.
 
     </div>
   ")

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -133,6 +133,29 @@ if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
 ```
 
 
+```{r, results='asis'}
+# only print out info box if xenograft or cell line
+if (metadata(unfiltered_sce)$sample_type == "patient-derived xenograft") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+
+    This library comes from a patient-derived xenograft sample.
+
+    </div>
+  ")
+} else if (metadata(unfiltered_sce)$sample_type == "cell line") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+
+    This library comes from a cell line sample.
+    Please be aware that no cell type annotation if performed for cell line samples.
+
+    </div>
+  ")
+}
+```
+
+
 # Processing Information for `r library_id`
 
 ```{r, results='asis'}


### PR DESCRIPTION
Closes #645 

This PR makes a couple changes:

1) In `generate_unfiltered_sce.R`, I added a new `metadata` field for `sample_type`. Note that I opened https://github.com/AlexsLemonade/scpca-docs/issues/252 for docs followup. I also learned about `tibble::deframe()` along the way, and I enjoyed that.
2) In `main_qc_report.rmd`, I added a chunk to print a 🟦 stating if we have a pdx or cell line, and if the latter there are no cell types. See attached screenshots for how this looks - how do we feel about placement? Should I move this into the section `Processing Information for library SCPCL`?  (edit - after filing this, i saw and fixed the `if` typo in the cell line blue box) 
3) Fix the new `forcats::fct_drop()` code.... this function operates on characters, not dfs.... Booooo.

# Cell line screenshot 
![Screenshot 2024-01-23 at 2 59 55 PM](https://github.com/AlexsLemonade/scpca-nf/assets/4701111/e7ba1e79-0e3c-4264-88d5-dbd02bb1b4c4)

----

# PDX screenshot
![Screenshot 2024-01-23 at 2 58 40 PM](https://github.com/AlexsLemonade/scpca-nf/assets/4701111/6bd1efc1-85a3-42ef-9abd-83bd653cf697)
