### PR TITLE
Standardize celltype report filenames

### DIFF
--- a/external-instructions.md
+++ b/external-instructions.md
@@ -460,7 +460,7 @@ results
 
 If bulk libraries were processed, a `bulk_quant.tsv` and `bulk_metadata.tsv` summarizing the counts data and metadata across all libraries will also be present in the `results` directory.
 
-If you performed cell type annotation, an additional QC report specific to cell typing results called `library_id_celltype-report.html` will also be present in the `results` directory.
+If you performed cell type annotation, an additional QC report specific to cell typing results called `library_id_celltype_report.html` will also be present in the `results` directory.
 
 The `checkpoints` folder will contain intermediate files that are produced by individual steps of the workflow, including mapping with `salmon`.
 The contents of this folder are used to allow restarting the workflow from internal checkpoints (in particular so the initial read mapping does not need to be repeated, see [repeating mapping steps](#repeating-mapping-steps)), and may contain log files and other outputs useful for troubleshooting or alternative analysis.

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -28,7 +28,7 @@ process sce_qc_report{
     // check for cell types
     // only provide report template if cell typing was performed and either singler or cellassign was used
     has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
-    celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
+    celltype_report = "${meta.library_id}_celltype_report.html" // rendered HTML
     celltype_template_path = "${template_dir}/${celltype_template_file}" // template input
 
     """
@@ -71,7 +71,7 @@ process sce_qc_report{
     metadata_json = "${meta.library_id}_metadata.json"
 
     has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
-    celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
+    celltype_report = "${meta.library_id}_celltype_report.html" // rendered HTML
 
     """
     touch ${unfiltered_out}


### PR DESCRIPTION
This find/replace change makes the celltype file report names look consistent with other files: `_celltype-report.html` -> `_celltype_report.html`