### PR TITLE
Update merged object for anndata export

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -295,7 +295,8 @@ library_df <- names(sce_list) |>
       library_id = library_id,
       tech_version = lib_meta$tech_version,
       assay_ontology_term_id = lib_meta$assay_ontology_term_id,
-      seq_unit = lib_meta$seq_unit
+      # rename to suspension_type for consistency with merged AnnData objects
+      suspension_type = lib_meta$seq_unit
     )
   }) |>
   dplyr::bind_rows()

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -170,8 +170,15 @@ if (!is.null(opt$feature_name)) {
     # add sample metadata from main sce to alt sce metadata
     metadata(alt_sce)$sample_metadata <- sample_metadata
 
-    # make sce czi compliant
-    alt_sce <- format_czi(alt_sce)
+    # make altExp sce czi compliant, for single SCE objects
+    if (!is_merged) {
+      sce <- format_czi(sce)
+    } else {
+      # paste X to reduced dim names if present
+      if (!is.null(reducedDimNames(sce))) {
+        reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+      }
+    }
 
     # export altExp sce as anndata object
     scpcaTools::sce_to_anndata(

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -139,7 +139,7 @@ sce <- readr::read_rds(opt$input_sce_file)
 sample_metadata <- metadata(sce)$sample_metadata
 
 # make main sce czi compliant for single objects, or format merged objects
-if (!is_merged) {
+if (!opt$is_merged) {
   sce <- format_czi(sce)
 } else {
   sce <- format_merged_sce(sce)
@@ -179,7 +179,7 @@ if (!is.null(opt$feature_name)) {
     metadata(alt_sce)$sample_metadata <- sample_metadata
 
     # make altExp sce czi compliant for single objects, or format merged objects
-    if (!is_merged) {
+    if (!opt$is_merged) {
       sce <- format_czi(sce)
     } else {
       sce <- format_merged_sce(sce)

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -39,6 +39,12 @@ option_list <- list(
     action = "store_true",
     default = FALSE,
     help = "Compress the HDF5 file containing the AnnData object"
+  ),
+  make_option(
+    opt_str = c("--is_merged"),
+    action = "store_true",
+    default = FALSE,
+    help = "Whether the input SCE file contains a merged object"
   )
 )
 

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -127,8 +127,17 @@ sce <- readr::read_rds(opt$input_sce_file)
 # we need this if we have any feature data that we need to add it o
 sample_metadata <- metadata(sce)$sample_metadata
 
-# make main sce czi compliant
-sce <- format_czi(sce)
+# make main sce czi compliant, for single SCE objects
+if (!is_merged) {
+  sce <- format_czi(sce)
+} else {
+  # paste X to reduced dim names if present
+  if (!is.null(reducedDimNames(sce))) {
+    reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+  }
+}
+
+
 
 # export sce as anndata object
 # this function will also remove any R-specific object types from the SCE metadata

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -70,11 +70,6 @@ format_merged_sce <- function(sce) {
   if (!is.null(reducedDimNames(sce))) {
     reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
   }
-
-  # Replace seq_unit with suspension_type
-  sce$suspension_type <- sce$seq_unit
-  sce$seq_unit <- NULL
-
   return(sce)
 }
 

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -67,9 +67,7 @@ if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5|.h5ad"))) {
 # this function updates merged object formatting for anndata export
 format_merged_sce <- function(sce) {
   # paste X to reduced dim names if present
-  if (!is.null(reducedDimNames(sce))) {
-    reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
-  }
+  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
   return(sce)
 }
 
@@ -139,10 +137,10 @@ sce <- readr::read_rds(opt$input_sce_file)
 sample_metadata <- metadata(sce)$sample_metadata
 
 # make main sce czi compliant for single objects, or format merged objects
-if (!opt$is_merged) {
-  sce <- format_czi(sce)
-} else {
+if (opt$is_merged) {
   sce <- format_merged_sce(sce)
+} else {
+  sce <- format_czi(sce)
 }
 
 
@@ -179,10 +177,10 @@ if (!is.null(opt$feature_name)) {
     metadata(alt_sce)$sample_metadata <- sample_metadata
 
     # make altExp sce czi compliant for single objects, or format merged objects
-    if (!opt$is_merged) {
-      sce <- format_czi(sce)
-    } else {
+    if (opt$is_merged) {
       sce <- format_merged_sce(sce)
+    } else {
+      sce <- format_czi(sce)
     }
 
     # export altExp sce as anndata object

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -66,7 +66,7 @@ if (!(stringr::str_ends(opt$output_rna_h5, ".hdf5|.h5|.h5ad"))) {
 
 # this function updates merged object formatting for anndata export
 format_merged_sce <- function(sce) {
-  # paste X to reduced dim names if present
+  # paste X to any present reduced dim names
   reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
   return(sce)
 }
@@ -119,10 +119,8 @@ format_czi <- function(sce) {
   # so everything gets set to false
   rowData(sce)$feature_is_filtered <- FALSE
 
-  # paste X to reduced dim names if present
-  if (!is.null(reducedDimNames(sce))) {
-    reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
-  }
+  # paste X to any present reduced dim names
+  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
 
   return(sce)
 }

--- a/merge.nf
+++ b/merge.nf
@@ -102,6 +102,7 @@ process export_anndata{
         --input_sce_file ${merged_sce_file} \
         --output_rna_h5 ${rna_hdf5_file} \
         --output_feature_h5 ${feature_hdf5_file} \
+        --is_merged \
         ${has_adt ? "--feature_name adt" : ''}
 
       # move normalized counts to X in AnnData
@@ -169,7 +170,7 @@ workflow {
         library_id_list,
         sce_file_list
       )}
-      
+
     merge_sce(grouped_libraries_ch)
 
     // generate merge report

--- a/templates/merge-report.rmd
+++ b/templates/merge-report.rmd
@@ -123,14 +123,14 @@ The merged object summarized in this report is comprised of `r num_libraries` in
 ```{r}
 # table summarizing number of libraries with tech version and seq unit
 tech_table <- coldata_df |>
-  dplyr::select(library_id, tech_version, assay_ontology_term_id, seq_unit) |>
+  dplyr::select(library_id, tech_version, assay_ontology_term_id, suspension_type) |>
   dplyr::distinct() |>
-  dplyr::count(tech_version, assay_ontology_term_id, seq_unit) |>
+  dplyr::count(tech_version, assay_ontology_term_id, suspension_type) |>
   dplyr::arrange(desc(n)) |>
   dplyr::rename(
     "Technology version" = "tech_version",
     "Experimental factor ontology" = "assay_ontology_term_id",
-    "Suspension type" = "seq_unit",
+    "Suspension type" = "suspension_type",
     "Number of libraries" = "n"
   )
 


### PR DESCRIPTION
Closes #681

This PR addresses issues raised about handling merged object during AnnData export:

1) In `merge_sces.R`, I ensured that `colData` column is called `suspension_type`, not `seq_unit`, and I updated `merge-report.rmd` accordingly.
2) I added a flag to `sce_to_anndata.R` to turn on in `merge.nf`.
3) I added a function `format_merged_sce()` to `sce_to_anndata.R` to format merged objects differently than single objects. This function only updates the reduced dim names, but even so I think the modularity is useful in case we ever want/need to change something else. Also, I use this function for altExps too. We don't expect reducedDims in the altExp so it really has no effect, but again one day we might need to add something else so I thought mirroring the code between main/altexp processing made sense. Any thoughts there?

I tested `merge.nf` with `SCPCP000003` (aka with an altExp) and confirmed it runs successfully.