### PR TITLE
Remove duplicated code in cell type module

### DIFF
--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -139,30 +139,6 @@ workflow annotate_celltypes {
       ]
     }
     .filter{it.is_cell_line}
-    .map{it.sample_id} 
-    .toList()
-
-    // branch to cell type the non-cell line libraries only
-    sce_files_channel_branched = sce_files_channel
-     .branch{
-        cell_line: it[0]["sample_id"].split(",").collect{it in cell_line_samples.getVal()}.every()
-        // only run cell typing on tissue samples
-        tissue: true
-      }
-    
-    // get just the meta and processed sce from the tissue (not cell line) samples
-    processed_sce_channel = sce_files_channel_branched.tissue.map{[it[0], it[3]]}
-
-  // read in sample metadata and make a list of cell line samples; these won't be cell typed
-  cell_line_samples = Channel.fromPath(params.sample_metafile)
-    .splitCsv(header: true, sep: '\t')
-    .map{
-      [
-        sample_id: it.scpca_sample_id,
-        is_cell_line: Utils.parseNA(it.is_cell_line).toBoolean() // FALSE -> false, NA -> false, TRUE -> true
-      ]
-    }
-    .filter{it.is_cell_line}
     .map{it.sample_id}
     .toList()
 


### PR DESCRIPTION
Hot fix into `main` to remove duplicated code that snuck in there during a merge.