### PR TITLE
Add CI to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,19 @@ To allow for efficient review, please include in any pull request a concise and 
 
 When the changes in `development` merit a new release, a pull request will be filed to merge the current version of the `development` branch into `main`, followed by tagging a release on the `main` branch.
 
+### Continuous integration in pull requests
+
+There are several automatic checks performed by GitHub Actions in all pull requests filed to `main` or `development`.
+
+These checks are required to pass before pull requests can be merged:
+
+- [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files.
+- [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors.
+- [Check Nextflow config](.github/workflows/nextflow-config-check.yaml): This workflow ensures that there are no syntax errors in the Nextflow configuration files
+
+There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook.
+Although highly recommended, it is not required that this workflow passes before pull requests can be merged.
+
 ## Stub workflows
 
 All Nextflow processes should include a [`stub` block](https://www.nextflow.io/docs/latest/process.html#stub) with a minimal script that can be run quickly to produce files in the expected output locations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ There are several automatic checks performed by GitHub Actions in all pull reque
 
 These checks are required to pass before pull requests can be merged:
 
-- [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files.
-- [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors.
 - [Check Nextflow config](.github/workflows/nextflow-config-check.yaml): This workflow ensures that there are no syntax errors in the Nextflow configuration files
+- [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors.
+- [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files.
 
 There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook.
 Although highly recommended, it is not required that this workflow passes before pull requests can be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ There are several automatic checks performed by GitHub Actions in all pull reque
 - [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors. This check is required to pass before pull requests can be merged.
 - [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files. This check is not required to pass before pull requests can be merged.
 
-There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook, on pull requests filed to the `development` branch.
+There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook.
 Although highly recommended, it is not required that this workflow passes before pull requests can be merged.
 
 ## Stub workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,13 @@ When the changes in `development` merit a new release, a pull request will be fi
 
 ### Continuous integration in pull requests
 
-There are several automatic checks performed by GitHub Actions in all pull requests filed to `main` or `development`.
+There are several automatic checks performed by GitHub Actions in all pull requests filed to `main` or `development`:
 
-These checks are required to pass before pull requests can be merged:
+- [Check Nextflow config](.github/workflows/nextflow-config-check.yaml): This workflow ensures that there are no syntax errors in the Nextflow configuration files. This check is required to pass before pull requests can be merged.
+- [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors. This check is required to pass before pull requests can be merged.
+- [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files. This check is not required to pass before pull requests can be merged.
 
-- [Check Nextflow config](.github/workflows/nextflow-config-check.yaml): This workflow ensures that there are no syntax errors in the Nextflow configuration files
-- [Check Nextflow stub](.github/workflows/nextflow-stub-check.yaml): This workflow ensures that the [stub workflow](#stub-workflows) runs without errors.
-- [Spell check R Markdown and Markdown files](.github/workflows/spell-check.yml): This workflow ensures there are no spelling errors in R Markdown and Markdown files.
-
-There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook.
+There is also one additional `pre-commit ci` workflow which runs all [pre-commit hooks as described in this section](#pre-commit-hooks), except for the spell check pre-commit hook, on pull requests filed to the `development` branch.
 Although highly recommended, it is not required that this workflow passes before pull requests can be merged.
 
 ## Stub workflows


### PR DESCRIPTION
Closes #695 

Here I've added a small section about CI into contributing. I nested this inside the PRs header and mentioned both required workflows and the pre-commit ci workflow (do I still have it correct that passing is not mandatory? I don't have access to Settings here so couldn't tell for sure).

Let me know if this is the right place in `CONTRIBUTING.md` to have added this, as well as any details to be expanded upon or reduced.