### PR TITLE
Bump memory for CCDL only

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,6 +1,6 @@
 // Resource maximum settings
 params.max_cpus = 24
-params.max_memory = 488.GB
+params.max_memory = 128.GB
 
 process{
   memory = {check_memory(4.GB * task.attempt, params.max_memory)}
@@ -24,7 +24,7 @@ process{
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
-  withLabel: mem_488 {
+  withLabel: mem_512 {
     memory = {check_memory(256.GB + 256.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -18,5 +18,5 @@ params{
 
   // set max cpus and memory for internal use
   max_cpus = 64
-  max_memory = 256.GB
+  max_memory = 1024.GB
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_488'
+  label 'mem_512'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:


### PR DESCRIPTION
I think the issue with https://github.com/AlexsLemonade/scpca-nf/issues/709#issuecomment-1977033313 was that we set the max memory in two places: in the base profile for a default, but also in the ccdl profile. So I dropped the base back down and upped the ccdl profile to 1TB, which will hopefully do the trick.

I also changed the label to  `mem_512`, because that better reflects the content.