### PR TITLE
QC report aesthetic updates

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -86,12 +86,14 @@ lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35) {
 #' @param color_variable Column in data frame to color by, not a string.
 #' @param legend_title Title for legend.
 #' @param legend_nrow Number of rows in legend. Default is 2.
+#' @param point_size Point size
 #'
 #' @return UMAP plot as a ggplot2 object
 plot_umap <- function(
     umap_df,
     color_variable,
     legend_title,
+    point_size = umap_point_size,
     legend_nrow = 2) {
   ggplot(umap_df) +
     aes(
@@ -100,7 +102,7 @@ plot_umap <- function(
       color = {{ color_variable }}
     ) +
     geom_point(
-      size = 0.3,
+      size = point_size,
       alpha = 0.5
     ) +
     # remove axis numbers and background grid
@@ -129,12 +131,14 @@ plot_umap <- function(
 #' @param umap_df Data frame with UMAP1 and UMAP2 columns
 #' @param n_celltypes The number of cell types (facets) displayed in the plot
 #' @param annotation_column Column containing cell type annotations
+#' @param point_size Point size
 #'
 #' @return ggplot object containing a faceted UMAP where each cell type is a facet.
 #'   In each panel, the cell type of interest is colored and all other cells are grey.
 faceted_umap <- function(umap_df,
                          n_celltypes,
-                         annotation_column) {
+                         annotation_column,
+                         point_size = umap_facet_point_size) {
   # Determine legend y-coordinate based on n_celltypes
   if (n_celltypes %in% 7:8) {
     legend_y <- 0.33
@@ -154,10 +158,10 @@ faceted_umap <- function(umap_df,
       ),
       color = "gray80",
       alpha = 0.5,
-      size = 0.3
+      size = point_size
     ) +
     # set points for desired cell type
-    geom_point(size = 0.3, alpha = 0.5) +
+    geom_point(size = point_size, alpha = 0.5) +
     facet_wrap(
       vars({{ annotation_column }}),
       ncol = 3

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -43,6 +43,8 @@ is_supplemental <- TRUE
 <!-- Import shared functions for cell type wrangling -->
 ```{r, child='utils/celltype_functions.rmd'}
 ```
+```{r, child='utils/report_functions.rmd'}
+```
 
 
 <!-- Define helper functions for calculating Jaccard matrices -->
@@ -294,6 +296,11 @@ plot_height <- 1
 #  sample_id should be defined with length > 1
 sample_id <- metadata(processed_sce)$sample_id
 has_multiplex <- length(sample_id) > 1
+
+# determine UMAP point sizing
+umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
+umap_point_size <- umap_points_sizes[1]
+umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 <!-- If multiplexed, open with warning  --> 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -53,6 +53,12 @@ reformat_nulls <- function(df) {
 set.seed(params$seed)
 ```
 
+
+<!-- source functions --> 
+```{r, child='utils/report_functions.rmd'}
+```
+
+
 ```{r sce_setup}
 # save some typing later
 library_id <- params$library
@@ -135,19 +141,10 @@ if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
 has_multiplex <- length(sample_id) > 1
 sample_types <- metadata(unfiltered_sce)$sample_type
 
-# determine UMAP point size based on number of processed cells
-n_processed_cells <- ncol(processed_sce)
-umap_point_size <- dplyr::case_when(
-  n_processed_cells <= 500 ~ 0.8,
-  n_processed_cells <= 1500 ~ 0.6,
-  .default = 0.3
-)
-umap_facet_point_size <- dplyr::case_when(
-  n_processed_cells <= 500 ~ 0.5,
-  n_processed_cells <= 1500 ~ 0.25,
-  n_processed_cells <= 5000 ~ 0.1,
-  .default = 0.01
-)
+# determine UMAP point sizing
+umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
+umap_point_size <- umap_points_sizes[1]
+umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -134,6 +134,20 @@ if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
 # check if we have multiplex
 has_multiplex <- length(sample_id) > 1
 sample_types <- metadata(unfiltered_sce)$sample_type
+
+# determine UMAP point size based on number of processed cells
+n_processed_cells <- ncol(processed_sce)
+umap_point_size <- dplyr::case_when(
+  n_processed_cells <= 500 ~ 0.8,
+  n_processed_cells <= 1500 ~ 0.6,
+  .default = 0.3
+)
+umap_facet_point_size <- dplyr::case_when(
+  n_processed_cells <= 500 ~ 0.5,
+  n_processed_cells <= 1500 ~ 0.25,
+  n_processed_cells <= 5000 ~ 0.1,
+  .default = 0.01
+)
 ```
 
 
@@ -170,6 +184,7 @@ if ("patient-derived xenograft" %in% sample_types) {
 
 if ("cell line" %in% sample_types) {
   if (has_multiplex) {
+    # get a list of samples in the library that are cell lines
     cell_line_samples <- names(sample_types[sample_types == "cell line"])
     cell_line_samples_bullets <- paste0("<li>", paste(cell_line_samples, collapse = "</li><li>", "</li>"))
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -141,10 +141,9 @@ sample_types <- metadata(unfiltered_sce)$sample_type
 # only print out info box if xenograft or cell line, with different logic/warnings
 # for multiplex libraries
 if ("patient-derived xenograft" %in% sample_types) {
-
   # determine which samples are the PDXs
   if (has_multiplex) {
-    # get a list of samples in the library that are pdxs 
+    # get a list of samples in the library that are pdxs
     pdx_samples <- names(sample_types[sample_types == "patient-derived xenograft"])
     pdx_samples_bullets <- paste0("<li>", paste(pdx_samples, collapse = "</li><li>", "</li>"))
 
@@ -158,7 +157,6 @@ if ("patient-derived xenograft" %in% sample_types) {
 
       </div>
     ")
-
   } else {
     glue::glue("
       <div class=\"alert alert-info\">
@@ -517,6 +515,11 @@ if (skip_miQC) {
   } else {
     miQC_plot <- miQC::plotModel(filtered_sce, model = miQC_model)
   }
+
+  # set line thickness
+  line_aes <- list(linewidth = 1, alpha = 0.8)
+  miQC_plot$layers[[2]]$aes_params <- line_aes
+  miQC_plot$layers[[3]]$aes_params <- line_aes
 
   miQC_plot +
     coord_cartesian(ylim = c(0, 100)) +

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -6,7 +6,7 @@ The below plot shows the UMAP (Uniform Manifold Approximation and Projection) em
 # create UMAP colored by number of genes detected
 scater::plotUMAP(
   processed_sce,
-  point_size = 0.3,
+  point_size = umap_point_size,
   point_alpha = 0.5,
   colour_by = "detected"
 ) +
@@ -16,7 +16,7 @@ scater::plotUMAP(
   scale_y_continuous(labels = NULL, breaks = NULL) +
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
-  ) + 
+  ) +
   theme(aspect.ratio = 1)
 ```
 
@@ -80,7 +80,7 @@ if (!is.null(processed_meta$highly_variable_genes)) {
 
 
   ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) +
-    geom_point(alpha = 0.1, size = 0.001) +
+    geom_point(alpha = 0.1, size = umap_facet_point_size) +
     facet_wrap(vars(gene_symbol)) +
     scale_color_viridis_c() +
     labs(

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -1,0 +1,28 @@
+<!-- This document contains function definitions that are used by both
+`main_qc_report.rmd` and `celltypes_supplemental_report.rmd` but are not specific to cell typing -->
+
+
+```{r}
+#' Determine size for UMAP points which depends on the number of cells in the
+#'   processed object.
+#'
+#' @param n_processed_cells Number of cells in the processed object
+#'
+#' @return A vector with two integer values: A standalone UMAP point size, and a
+#'   point size for faceted UMAPs
+determine_umap_point_size <- function(n_processed_cells) {
+  umap_point_size <- dplyr::case_when(
+    n_processed_cells <= 500 ~ 0.8,
+    n_processed_cells <= 2250 ~ 0.6,
+    .default = 0.3
+  )
+  umap_facet_point_size <- dplyr::case_when(
+    n_processed_cells <= 500 ~ 0.5,
+    n_processed_cells <= 2250 ~ 0.25,
+    n_processed_cells <= 5000 ~ 0.1,
+    .default = 0.01
+  )
+
+  return(c(umap_point_size, umap_facet_point_size))
+}
+```


### PR DESCRIPTION
Closes #618
Closes #620 

This PR makes two viz changes to the QC report:

- For #620, I updated the miQC plot line thickness as described in the isssue
- For #618, I updated the UMAP point size. I explored a variety of different numbers of cells and tweaked numbers accordingly. In the attached zip here, I include a bunch of reports where the file name contains the number of cells. All these reports include the update miQC line sizing, too.
  - Once we agree on the point sizes, I will port the code defining the umap point sizes into the cell type supplemental report. I feel like we might want to put that in a function for Future Us, which might entail making a new `utils/report_functions.rmd` file? Thoughts?


Let me know what you think of sizing choices!

[qc_reports_cell_counts.zip](https://github.com/AlexsLemonade/scpca-nf/files/14184266/qc_reports_cell_counts.zip)
