### PR TITLE
Fix bugs in v0.8.0

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -200,7 +200,7 @@ sample_type <- sample_metadata_df |>
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
       # if neither column was provided, note that
-      is.na(is_xenograft) && is.na(is_cell_line) ~ "Not provided",
+      is.na(is_xenograft) & is.na(is_cell_line) ~ "Not provided",
       .default = "patient tissue"
     )
   ) |>

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -56,7 +56,7 @@ process alevin_rad {
 process fry_quant_rna {
   container params.ALEVINFRY_CONTAINER
   label 'cpus_8'
-  label 'mem_8'
+  label 'mem_16'
   tag "${meta.run_id}-rna"
   publishDir "${params.checkpoints_dir}/alevinfry/${meta.library_id}", mode: 'copy', enabled: params.publish_fry_outs
 

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -3,7 +3,7 @@
 
 process sce_qc_report {
   container params.SCPCATOOLS_CONTAINER
-  label 'mem_8'
+  label 'mem_16'
   tag "${meta.library_id}"
   publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
   input:

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -526,12 +526,11 @@ if (skip_miQC) {
     miQC_plot <- miQC::plotMetrics(filtered_sce)
   } else {
     miQC_plot <- miQC::plotModel(filtered_sce, model = miQC_model)
+    # set line thickness
+    line_aes <- list(linewidth = 1, alpha = 0.8)
+    miQC_plot$layers[[2]]$aes_params <- line_aes
+    miQC_plot$layers[[3]]$aes_params <- line_aes
   }
-
-  # set line thickness
-  line_aes <- list(linewidth = 1, alpha = 0.8)
-  miQC_plot$layers[[2]]$aes_params <- line_aes
-  miQC_plot$layers[[3]]$aes_params <- line_aes
 
   miQC_plot +
     coord_cartesian(ylim = c(0, 100)) +


### PR DESCRIPTION
In processing projects through v0.8.0, I found two bugs that needed to be addressed. 

- The first was we are trying to adjust the linewidth on the miQC plot, independent of if the miQC plot just plots the metrics or the models. If the metrics are plotted without the model, then no lines are present to adjust. I just moved that to be within the `if` statement that actually creates the miQC plot with the model. 
- The second was an extra `&` that seemed to be causing an error in evaluating the `sample_type` for multiplex samples. When I removed this then things worked as expected. The double & only looks at the first element and with multiplex we have a vector. 
- While I was here, I bumped up the memory usage for the fry quant process and qc report, since we were seeing a reasonable number of failures. 

I tested this with the two libraries that were causing issues, so this at least fixes the errors I've come across so far. 