### PR TITLE
Update version tag and scpcaTools container

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.3.2'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -86,12 +86,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.7.3` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.8.0` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.7.3 \
+  -r v0.8.0 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -325,7 +325,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.7.3`, then you will want to set `-r v0.7.3` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.8.0`, then you will want to set `-r v0.8.0` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -87,7 +87,7 @@ Please refer to our [`CONTRIBUTING.md`](CONTRIBUTING.md#stub-workflows) for more
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.7.3 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.8.0 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.7.3'
+  version = 'v0.8.0'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
Related to #654, here I'm updating the version tag and using the latest `scpcaTools` container. 