### PR TITLE
Check that all column names are "barcode" 

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -191,7 +191,7 @@ if (!is.null(opt$cellassign_predictions)) {
 
   # if the only column is the barcode column then CellAssign didn't complete successfully
   # otherwise add in cell type annotations and metadata to SCE
-  if (colnames(predictions) == "barcode") {
+  if (all(colnames(predictions) == "barcode")) {
     # if failed then note that in the cell type column
     sce$cellassign_celltype_annotation <- "Not run"
   } else {


### PR DESCRIPTION
In running through a multiplexed library to completion, there was a lingering error in `add_celltypes_to_sce.R` where we were checking that the column names were equal to `barcode`. That works when we only have one column, but when we have multiple, it checks each column name against `barcode` and returns a vector. R doesn't like that there are multiple TRUE/FALSE values as a vector, so I added the `all` statement here. If the only column names are `barcode` then we assign cells to `Not run`, otherwise we proceed with adding in celltypes. 

Note that I did run this and everything ran to completion. I think we are good to do another release with these new bug fixes? 