### PR TITLE
Add merge.nf external instructions

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -25,6 +25,7 @@ glioblastoma
 GRCh
 Hippen
 HPC
+HTO
 HTOs
 intronic
 Jaccard

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -641,17 +641,15 @@ If you specified a different parameter value from the default `scpca-out` for th
 Results from running the `merge.nf` workflow will also be added to this `params.outdir` directory in a sub-directory called `merged`.
 The `merge.nf` workflow will create merged objects for all processed library objects present for the specified project id.
 
-In order to run this workflow, you will first need to clone the `scpca-nf` repository and navigate into it:
 
-```sh
-git clone git@github.com:AlexsLemonade/scpca-nf.git
-cd scpca-nf
-```
-
-Then, you can run the workflow as follows:
+The workflow can be run as shown below.
+To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.7.2` version.
+Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf/merge.nf \
+  -r v0.7.2 \
   -config <path to config file>  \
   -profile <name of profile> \
   --project <project id whose libraries should be merged>

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -33,7 +33,10 @@
   - [Overview](#overview-1)
   - [Steps for running the `merge.nf` workflow](#steps-for-running-the-mergenf-workflow)
     - [Running the `merge.nf` workflow](#running-the-mergenf-workflow)
+  - [Output files](#output-files-1)
   - [Special considerations for specific data types when running `merge.nf`](#special-considerations-for-specific-data-types-when-running-mergenf)
+    - [Merging libraries with CITE-seq data](#merging-libraries-with-cite-seq-data)
+    - [Merging libraries with cellhash data](#merging-libraries-with-cellhash-data)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -638,11 +641,9 @@ The `merge.nf` workflow requires two parameters to run:
   In this case, a separate merged object will be created for each id.
 - `run_metafile`, the run metadata file which was previously prepared when running the main workflow
 
-<!-- I'm not sure this stuff about outdir is needed actually??-->
 The `merge.nf` workflow runs by first finding all libraries present, for each project, in the specified `params.outdir`, which represents the output directory where `scpca-nf` will have stored results from a prior run.
 If you specified a different parameter value from the default `scpca-out` for the `outdir` parameter in your `scpca-nf` configuration file, you will need to ensure that same value is provided to `merge.nf`.
 Results from running the `merge.nf` workflow will also be added to this `params.outdir` directory in a sub-directory called `merged`.
-The `merge.nf` workflow will create merged objects for all processed library objects present for the specified project id.
 
 The workflow can be run as shown:
 
@@ -665,14 +666,42 @@ nextflow run AlexsLemonade/scpca-nf/merge.nf \
   --project <project id whose libraries should be merged>
 ```
 
+### Output files
+
+The `merge.nf` workflow will output, for each specified project id, an `.rds` file containing a merged `SingleCellExperiment` object, an `.hdf5` file containing a merged `AnnData` object, and a report which provides a brief summary of the types of libraries and their samples' diagnoses included in the merged object, as well as UMAP visualizations highlighting each library.
+
+These output files will follow this structure:
+
+```
+merged
+└── <project id>
+    ├── <project_id>_merged.rds
+    ├── <project_id>_merged_rna.hdf5
+    └── <project_id>_merged-summary-report.html
+```
+
 
 ### Special considerations for specific data types when running `merge.nf`
 
 There are some additional considerations to be aware of for libraries which contain additional modalities, such as ADT counts from CITE-seq or HTO counts from multiplexing.
 
+#### Merging libraries with CITE-seq data
+
 If any libraries in a merge group have ADT counts, these counts will also be merged and included in the final merged object.
 In the case of `SingleCellExperiment` objects, ADT counts will be provided as an alternative experiment called `"adt"` in same object.
 In the case of `AnnData`, a separate file will be exported with the extension `_adt.hdf5` that contains the merged ADT counts.
+The output files will follow this structure if CITE-seq data is present:
+
+```
+merged
+└── <project id>
+    ├── <project_id>_merged.rds
+    ├── <project_id>_merged_rna.hdf5
+    ├── <project_id>_merged_adt.hdf5
+    └── <project_id>_merged-summary-report.html
+```
+
+#### Merging libraries with cellhash data
 
 The `merge.nf` workflow currently does not support merging HTO counts from multiplexed libraries.
 If any libraries contain HTO counts, the RNA counts will still be merged and exported, but the HTO counts will not be included.

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -67,12 +67,24 @@ Here we provide an overview of the steps you will need to complete:
 The standard configuration the `scpca-nf` workflow expects that compute nodes will have direct access to the internet, and will download reference files and container images with any required software as required.
 If your HPC system does not allow internet access from compute nodes, you will need to download the required reference files and software before running, [following the instructions we have provided](#using-scpca-nf-on-nodes-without-direct-internet-access).
 
-Once you have set up your environment and created the metadata and configuration files, you will be able to start your run as follows, adding any additional optional parameters that you may choose.
+Once you have set up your environment and created the metadata and configuration files, you will be able to start your run as follows, adding any additional optional parameters that you may choose:
 
-You will also need to specify a release tagged version of the workflow with the `-r` flag.
+```sh
+nextflow run AlexsLemonade/scpca-nf \
+  -config <path to config file>  \
+  -profile <name of profile>
+```
+
+Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
+This command will pull the `scpca-nf` workflow directly from Github, and run it based on the settings in the configuration file that you have defined.
+
+**Note:** `scpca-nf` is under active development.
+Using the above command will run the workflow from the `main` branch of the workflow repository.
+To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
+
+To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
 The command below will pull the `scpca-nf` workflow directly from Github using the `v0.7.2` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
-
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
@@ -80,14 +92,6 @@ nextflow run AlexsLemonade/scpca-nf \
   -config <path to config file>  \
   -profile <name of profile>
 ```
-
-Above, `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
-This command will pull the `scpca-nf` workflow directly from Github, and run it based on the settings in the configuration file that you have defined.
-
-**Note:** `scpca-nf` is under active development.
-Using the above command will run the workflow from the `main` branch of the workflow repository.
-To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
-
 
 For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary HTML report and any relevant intermediate files.
 For a complete description of the expected output files, see the section describing [output files](#output-files).
@@ -214,8 +218,7 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -config my_config.config \
-  -r v0.7.2
+  -config my_config.config
 ```
 
 For reference, we provide an example template configuration file, [`user_template.config`](examples/user_template.config), which includes some other workflow parameters that may be useful, as well as an example of configuring a profile for executing the workflow on a cluster, discussed below.
@@ -241,7 +244,6 @@ In our example template file [`user_template.config`](examples/user_template.con
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
   -config user_template.config \
-  -r v0.7.2 \
   -profile cluster
 ```
 
@@ -293,7 +295,6 @@ You can then direct Nextflow to use the parameters stored in `localref_params.ya
 nextflow run AlexsLemonade/scpca-nf \
   -params-file localref_params.yaml \
   -config user_template.config \
-  -r v0.7.2 \
   -profile cluster
 ```
 
@@ -495,6 +496,8 @@ This will tell the workflow to save the `alevin-fry` outputs to a folder labeled
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
+  -config <path to config file>  \
+  -profile <name of profile> \
   --publish_fry_outs
 ```
 
@@ -560,7 +563,7 @@ For genetic demultiplexing, we also require:
 
 If any sample in a pool is missing a matched bulk RNA-seq library, then genetic demultiplexing will be skipped and only cellhash-based demultiplexing will be performed.
 
-To skip genetic demultiplexing for all libraries and perform cellhash-based demultiplexing _only_, use the `--skip_genetic_demux` flag at the command line:
+To skip genetic demultiplexing for all libraries and perform cellhash-based demultiplexing _only_ use the `--skip_genetic_demux` flag at the command line:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -670,7 +670,7 @@ nextflow run AlexsLemonade/scpca-nf/merge.nf \
 
 There are some additional considerations to be aware of for libraries which contain additional modalities, such as ADT counts from CITE-seq or HTO counts from multiplexing.
 
-If any libraries in a merge group having ADT counts, these counts will also be merged and included in the final merged object.
+If any libraries in a merge group have ADT counts, these counts will also be merged and included in the final merged object.
 In the case of `SingleCellExperiment` objects, ADT counts will be provided as an alternative experiment called `"adt"` in same object.
 In the case of `AnnData`, a separate file will be exported with the extension `_adt.hdf5` that contains the merged ADT counts.
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -67,24 +67,12 @@ Here we provide an overview of the steps you will need to complete:
 The standard configuration the `scpca-nf` workflow expects that compute nodes will have direct access to the internet, and will download reference files and container images with any required software as required.
 If your HPC system does not allow internet access from compute nodes, you will need to download the required reference files and software before running, [following the instructions we have provided](#using-scpca-nf-on-nodes-without-direct-internet-access).
 
-Once you have set up your environment and created the metadata and configuration files, you will be able to start your run as follows, adding any additional optional parameters that you may choose:
+Once you have set up your environment and created the metadata and configuration files, you will be able to start your run as follows, adding any additional optional parameters that you may choose.
 
-```sh
-nextflow run AlexsLemonade/scpca-nf \
-  -config <path to config file>  \
-  -profile <name of profile>
-```
-
-Where `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
-This command will pull the `scpca-nf` workflow directly from Github, and run it based on the settings in the configuration file that you have defined.
-
-**Note:** `scpca-nf` is under active development.
-Using the above command will run the workflow from the `main` branch of the workflow repository.
-To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
-
-To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
+You will also need to specify a release tagged version of the workflow with the `-r` flag.
 The command below will pull the `scpca-nf` workflow directly from Github using the `v0.7.2` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
+
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
@@ -92,6 +80,14 @@ nextflow run AlexsLemonade/scpca-nf \
   -config <path to config file>  \
   -profile <name of profile>
 ```
+
+Above, `<path to config file>` is the **relative** path to the [configuration file](#configuration-files) that you have setup and `<name of profile>` is the name of the profile that you chose when [creating a profile](#setting-up-a-profile-in-the-configuration-file).
+This command will pull the `scpca-nf` workflow directly from Github, and run it based on the settings in the configuration file that you have defined.
+
+**Note:** `scpca-nf` is under active development.
+Using the above command will run the workflow from the `main` branch of the workflow repository.
+To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
+
 
 For each library that is successfully processed, the workflow will return quantified gene expression data as a `SingleCellExperiment` object stored in an RDS file along with a summary HTML report and any relevant intermediate files.
 For a complete description of the expected output files, see the section describing [output files](#output-files).
@@ -218,7 +214,8 @@ This file is then used with the `-config` (or `-c`) argument at the command line
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -config my_config.config
+  -config my_config.config \
+  -r v0.7.2
 ```
 
 For reference, we provide an example template configuration file, [`user_template.config`](examples/user_template.config), which includes some other workflow parameters that may be useful, as well as an example of configuring a profile for executing the workflow on a cluster, discussed below.
@@ -244,6 +241,7 @@ In our example template file [`user_template.config`](examples/user_template.con
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
   -config user_template.config \
+  -r v0.7.2 \
   -profile cluster
 ```
 
@@ -295,6 +293,7 @@ You can then direct Nextflow to use the parameters stored in `localref_params.ya
 nextflow run AlexsLemonade/scpca-nf \
   -params-file localref_params.yaml \
   -config user_template.config \
+  -r v0.7.2 \
   -profile cluster
 ```
 
@@ -496,8 +495,6 @@ This will tell the workflow to save the `alevin-fry` outputs to a folder labeled
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -config <path to config file>  \
-  -profile <name of profile> \
   --publish_fry_outs
 ```
 
@@ -563,7 +560,7 @@ For genetic demultiplexing, we also require:
 
 If any sample in a pool is missing a matched bulk RNA-seq library, then genetic demultiplexing will be skipped and only cellhash-based demultiplexing will be performed.
 
-To skip genetic demultiplexing for all libraries and perform cellhash-based demultiplexing _only_ use the `--skip_genetic_demux` flag at the command line:
+To skip genetic demultiplexing for all libraries and perform cellhash-based demultiplexing _only_, use the `--skip_genetic_demux` flag at the command line:
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -613,7 +613,7 @@ nextflow run AlexsLemonade/scpca-nf \
 
 In addition to the main `scpca-nf` workflow, this repository contains a separate workflow called `merge.nf` that will merge a set of processed ScPCA `SingleCellExperiment` objects into a single merged `SingleCellExperiment` object containing all counts from the specified libraries.
 Specifically, for a given SCPCA project id, this workflow creates a merged `SingleCellExperiment` object, a merged `AnnData` object, and an associated merged object HTML report.
-This workflow is specifically designed to run on processed `SingleCellExperiment` object files created by the `scpca-nf` workflow.
+This workflow is specifically designed to run on processed `SingleCellExperiment` object files output by the `scpca-nf` workflow.
 
 There are several important items to be aware of when running this workflow:
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -619,7 +619,7 @@ There are several important items to be aware of when running this workflow:
 
 * **This workflow does not integrate libraries or perform any batch-correction**.
 It only merges objects into a single object to facilitate downstream analyses such as, but not limited to, integration.
-* Running this workflow may require a significant amount of memory and up to 100 GB of storage.
+* Running this workflow may require a significant amount of memory and up to 250 GB of storage.
 * If ADT counts from a CITE-seq experiment are included in at least one library being merged, these results will be included in the final merged object.
 * Any HTO counts from multiplexed libraries will not be included in the final merged object.
 * At this time, the workflow only supports merging libraries from the specified ScPCA project id(s).

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -496,8 +496,6 @@ This will tell the workflow to save the `alevin-fry` outputs to a folder labeled
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -config <path to config file>  \
-  -profile <name of profile> \
   --publish_fry_outs
 ```
 
@@ -646,8 +644,16 @@ If you specified a different parameter value from the default `scpca-out` for th
 Results from running the `merge.nf` workflow will also be added to this `params.outdir` directory in a sub-directory called `merged`.
 The `merge.nf` workflow will create merged objects for all processed library objects present for the specified project id.
 
-The workflow can be run as shown below.
-You will need to specify a release tagged version of the workflow with the `-r` flag.
+The workflow can be run as shown:
+
+```sh
+nextflow run AlexsLemonade/scpca-nf/merge.nf \
+  -config <path to config file>  \
+  -profile <name of profile> \
+  --project <project id whose libraries should be merged>
+```
+
+To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
 The command below will pull the `scpca-nf` workflow directly from Github using the `v0.7.2` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -622,7 +622,7 @@ It only merges objects into a single object to facilitate downstream analyses su
 * Running this workflow may require a significant amount of memory and up to 100 GB of storage.
 * If ADT counts from a CITE-seq experiment are included in at least one library being merged, these results will be included in the final merged object.
 * Any HTO counts from multiplexed libraries will not be included in the final merged object.
-* At this time, the workflow only supports merging set of libraries associated with the specified ScPCA project id(s).
+* At this time, the workflow only supports merging libraries from the specified ScPCA project id(s).
 It is not currently possible to specify different groupings.
 * You will need to configure your run time environment using the same approach [as described for the main `scpca-nf` workflow](#configuring-scpca-nf-for-your-environment).
   * The only exception to this is that you will only need to use one metadata file, [the run metadata file](#prepare-the-run-metadata-file), and only the following columns are required: `scpca_project_id`, `scpca_library_id`, `scpca_sample_id`, `seq_unit`, and `technology`.
@@ -638,12 +638,12 @@ The `merge.nf` workflow requires two parameters to run:
 
 The `merge.nf` workflow runs by first finding all libraries present, for each project, in the specified `params.outdir`, which represents the output directory where `scpca-nf` will have stored results from a prior run.
 If you specified a different parameter value from the default `scpca-out` for the `outdir` parameter in your `scpca-nf` configuration file, you will need to ensure that same value is provided to `merge.nf`.
-Results from running the `merge.nf` workflow will also be added to this `params.outdir` in a sub-directory called `merged`.
+Results from running the `merge.nf` workflow will also be added to this `params.outdir` directory in a sub-directory called `merged`.
 The `merge.nf` workflow will create merged objects for all processed library objects present for the specified project id.
 
 In order to run this workflow, you will first need to clone the `scpca-nf` repository and navigate into it:
 
-```
+```sh
 git clone git@github.com:AlexsLemonade/scpca-nf.git
 cd scpca-nf
 ```

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -651,7 +651,7 @@ cd scpca-nf
 Then, you can run the workflow as follows:
 
 ```sh
-nextflow run merge.nf \
+nextflow run AlexsLemonade/scpca-nf/merge.nf \
   -config <path to config file>  \
   -profile <name of profile> \
   --project <project id whose libraries should be merged>


### PR DESCRIPTION
Closes #646 

This PR adds external instructions for the `merge.nf` workflow. Let me know about the level of detail and the order in which I provided information. Also, am I missing anything..?

Also, do we want to indicate in the repo's `README` that this workflow exists? Since other `README` updates are coming down the line (https://github.com/AlexsLemonade/scpca-nf/issues/619), I wondered if we should wait until those additional changes happen. Or, since we already link the external instructions in the `README`, it may not be necessary at all.  

Primarily requesting Ally for review here, but @jashapiro please feel free to chime in if you have any wording/organizational suggestions!