### PR TITLE
Handle empty sample type columns and add sentence about references not having tumor cells

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -184,6 +184,14 @@ unfiltered_sce <- unfiltered_sce |>
   # `add_sample_metadata` will filter sample_metadata_df to the relevant sample ids
   add_sample_metadata(metadata_df = sample_metadata_df)
 
+# if columns with sample type info aren't provided, set to NA
+if (!("is_xenograft" %in% colnames(sample_metadata_df))) {
+  sample_metadata_df$is_xenograft <- NA
+}
+if (!("is_cell_line" %in% colnames(sample_metadata_df))) {
+  sample_metadata_df$is_cell_line <- NA
+}
+
 # add explicit metadata field for the sample type
 sample_type <- sample_metadata_df |>
   dplyr::filter(sample_id %in% sample_ids) |>
@@ -191,6 +199,8 @@ sample_type <- sample_metadata_df |>
     sample_type = dplyr::case_when(
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
+      # if neither column was provided, note that
+      is.na(is_xenograft) & is.na(is_cell_line) ~ "Not provided",
       .default = "patient tissue"
     )
   ) |>

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -200,7 +200,7 @@ sample_type <- sample_metadata_df |>
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
       # if neither column was provided, note that
-      is.na(is_xenograft) & is.na(is_cell_line) ~ "Not provided",
+      is.na(is_xenograft) && is.na(is_cell_line) ~ "Not provided",
       .default = "patient tissue"
     )
   ) |>

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -50,4 +50,5 @@ UMI
 uri
 Visium
 VS
+xenograft
 ZenHub

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,12 +42,14 @@ Be sure to enter the **full** path to the directory containing the fastq files i
 You will also need to create a tab-separated values **sample** metadata file.
 At a minimum, the sample metadata file must contain a column with `scpca_sample_id` as the header.
 The contents of this column should contain all unique sample ids that are present in the `scpca_sample_id` column of the run metadata file.
+Additionally, you may include columns indicating the sample type, such as `is_cell_line` and `is_xenograft`.
+If the sample is from a cell line, `is_cell_line` should be `TRUE`, and if the sample is from a patient-derived xenograft, `is_xenograft` should be `TRUE`.
 
 Below is an example of a sample metadata file:
 
-| scpca_sample_id | diagnosis    | age |
-| --------------- | ------------ | --- |
-| sample01        | glioblastoma | 71  |
+| scpca_sample_id |is_cell_line | is_xenograft | diagnosis    | age |
+| --------------- |-------------| -------------|------------ | --- |
+| sample01        | FALSE       | FALSE        | glioblastoma | 71  |
 
 **Note that the `diagnosis` and `age` columns are shown as example sample metadata one might include in the sample metadata file.
 The metadata file that you create does not need to match this exactly, but it must contain the required `scpca_sample_id` column.**

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ Additionally, you may include columns `is_cell_line` and `is_xenograft` to indic
 
 - `is_cell_line`: Use `TRUE` if the sample is from a cell line and `FALSE` otherwise.
 Cell type annotation will not be performed for samples that are `TRUE`.
-- `is_xenograft`: Use `TRUE` is the sample is from a patient-derived xenograft and `FALSE` otherwise.
+- `is_xenograft`: Use `TRUE` if the sample is from a patient-derived xenograft and `FALSE` otherwise.
 
 This information will be reflected in the summary QC report.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,8 +42,13 @@ Be sure to enter the **full** path to the directory containing the fastq files i
 You will also need to create a tab-separated values **sample** metadata file.
 At a minimum, the sample metadata file must contain a column with `scpca_sample_id` as the header.
 The contents of this column should contain all unique sample ids that are present in the `scpca_sample_id` column of the run metadata file.
-Additionally, you may include columns indicating the sample type, such as `is_cell_line` and `is_xenograft`.
-If the sample is from a cell line, `is_cell_line` should be `TRUE`, and if the sample is from a patient-derived xenograft, `is_xenograft` should be `TRUE`.
+Additionally, you may include columns `is_cell_line` and `is_xenograft` to indicate the sample type:
+
+- `is_cell_line`: Use `TRUE` if the sample is from a cell line and `FALSE` otherwise.
+Cell type annotation will not be performed for samples that are `TRUE`.
+- `is_xenograft`: Use `TRUE` is the sample is from a patient-derived xenograft and `FALSE` otherwise.
+
+This information will be reflected in the summary QC report.
 
 Below is an example of a sample metadata file:
 

--- a/examples/example_sample_metadata.tsv
+++ b/examples/example_sample_metadata.tsv
@@ -1,7 +1,7 @@
-scpca_sample_id	optional_column_1	optional_column_2
-sample01	diagnosis1	age1
-sample02	diagnosis2	age2
-sample03	diagnosis3	age3
-sample04	diagnosis4	age4
-sample05	diagnosis5	age5
-sample06	diagnosis6	age6
+scpca_sample_id	is_cell_line	is_xenograft	optional_column_1	optional_column_2
+sample01	FALSE	FALSE	diagnosis1	age1
+sample02	FALSE	FALSE	diagnosis2	age2
+sample03	TRUE	FALSE	diagnosis3	age3
+sample04	FALSE	TRUE	diagnosis4	age4
+sample05	FALSE	FALSE	diagnosis5	age5
+sample06	FALSE	FALSE	diagnosis6	age6

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -169,6 +169,9 @@ The contents of this column should contain all unique sample IDs that are presen
 We encourage you to use standard terminology, such as ontology terms, to describe samples when possible.
 There is no limit to the number of columns allowed for the sample metadata, and you may include as many metadata fields as you please.
 Some suggested columns include diagnosis, tissue, age, sex, stage of disease, cell line.
+Additionally, you may include columns indicating the sample type, such as `is_cell_line` and `is_xenograft`.
+If the sample is from a cell line, `is_cell_line` should be `TRUE`, and if the sample is from a patient-derived xenograft, `is_xenograft` should be `TRUE`.
+
 
 We have provided an example run metadata file for reference.
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -169,9 +169,11 @@ The contents of this column should contain all unique sample IDs that are presen
 We encourage you to use standard terminology, such as ontology terms, to describe samples when possible.
 There is no limit to the number of columns allowed for the sample metadata, and you may include as many metadata fields as you please.
 Some suggested columns include diagnosis, tissue, age, sex, stage of disease, cell line.
-Additionally, you may include columns indicating the sample type, such as `is_cell_line` and `is_xenograft`.
-If the sample is from a cell line, `is_cell_line` should be `TRUE`, and if the sample is from a patient-derived xenograft, `is_xenograft` should be `TRUE`.
+Additionally, you may include columns `is_cell_line` and `is_xenograft` to indicate the sample type:
 
+- `is_cell_line`: Use `TRUE` if the sample is from a cell line and `FALSE` otherwise.
+Cell type annotation will not be performed for samples that are `TRUE`.
+- `is_xenograft`: Use `TRUE` if the sample is from a patient-derived xenograft and `FALSE` otherwise.
 
 We have provided an example run metadata file for reference.
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -329,6 +329,7 @@ When multiple methods annotate a given cell as the same or similar cell type, th
 
 Note that the contents of this report will vary based on which cell type annotations are present.
 Further, be aware that different cell type annotation methods may assign different labels to the same or similar cell type (e.g., the different string representations `B cell naive` and `Naive B cell`), due to use of different underlying reference datasets.
+Please note that all cell type annotation reference datasets are derived from normal (not tumor) tissue.
 
 <!--Note that the specific contents of this report will depend on which cell type annotations are present.-->
 **This library contains the following cell type annotations:**


### PR DESCRIPTION
Closes #713 
Closes #707 

Here I'm making a few fixes to the workflow: 

- I added a sentence about not having tumor cells in the supplemental cell type report. This is the only place we explicitly talk about references, so I chose to include it only in the supplemental and not in the main report too. 
- I updated `generate_unfiltered_sce.R` to handle missing columns for `is_cell_line` and `is_xenograft`. If both are missing, then `Not provided` is used as the `sample_type`. 
- I will note that we use the `is_cell_line` column specifically when determining if cell typing should be skipped, so I think we do want to note that those columns can be included, even if they aren't required. I accounted for them in the example metadata and readme and then also added a note about it to the external instructions for creating the sample metadata. 