### PR TITLE
Update sample_type printing logic to handle multiplex samples

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -264,7 +264,6 @@ merged_sce <- scpcaTools::merge_sce_list(
   retain_coldata_cols = retain_coldata_columns,
   include_altexp = opt$include_altexp,
   preserve_rowdata_cols = c("gene_symbol", "gene_ids"),
-  # altExp information to retain; values will be NULL unless there is CITE-seq
   retain_altexp_coldata_cols = retain_altexp_coldata_list,
   preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
 )

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -130,52 +130,91 @@ if (has_processed) {
 if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
   stop("Cell type annotations were provided but the parameter specifying the cell type report file is missing.")
 }
+
+# check if we have multiplex
+has_multiplex <- length(sample_id) > 1
 ```
 
 
 ```{r, results='asis'}
-# only print out info box if xenograft or cell line
-if (metadata(unfiltered_sce)$sample_type == "patient-derived xenograft") {
-  glue::glue("
-    <div class=\"alert alert-info\">
+# only print out info box if xenograft or cell line, with different logic/warnings
+# for multiplex libraries
+if ("patient-derived xenograft" %in% metadata(unfiltered_sce)$sample_type) {
 
-    This library comes from a patient-derived xenograft sample.
+  # determine which samples are the PDXs
+  if (has_multiplex) {
+    pdxs <- metadata(unfiltered_sce)$sample_type
+    pdx_samples <- names(pdxs[pdxs == "patient-derived xenograft"])
+    pdx_samples_bullets <- paste0("<li>", paste(pdx_samples, collapse = "</li><li>", "</li>"))
 
-    </div>
-  ")
-} else if (metadata(unfiltered_sce)$sample_type == "cell line") {
-  glue::glue("
-    <div class=\"alert alert-info\">
+    glue::glue("
+      <div class=\"alert alert-info\">
 
-    This library comes from a cell line sample.
-    Please be aware that no cell type annotation is performed for cell line samples.
+      This library includes patient-derived xenograft samples.
+      The following samples are derived from patient xenografts:
 
-    </div>
-  ")
+      {pdx_samples_bullets}
+
+      </div>
+    ")
+
+  } else {
+    glue::glue("
+      <div class=\"alert alert-info\">
+
+      This library comes from a patient-derived xenograft sample.
+
+      </div>
+    ")
+  }
+}
+
+if ("cell line" %in% metadata(unfiltered_sce)$sample_type) {
+  if (has_multiplex) {
+    cell_lines <- metadata(unfiltered_sce)$sample_type
+    cell_line_samples <- names(pdxs[pdxs == "cell line"])
+    cell_line_samples_bullets <- paste0("<li>", paste(cell_line_samples, collapse = "</li><li>", "</li>"))
+
+    glue::glue("
+      <div class=\"alert alert-info\">
+
+      This library includes cell line samples.
+      Please be aware that no cell type annotation is performed for cell line samples.
+      The following samples are derived from cell lines:
+
+      {cell_line_samples_bullets}
+
+      </div>
+    ")
+  } else {
+    glue::glue("
+      <div class=\"alert alert-info\">
+
+      This library comes from a cell line sample.
+      Please be aware that no cell type annotation is performed for cell line samples.
+
+      </div>
+    ")
+  }
 }
 ```
 
 
 # Processing Information for `r library_id`
 
-```{r, results='asis'}
-# only print out multiplexed warning if more than one sample is present
-has_multiplex <- length(sample_id) > 1
+```{r, eval = has_multiplex, results='asis'}
+# convert sample id to bullet separated list
+multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
+glue::glue("
+  <div class=\"alert alert-warning\">
 
-if (has_multiplex) {
-  # convert sample id to bullet separated list
-  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = "</li><li>", "</li>"))
-  glue::glue("
-    <div class=\"alert alert-warning\">
+  This library is multiplexed and contains data from more than one sample.
+  Data from the following samples are included in this library:
 
-    This library is multiplexed and contains data from more than one sample.
-    Data from the following samples are included in this library:
+  {multiplex_samples}
 
-    {multiplex_samples}
-
-    </div>
-  ")
-}
+  </div>
+")
 ```
 
 ## Raw Sample Metrics


### PR DESCRIPTION
**Stacked on #666 😈**

Closes #676 

This PR updates the logic where we print the `metadata(sce)$sample_type` info box at the top of the QC report. I'm filing as a Draft since I'm currently testing the code, and will request review once any bugs are squashed. 

One question is the relevant placement of boxes. We currently don't have any multiplex libraries from PDX or cell line samples, but if/when we do, the info box about the sample type will be printed _before_ the warning that the library contains multiplex samples. Do we want to move the multiplex warning to be above the sample_type info box?