### PR TITLE
Restore heatmap legend

### DIFF
--- a/templates/merge-report.rmd
+++ b/templates/merge-report.rmd
@@ -76,7 +76,6 @@ additional_sce_modalities <- merged_sce$additional_modalities |>
 
 has_adt <- "adt" %in% additional_sce_modalities
 multiplexed <- "cellhash" %in% additional_sce_modalities
-not_multiplexed <- !multiplexed
 ```
 
 ```{r, integration-warning, eval=FALSE}
@@ -214,7 +213,7 @@ glue::glue("
 ```
 
 
-```{r, eval=not_multiplexed}
+```{r, eval=!multiplexed}
 # get total number of samples and libraries
 num_samples <- merged_sce$sample_id |>
   unique() |>
@@ -222,7 +221,7 @@ num_samples <- merged_sce$sample_id |>
 ```
 
 
-```{r, eval=not_multiplexed, results='asis'}
+```{r, eval=!multiplexed, results='asis'}
 glue::glue(
   "
   The merged object summarized in this report contains {num_samples} samples.
@@ -231,7 +230,7 @@ glue::glue(
 ```
 
 
-```{r, eval=not_multiplexed}
+```{r, eval=!multiplexed}
 knitr::asis_output("
 ## Diagnoses
 
@@ -242,7 +241,7 @@ If a subdiagnosis is available, the total number of samples will be shown for ea
 ```
 
 
-```{r, eval=not_multiplexed}
+```{r, eval=!multiplexed}
 # table of diagnosis
 diagnosis_table <- coldata_df |>
   dplyr::select(sample_id, diagnosis, subdiagnosis) |>
@@ -273,7 +272,7 @@ make_kable(diagnosis_table)
 ```
 
 
-```{r, eval=not_multiplexed}
+```{r, eval=!multiplexed}
 knitr::asis_output(
   "
 ## Disease stage
@@ -285,7 +284,7 @@ The following table shows both the diagnosis and at what point during disease pr
 ```
 
 
-```{r, eval=not_multiplexed}
+```{r, eval=!multiplexed}
 # count number of samples per diagnosis/ disease timing combination
 disease_timing_table <- coldata_df |>
   dplyr::select(sample_id, diagnosis, disease_timing) |>

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -552,7 +552,7 @@ create_single_heatmap(
   row_title = "CellAssign annotations",
   column_title = "SingleR annotations",
   labels_font_size = find_label_size(all_celltypes),
-  keep_legend_name = "SingleR annotations",
+  keep_legend_name = "CellAssign annotations",
   col_fun = heatmap_col_fun,
   # additional arguments
   column_names_rot = 90

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -116,7 +116,6 @@ ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(heatmap_padding, "in"))
 #' @param labels_font_size Font size to use for rows and column labels.
 #' @param keep_legend_name The name to use in the legend
 #' @param col_fun Color function for the heatmap palette. Default is `heatmap_col_fun`.
-#' @param override_keep_legend Boolean to always keep the legend regardless of other logic
 #' @param ... Additional arguments to pass to `ComplexHeatmap::Heatmap()`
 #'
 #' @return A ComplexHeatmap object
@@ -127,7 +126,6 @@ create_single_heatmap <- function(
     labels_font_size,
     keep_legend_name,
     col_fun = heatmap_col_fun,
-    override_keep_legend = FALSE,
     ...) {
   heat <- ComplexHeatmap::Heatmap(
     t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
@@ -154,9 +152,8 @@ create_single_heatmap <- function(
       direction = "horizontal",
       legend_width = unit(1.5, "in")
     ),
-    # only keep legends if override_keep_legend is TRUE, or
-    # if the row title matches `keep_legend_name`
-    show_heatmap_legend = override_keep_legend || row_title == keep_legend_name,
+    # only keep legends that match `keep_legend_name`
+    show_heatmap_legend = row_title == keep_legend_name,
   )
 
   return(heat)
@@ -558,8 +555,7 @@ create_single_heatmap(
   keep_legend_name = "SingleR annotations",
   col_fun = heatmap_col_fun,
   # additional arguments
-  column_names_rot = 90,
-  override_keep_legend = TRUE
+  column_names_rot = 90
 ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -154,7 +154,8 @@ create_single_heatmap <- function(
       direction = "horizontal",
       legend_width = unit(1.5, "in")
     ),
-    # only keep legends that match `keep_legend_name`
+    # only keep legends if override_keep_legend is TRUE, or
+    # if the row title matches `keep_legend_name`
     show_heatmap_legend = override_keep_legend || row_title == keep_legend_name,
   )
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -116,6 +116,7 @@ ComplexHeatmap::ht_opt(TITLE_PADDING = grid::unit(heatmap_padding, "in"))
 #' @param labels_font_size Font size to use for rows and column labels.
 #' @param keep_legend_name The name to use in the legend
 #' @param col_fun Color function for the heatmap palette. Default is `heatmap_col_fun`.
+#' @param override_keep_legend Boolean to always keep the legend regardless of other logic
 #' @param ... Additional arguments to pass to `ComplexHeatmap::Heatmap()`
 #'
 #' @return A ComplexHeatmap object
@@ -126,6 +127,7 @@ create_single_heatmap <- function(
     labels_font_size,
     keep_legend_name,
     col_fun = heatmap_col_fun,
+    override_keep_legend = FALSE,
     ...) {
   heat <- ComplexHeatmap::Heatmap(
     t(mat), # transpose because matrix rows are in common & we want a vertical arrangement
@@ -153,7 +155,7 @@ create_single_heatmap <- function(
       legend_width = unit(1.5, "in")
     ),
     # only keep legends that match `keep_legend_name`
-    show_heatmap_legend = row_title == keep_legend_name,
+    show_heatmap_legend = override_keep_legend || row_title == keep_legend_name,
   )
 
   return(heat)
@@ -555,7 +557,8 @@ create_single_heatmap(
   keep_legend_name = "SingleR annotations",
   col_fun = heatmap_col_fun,
   # additional arguments
-  column_names_rot = 90
+  column_names_rot = 90,
+  override_keep_legend = TRUE
 ) |>
   ComplexHeatmap::draw(
     heatmap_legend_side = "bottom"


### PR DESCRIPTION
edit- closes #701 

While looking over the reports shared here https://github.com/AlexsLemonade/ScPCA-admin/issues/716#issuecomment-1953118312, I noticed that the CellAssign/SingleR heatmaps were missing a legend. This PR restores that legend by adding a quick argument to the heatmap function that says to always retain the legend.

Rendered report -  
[celltypes_supplemental_report.html.zip](https://github.com/AlexsLemonade/scpca-nf/files/14360330/celltypes_supplemental_report.html.zip)


Also, I reverted a change I made in https://github.com/AlexsLemonade/scpca-nf/pull/697; We definitely didn't need that `not_multiplexed` variable I made. I don't really recall/understand what I was experiencing that I thought we needed it, but we really don't need it. `eval = !multiplexed` works just fine.