### PR TITLE
Add cellassign note to QC if not run

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -361,7 +361,7 @@ Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_
 ```
 
 
-```{r, eval = has_umap}
+```{r, eval = has_umap, warning = FALSE}
 # Create dataset for plotting UMAPs with lumped and label-wrapped cell types
 umap_df <- lump_wrap_celltypes(celltype_df)
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -254,24 +254,25 @@ methods_bullets <- c(
   stringr::str_flatten(collapse = "\n")
 
 
-# print the bullets
+
+# print the bullets and other info messages
 glue::glue("
   This library contains the following cell type annotations:
 
   {methods_bullets}
-
-  For additional information about cell typing, including methods used for cell typing, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
 ")
-```
 
+if (cellassign_not_run) {
+  glue::glue(
+    "\n\nCell type annotation with `CellAssign` was attempted but not run due to an insufficient number of cells."
+  )
+}
 
-```{r eval=cellassign_not_run && !is_supplemental, results='asis'}
 glue::glue("
-   <div class=\"alert alert-info\">
-   Cell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
-  </div>
+  \n\nFor additional information about cell typing, including methods used for cell typing, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
 ")
 ```
+
 
 ## Statistics
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -237,6 +237,11 @@ determine_umap_dimensions <- function(n_celltypes) {
 The plots and tables included here detail the results from performing cell type annotation.
 
 ```{r, eval = !is_supplemental, results = 'asis'}
+cellassign_not_run <- check_cellassign_not_run(
+  has_cellassign,
+  colData(processed_sce)
+)
+
 # define bullets glue string
 methods_bullets <- c(
   ifelse(has_submitter, "Submitter-provided", NA),
@@ -256,6 +261,15 @@ glue::glue("
   {methods_bullets}
 
   For additional information about cell typing, including methods used for cell typing, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
+")
+```
+
+
+```{r eval=cellassign_not_run && !is_supplemental, results='asis'}
+glue::glue("
+   <div class=\"alert alert-info\">
+   Cell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
+  </div>
 ")
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -371,7 +371,9 @@ glue::glue("{methods_text}")
 if (cellassign_not_run) {
   # this needs two \n\n to appear on a separate line
   glue::glue(
-    "\n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
+   <div class=\"alert alert-info\">
+    \n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
+    </div>
     "
   )
 }

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -369,8 +369,9 @@ if (has_cellassign) {
 glue::glue("{methods_text}")
 
 if (cellassign_not_run) {
+  # this needs two \n\n to appear on a separate line
   glue::glue(
-    "\n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1), was attempted but did not run due to an insufficient number of cells.
+    "\n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
     "
   )
 }

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -370,7 +370,7 @@ glue::glue("{methods_text}")
 
 if (cellassign_not_run) {
   glue::glue(
-    "\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1), was attempted but did not run due to an insufficient number of cells.
+    "\n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1), was attempted but did not run due to an insufficient number of cells.
     "
   )
 }

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -273,6 +273,17 @@ available_celltypes <- c(
   na.omit() |>
   as.character()
 
+# check if cellassign run was attempted but failed
+if (!has_cellassign && "cellassign_celltype_annotation" %in% names(colData(processed_sce))) {
+  # This means the values should all be `"Not run"`
+  if (!(all(processed_sce$cellassign_celltype_annotation == "Not run"))) {
+    stop("Error: Unexpected CellAssign celltypes are present.")
+  }
+  cellassign_not_run <- TRUE
+} else {
+  cellassign_not_run <- FALSE
+}
+
 # This variable need to be defined for edge conditions when certain cell types
 #  aren't available:
 #  When we have chunks with `eval=<has_method>`, knitr seems to need all other
@@ -356,6 +367,13 @@ if (has_cellassign) {
 }
 
 glue::glue("{methods_text}")
+
+if (cellassign_not_run) {
+  glue::glue(
+    "\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1), was attempted but did not run due to an insufficient number of cells.
+    "
+  )
+}
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -367,16 +367,15 @@ if (has_cellassign) {
 }
 
 glue::glue("{methods_text}")
+```
 
-if (cellassign_not_run) {
-  # this needs two \n\n to appear on a separate line
-  glue::glue(
+
+```{r eval=cellassign_not_run, results='asis'}
+glue::glue("
    <div class=\"alert alert-info\">
-    \n\nCell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
-    </div>
-    "
-  )
-}
+   Cell type annotation with [`CellAssign`](https://github.com/Irrationone/cellassign), a marker-gene-based approach ([Zhang _et al._ 2019](https://doi.org/10.1038/s41592-019-0529-1)), was attempted but not run due to an insufficient number of cells.
+  </div>
+")
 ```
 
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -259,7 +259,8 @@ processed_sce <- params$processed_sce
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
 has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
-has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods
+has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
+  !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
 # check for umap
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
@@ -273,16 +274,11 @@ available_celltypes <- c(
   na.omit() |>
   as.character()
 
-# check if cellassign run was attempted but failed
-if (!has_cellassign && "cellassign_celltype_annotation" %in% names(colData(processed_sce))) {
-  # This means the values should all be `"Not run"`
-  if (!(all(processed_sce$cellassign_celltype_annotation == "Not run"))) {
-    stop("Error: Unexpected CellAssign celltypes are present.")
-  }
-  cellassign_not_run <- TRUE
-} else {
-  cellassign_not_run <- FALSE
-}
+# was cellassign run?
+cellassign_not_run <- check_cellassign_not_run(
+  has_cellassign,
+  colData(processed_sce)
+)
 
 # This variable need to be defined for edge conditions when certain cell types
 #  aren't available:
@@ -368,7 +364,6 @@ if (has_cellassign) {
 
 glue::glue("{methods_text}")
 ```
-
 
 ```{r eval=cellassign_not_run, results='asis'}
 glue::glue("

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -114,7 +114,7 @@ if (has_processed) {
 
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
-  has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &
+  has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
     !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
   # If at least 1 is present, we have cell type annotations.
@@ -141,10 +141,9 @@ sample_types <- metadata(unfiltered_sce)$sample_type
 # only print out info box if xenograft or cell line, with different logic/warnings
 # for multiplex libraries
 if ("patient-derived xenograft" %in% sample_types) {
-
   # determine which samples are the PDXs
   if (has_multiplex) {
-    # get a list of samples in the library that are pdxs 
+    # get a list of samples in the library that are pdxs
     pdx_samples <- names(sample_types[sample_types == "patient-derived xenograft"])
     pdx_samples_bullets <- paste0("<li>", paste(pdx_samples, collapse = "</li><li>", "</li>"))
 
@@ -158,7 +157,6 @@ if ("patient-derived xenograft" %in% sample_types) {
 
       </div>
     ")
-
   } else {
     glue::glue("
       <div class=\"alert alert-info\">

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -140,4 +140,27 @@ prepare_submitter_annotation_values <- function(df) {
 
   return(df)
 }
+
+#' Check if CellAssign was run or not
+#'
+#' @param has_cellassign Boolean indicating if CellAssign is present
+#' @param sce_coldata colData slot of a processed SCE object
+#'
+#' @return TRUE if CellAssign was not run, FALSE if CellAssign was run
+check_cellassign_not_run <- function(
+    has_cellassign,
+    sce_coldata) {
+  if (!has_cellassign && "cellassign_celltype_annotation" %in% names(sce_coldata)) {
+    # This means the values should all be `"Not run"`
+    if (!(all(sce_coldata$cellassign_celltype_annotation == "Not run"))) {
+      stop("Error: Unexpected CellAssign celltypes are present.")
+    }
+
+    cellassign_not_run <- TRUE
+  } else {
+    cellassign_not_run <- FALSE
+  }
+
+  return(cellassign_not_run)
+}
 ```


### PR DESCRIPTION
Closes #663 

This PR adds a quick sentence to the top of the QC report if CellAssign was attempted but not run, where relevant
While I was here, I also added a `warning=FALSE` for an area in the UMAPs that was printing a warning (but code is all fine) that users don't need to see.

Here's how the sentence I added looks:

---

![Screenshot 2024-02-05 at 11 41 08 AM](https://github.com/AlexsLemonade/scpca-nf/assets/4701111/bd100c8c-fc16-4d4c-945f-ef7b49f12468)
