### PR TITLE
Add max_mem label for Cell Assign

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,6 +1,6 @@
 // Resource maximum settings
 params.max_cpus = 24
-params.max_memory = 128.GB
+params.max_memory = 488.GB
 
 process{
   memory = {check_memory(4.GB * task.attempt, params.max_memory)}
@@ -24,8 +24,8 @@ process{
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
-  withLabel: mem_256 {
-    memory = {check_memory(128.GB + 128.GB * task.attempt, params.max_memory)}
+  withLabel: mem_488 {
+    memory = {check_memory(256.GB + 256.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,6 +1,6 @@
 // Resource maximum settings
 params.max_cpus = 24
-params.max_memory = 128.GB
+params.max_memory = 96.GB
 
 process{
   memory = {check_memory(4.GB * task.attempt, params.max_memory)}
@@ -24,8 +24,8 @@ process{
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
-  withLabel: mem_512 {
-    memory = {check_memory(256.GB + 256.GB * task.attempt, params.max_memory)}
+  withLabel: max_mem {
+    memory = {task.attempt > 1 ? check_memory(96.GB, params.max_memory) : params.max_memory}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -1,6 +1,6 @@
 // Resource maximum settings
 params.max_cpus = 24
-params.max_memory = 96.GB
+params.max_memory = 128.GB
 
 process{
   memory = {check_memory(4.GB * task.attempt, params.max_memory)}
@@ -23,6 +23,9 @@ process{
   }
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
+  }
+  withLabel: mem_128 {
+    memory = {check_memory(64.GB + 64.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -24,7 +24,7 @@ process{
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
-  withLabel: max_mem {
+  withLabel: mem_max {
     memory = {task.attempt > 1 ? params.max_memory : check_memory(96.GB, params.max_memory)}
   }
   withLabel: cpus_2  {

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -25,7 +25,7 @@ process{
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
   withLabel: max_mem {
-    memory = {task.attempt > 1 ? check_memory(96.GB, params.max_memory) : params.max_memory}
+    memory = {task.attempt > 1 ? params.max_memory : check_memory(96.GB, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -24,8 +24,8 @@ process{
   withLabel: mem_96 {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
-  withLabel: mem_128 {
-    memory = {check_memory(64.GB + 64.GB * task.attempt, params.max_memory)}
+  withLabel: mem_256 {
+    memory = {check_memory(128.GB + 128.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -18,5 +18,5 @@ params{
 
   // set max cpus and memory for internal use
   max_cpus = 64
-  max_memory = 1024.GB
+  max_memory = 256.GB
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_512'
+  label 'max_mem'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_256'
+  label 'mem_488'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_128'
+  label 'mem_256'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'mem_96'
+  label 'mem_128'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -49,7 +49,7 @@ process classify_cellassign {
       mode: 'copy',
       pattern: "${cellassign_dir}"
     )
-  label 'max_mem'
+  label 'mem_max'
   label 'cpus_12'
   tag "${meta.library_id}"
   input:


### PR DESCRIPTION
Closes #709 

Here I added a new label, `max_mem` that uses the 96 gb on the first try and then increases to use the max memory on the second and third try. I'm testing this now, but also waiting for the other test run to actually complete to make sure this solves the problem. I just wanted to get this filed in case we are good to make these changes tomorrow. 