### PR TITLE
Specify merging only specific runs from a project

### DIFF
--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -10,9 +10,9 @@ params{
   checkpoints_dir = "${params.outdir}/checkpoints"
   results_dir = "${params.outdir}/results"
 
-  // a set of run_ids for testing
+  // a set of run_ids for testing. used only by the main workflow
   run_ids = "SCPCR000001,SCPCS000101"
-  // include all runs in a merged project
+  // include all runs in a merged project. used only by the merged workflow
   merge_run_ids = "All"
 
   // cell type references

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -12,6 +12,8 @@ params{
 
   // a set of run_ids for testing
   run_ids = "SCPCR000001,SCPCS000101"
+  // include all runs in a merged project
+  merge_run_ids = "All"
 
   // cell type references
   project_celltype_metafile = "s3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv"

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -215,9 +215,9 @@ Note that the workflow will also merge any present alternative experiments (e.g.
 The merge workflow requires two parameters:
 
 - `project`, the SCPCA project id whose objects should be merged
+- `merge_run_ids`, the set of run ids, library ids, or sample ids to include in the merged object, by default all runs for each project will be included
 - `run_metafile`, the metadata file (`scpca-library-metadata.tsv`) which contains information about libraries to merge
   - This is specified in the `ccdl` profile configuration file
-
 
 Data Lab members with access to AWS can run the workflow with the following command(s):
 
@@ -227,4 +227,7 @@ nextflow run merge.nf -profile ccdl,batch --project SCPCP000000
 
 # Run more than one project
 nextflow run merge.nf -profile ccdl,batch --project SCPCP00000X,SCPCP00000Y
+
+# Specify a set of run ids to use
+nextflow run merge.nf -profile ccdl,batch --project SCPCP000000 --run_ids SCPCR00000X,SCPCR00000Y
 ```

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -214,7 +214,8 @@ Note that the workflow will also merge any present alternative experiments (e.g.
 
 The merge workflow requires two parameters:
 
-- `project`, the SCPCA project id whose objects should be merged
+- `project`, the SCPCA project id whose objects should be merged.
+If running multiple projects, provide a comma separated list of project IDs.
 - `merge_run_ids`, the set of run ids, library ids, or sample ids to include in the merged object.
 By default all runs ids for the given project will be included
 - `run_metafile`, the metadata file (`scpca-library-metadata.tsv`) which contains information about libraries to merge

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -215,7 +215,8 @@ Note that the workflow will also merge any present alternative experiments (e.g.
 The merge workflow requires two parameters:
 
 - `project`, the SCPCA project id whose objects should be merged
-- `merge_run_ids`, the set of run ids, library ids, or sample ids to include in the merged object, by default all runs for each project will be included
+- `merge_run_ids`, the set of run ids, library ids, or sample ids to include in the merged object.
+By default all runs ids for the given project will be included
 - `run_metafile`, the metadata file (`scpca-library-metadata.tsv`) which contains information about libraries to merge
   - This is specified in the `ccdl` profile configuration file
 

--- a/merge.nf
+++ b/merge.nf
@@ -123,11 +123,23 @@ workflow {
     // grab project ids to run
     project_ids = params.project?.tokenize(',') ?: []
 
+    // grab run ids to include
+    run_ids = params.merge_run_ids?.tokenize(',') ?: []
+    // if no run ids, run all
+    run_all = run_ids[0] == "All"
+
     // read in run metafile and filter to projects of interest
     libraries_ch = Channel.fromPath(params.run_metafile)
       .splitCsv(header: true, sep: '\t')
       // filter to only include specified project ids
       .filter{it.scpca_project_id in project_ids}
+      // filter to run all ids or just specified ones
+      .filter{
+        run_all
+        || (it.scpca_run_id in run_ids)
+        || (it.scpca_library_id in run_ids)
+        || (it.scpca_sample_id in run_ids)
+      }
       .map{[
         seq_unit: it.seq_unit,
         technology: it.technology,

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,8 @@ params {
   run_ids = "All"
   // to run all samples in a project use that project's submitter name
   project = ""
+  // if running the merge workflow, include all runs in a project by default
+  merge_run_ids = "All"
 
   // Processing options
   af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial


### PR DESCRIPTION
Closes #705 

This PR adds the capability to specify runs, libraries, and/or samples to include when creating a merged object for a ScPCA project. First, we filter to any libraries that are in a specific project and then I filter to either include all runs or specify based on a parameter. 

I did choose to add a `merge_run_ids` parameter here rather than use the `run_ids` parameter set for the main workflow. The reason is because I noticed we have a default list of test runs in the ccdl profile, rather than using the `All` setting. So if you don't use the flag for `run_ids` then it will only include the test runs we specify in the profile. We would need to remember to always include `--run_ids All` when running the merge workflow, and I don't think we want to have to do that every single time. I can see scenarios of us forgetting this. So now we have a separate `merge_run_ids` param that by default is set to `All` both in the ccdl profile and the main nextflow config.

Within this PR I also added how to run with specific run ids to the internal instructions, but is this something we also want to include in external instructions? It seems like a very specific need and is not a required parameter, but I can add it if we think it's necessary. 