### PR TITLE
Fix missing files directory bug

### DIFF
--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -164,7 +164,7 @@ workflow map_quant_feature{
       .branch{
         make_rad: (
           // input files exist
-          file(it.files_directory, type: "dir").exists() && (
+          it.files_directory && file(it.files_directory, type: "dir").exists() && (
             // and repeat has been requested
             params.repeat_mapping
             // or the feature rad file directory does not exist

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -125,7 +125,7 @@ workflow map_quant_rna {
       .branch{
         make_rad: (
           // input files exist
-          file(it.files_directory, type: "dir").exists() && (
+          it.files_directory && file(it.files_directory, type: "dir").exists() && (
             // and repeat has been requested
             params.repeat_mapping
             // the rad directory does not exist


### PR DESCRIPTION
Closes #670 

This PR fixes a bug to ensure that `it.file_directory` is not `false` in the first place before we check if it exists. Workflow now runs without the associated error.