### PR TITLE
Skip merging projects with multiplexed libraries

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -223,8 +223,8 @@ possible_columns <- c(
   "altexps_cellhash_sum",
   "altexps_cellhash_detected",
   "altexps_cellhash_percent",
-  "hashedDrops_sampleID",
-  "HTODemux_sampleID",
+  "hashedDrops_sampleid",
+  "HTODemux_sampleid",
   "vireo_sampleid"
 )
 

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -35,6 +35,13 @@ option_list <- list(
     help = "Keep any altExp present in the merged object."
   ),
   make_option(
+    opt_str = c("--multiplexed"),
+    action = "store_true",
+    default = FALSE,
+    help = "Indicates if the provided SCE's contain multiplexed data.
+      If so, the sample metadata will not be added to the colData."
+  ),
+  make_option(
     opt_str = c("-t", "--threads"),
     type = "integer",
     default = 1,
@@ -269,14 +276,16 @@ merged_sce <- scpcaTools::merge_sce_list(
   preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
 )
 
-# add sample metadata to colData
-merged_sce <- scpcaTools::metadata_to_coldata(
-  merged_sce,
-  join_columns = "library_id"
-)
+# add sample metadata to colData as long as there are no multiplexed data
+if (!opt$multiplexed) {
+  merged_sce <- scpcaTools::metadata_to_coldata(
+    merged_sce,
+    join_columns = "library_id"
+  )
 
-# remove sample metadata
-metadata(merged_sce) <- metadata(merged_sce)[names(metadata(merged_sce)) != "sample_metadata"]
+  # remove sample metadata
+  metadata(merged_sce) <- metadata(merged_sce)[names(metadata(merged_sce)) != "sample_metadata"]
+}
 
 # grab technology and EFO from metadata$library_metadata
 library_df <- names(sce_list) |>

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -35,13 +35,6 @@ option_list <- list(
     help = "Keep any altExp present in the merged object."
   ),
   make_option(
-    opt_str = c("--multiplexed"),
-    action = "store_true",
-    default = FALSE,
-    help = "Indicates if the provided SCE's contain multiplexed data.
-      If so, the sample metadata will not be added to the colData."
-  ),
-  make_option(
     opt_str = c("-t", "--threads"),
     type = "integer",
     default = 1,
@@ -275,17 +268,6 @@ merged_sce <- scpcaTools::merge_sce_list(
   retain_altexp_coldata_cols = retain_altexp_coldata_list,
   preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
 )
-
-# add sample metadata to colData as long as there are no multiplexed data
-if (!opt$multiplexed) {
-  merged_sce <- scpcaTools::metadata_to_coldata(
-    merged_sce,
-    join_columns = "library_id"
-  )
-
-  # remove sample metadata
-  metadata(merged_sce) <- metadata(merged_sce)[names(metadata(merged_sce)) != "sample_metadata"]
-}
 
 # grab technology and EFO from metadata$library_metadata
 library_df <- names(sce_list) |>

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -211,14 +211,7 @@ possible_columns <- c(
   "adt_scpca_filter",
   "altexps_adt_sum",
   "altexps_adt_detected",
-  "altexps_adt_percent",
-  # cellhash statistics & demux results
-  "altexps_cellhash_sum",
-  "altexps_cellhash_detected",
-  "altexps_cellhash_percent",
-  "hashedDrops_sampleid",
-  "HTODemux_sampleid",
-  "vireo_sampleid"
+  "altexps_adt_percent"
 )
 
 # Define colData columns to retain based on intersection with present columns

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -211,7 +211,14 @@ possible_columns <- c(
   "adt_scpca_filter",
   "altexps_adt_sum",
   "altexps_adt_detected",
-  "altexps_adt_percent"
+  "altexps_adt_percent",
+  # cellhash statistics & demux results
+  "altexps_cellhash_sum",
+  "altexps_cellhash_detected",
+  "altexps_cellhash_percent",
+  "hashedDrops_sampleid",
+  "HTODemux_sampleid",
+  "vireo_sampleid"
 )
 
 # Define colData columns to retain based on intersection with present columns

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -262,6 +262,15 @@ merged_sce <- scpcaTools::merge_sce_list(
   preserve_altexp_rowdata_cols = preserve_altexp_rowdata_list
 )
 
+# add sample metadata to colData
+merged_sce <- scpcaTools::metadata_to_coldata(
+  merged_sce,
+  join_columns = "library_id"
+)
+
+# remove sample metadata
+metadata(merged_sce) <- metadata(merged_sce)[names(metadata(merged_sce)) != "sample_metadata"]
+
 # grab technology and EFO from metadata$library_metadata
 library_df <- names(sce_list) |>
   purrr::map(\(library_id){

--- a/merge.nf
+++ b/merge.nf
@@ -190,10 +190,5 @@ workflow {
     generate_merge_report(merge_sce.out, file(merge_template))
 
     // export merged objects to AnnData
-    anndata_ch = merge_sce.out
-      .filter{!it[3]} // remove multiplexed samples before export
-      .map{it.take(3)} // keep everything but multiplexed logical
-
-
-    export_anndata(anndata_ch)
+    export_anndata(merge_sce.out)
 }

--- a/merge.nf
+++ b/merge.nf
@@ -162,6 +162,8 @@ workflow {
     grouped_libraries_ch = libraries_ch
       // only include single-cell/single-nuclei which ensures we don't try to merge libraries from spatial or bulk data
       .filter{it.seq_unit in ['cell', 'nucleus']}
+      // remove any multiplexed projects
+      .filter{!(it.project_id in multiplex_projects.getVal())}
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[
         it.project_id,

--- a/merge.nf
+++ b/merge.nf
@@ -167,14 +167,14 @@ workflow {
         multiplexed: it.project_id in multiplex_projects.getVal()
         single_sample: true
       }
-    
+
     filtered_libraries_ch.multiplexed
       .unique{ it.project_id }
       .subscribe{
         log.warn("Not merging ${it.project_id} because it contains multiplexed libraries.")
       }
-      
-    grouped_libraries_ch = filtered_libraries.single_sample 
+
+    grouped_libraries_ch = filtered_libraries_ch.single_sample
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[
         it.project_id,


### PR DESCRIPTION
Closes #716 
Closes #717 

Here I added a line to filter out any projects that have multiplexed libraries from the channel that is used as input to create merged objects. 

Because we have decided against including multiplexed libraries being included in merged objects, I removed any support we had for merging multiplexed libraries in the `merge_sces.R` script. I was a little torn on if we should keep this, but if the plan is to eventually create merged objects for all non-multiplexed libraries in a project, then we don't need this anymore. I can add it back if we want the flexibility to use it in the future, but I think a better change to that script would be to spit out an error if any libraries being merged contained multiplexed data when we address #718. 

As part of that, I also removed the columns to keep referring to cell hash stats and demuxing results, resolving the issue in #717. 