### PR TITLE
Fix multiplex anndata export

### DIFF
--- a/merge.nf
+++ b/merge.nf
@@ -171,6 +171,7 @@ workflow {
         sce_file_list
       )}
 
+    // merge SCEs
     merge_sce(grouped_libraries_ch)
 
     // generate merge report
@@ -178,7 +179,6 @@ workflow {
 
     // export merged objects to AnnData
     anndata_ch = merge_sce.out
-      .filter{!it[3]} // remove multiplexed samples before export
       .map{it.take(3)} // keep everything but multiplexed logical
 
 


### PR DESCRIPTION
Closes #698

This PR deletes the `filter` line as described in #698.
I confirmed it works as expected with the test data - you can see the output in `test-data/scpca_out` on `S3`.