### PR TITLE
Reduce merge memory a touch

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -155,12 +155,9 @@ if ("submitter" %in% all_celltypes) {
 if ("singler" %in% all_celltypes) {
   # Check if the label used for annotation was ontology in at least 1 SCE
   use_ontology <- sce_list |>
-    purrr::map(\(sce) {
-      metadata(sce)$singler_reference_label == "label.ont"
+    purrr::map_lgl(\(sce) {
+      any(metadata(sce)$singler_reference_label == "label.ont")
     }) |>
-    # avoid warning with unlist; can't use map_lgl since ^ would always need to
-    #  return length 1
-    unlist() |>
     any()
 
   # Add `"Cell type annotation not performed"` string to libraries without SingleR

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -130,6 +130,7 @@ format_czi <- function(sce) {
 
 # read in sce
 sce <- readr::read_rds(opt$input_sce_file)
+message("sce read")
 
 # grab sample metadata
 # we need this if we have any feature data that we need to add it o
@@ -142,6 +143,8 @@ if (opt$is_merged) {
   sce <- format_czi(sce)
 }
 
+message("Formatting done")
+
 
 
 # export sce as anndata object
@@ -152,6 +155,8 @@ scpcaTools::sce_to_anndata(
   anndata_file = opt$output_rna_h5,
   compression = ifelse(opt$compress_output, "gzip", "none")
 )
+
+message("Exported RNA")
 
 # AltExp to AnnData -----------------------------------------------------------
 
@@ -183,6 +188,7 @@ if (!is.null(opt$feature_name)) {
 
       # make sce czi compliant
       alt_sce <- format_czi(alt_sce)
+      message("alt formatted")
 
       # export altExp sce as anndata object
       scpcaTools::sce_to_anndata(

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -25,7 +25,7 @@ process {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_max {
-    memory = {task.attempt > 1 ? params.max_memory : check_memory(192.GB, params.max_memory)}
+    memory = {(task.attempt > 2  && task.exitStatus in 137..140) ? params.max_memory : check_memory(192.GB * task.attempt, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/process_base.config
+++ b/config/process_base.config
@@ -25,7 +25,7 @@ process {
     memory = {check_memory(48.GB  + 48.GB * task.attempt, params.max_memory)}
   }
   withLabel: mem_max {
-    memory = {task.attempt > 1 ? params.max_memory : check_memory(96.GB, params.max_memory)}
+    memory = {task.attempt > 1 ? params.max_memory : check_memory(192.GB, params.max_memory)}
   }
   withLabel: cpus_2  {
     cpus = {check_cpus(2, params.max_cpus)}

--- a/config/profile_awsbatch_auto.config
+++ b/config/profile_awsbatch_auto.config
@@ -16,4 +16,7 @@ aws {
 process {
   executor = 'awsbatch'
   queue = { task.attempt < 3 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'}
+  withLabel: 'long_running' {
+    queue = task.attempt < 2 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'
+  }
 }

--- a/config/profile_awsbatch_auto.config
+++ b/config/profile_awsbatch_auto.config
@@ -17,6 +17,6 @@ process {
   executor = 'awsbatch'
   queue = { task.attempt < 3 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'}
   withLabel: 'long_running' {
-    queue = task.attempt < 2 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue'
+    queue = { task.attempt < 2 ? 'nextflow-batch-autoscale-queue' : 'nextflow-batch-priority-queue' }
   }
 }

--- a/merge.nf
+++ b/merge.nf
@@ -199,7 +199,7 @@ workflow {
         sce_file_list
       )}
       .branch{
-        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && !params.repeat_merge
+        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && params.reuse_merge
         make_merge: true
       }
 

--- a/merge.nf
+++ b/merge.nf
@@ -90,6 +90,7 @@ process generate_merge_report {
 process export_anndata {
     container params.SCPCATOOLS_CONTAINER
     label 'mem_max'
+    label 'long_running'
     tag "${merge_group_id}"
     publishDir "${params.results_dir}/${merge_group_id}/merged", mode: 'copy'
     input:

--- a/merge.nf
+++ b/merge.nf
@@ -198,8 +198,21 @@ workflow {
         library_id_list,
         sce_file_list
       )}
+      .branch(
+        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists()
+        make_merge: true
+      )
 
-    merge_sce(grouped_libraries_ch)
+    merged_ch = grouped_libraries_ch.has_merge
+      .map{[ # merge file, project id, has adt
+        file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds")
+        it[0],
+        it[1]
+      ]}
+
+    // merge SCE objects
+    merge_sce(grouped_libraries_ch.make_merge)
+      .mix(grouped_libraries_ch.make_merge)
 
     // generate merge report
     generate_merge_report(merge_sce.out, file(merge_template))

--- a/merge.nf
+++ b/merge.nf
@@ -29,6 +29,7 @@ if (param_error) {
 // merge individual SCE objects into one SCE object
 process merge_sce {
   container params.SCPCATOOLS_CONTAINER
+  tag "${merge_group_id}"
   label 'mem_max'
   publishDir "${params.results_dir}/${merge_group_id}/merged"
   input:
@@ -59,6 +60,7 @@ process merge_sce {
 // create merge report
 process generate_merge_report {
   container params.SCPCATOOLS_CONTAINER
+  tag "${merge_group_id}"
   publishDir "${params.results_dir}/${merge_group_id}/merged"
   label 'mem_max'
   input:

--- a/merge.nf
+++ b/merge.nf
@@ -204,7 +204,7 @@ workflow {
       }
 
     pre_merged_ch = grouped_libraries_ch.has_merge
-      .map{[ # merge file, project id, has adt
+      .map{[ // merge file, project id, has adt
         file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds")
         it[0],
         it[1]

--- a/merge.nf
+++ b/merge.nf
@@ -31,6 +31,7 @@ process merge_sce {
   container params.SCPCATOOLS_CONTAINER
   tag "${merge_group_id}"
   label 'mem_max'
+  label 'long_running'
   publishDir "${params.results_dir}/${merge_group_id}/merged"
   input:
     tuple val(merge_group_id), val(has_adt), val(library_ids), path(scpca_nf_file)

--- a/merge.nf
+++ b/merge.nf
@@ -198,10 +198,10 @@ workflow {
         library_id_list,
         sce_file_list
       )}
-      .branch(
+      .branch{
         has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && (params.repeat_merge)
         make_merge: true
-      )
+      }
 
     pre_merged_ch = grouped_libraries_ch.has_merge
       .map{[ # merge file, project id, has adt

--- a/merge.nf
+++ b/merge.nf
@@ -199,7 +199,7 @@ workflow {
         sce_file_list
       )}
       .branch{
-        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && (params.repeat_merge)
+        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && !params.repeat_merge
         make_merge: true
       }
 

--- a/merge.nf
+++ b/merge.nf
@@ -205,7 +205,7 @@ workflow {
 
     pre_merged_ch = grouped_libraries_ch.has_merge
       .map{[ // merge file, project id, has adt
-        file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds")
+        file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds"),
         it[0],
         it[1]
       ]}

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -51,6 +51,7 @@ process classify_cellassign {
     )
   label 'mem_max'
   label 'cpus_12'
+  label 'long_running'
   tag "${meta.library_id}"
   input:
     tuple val(meta), path(processed_rds), path(cellassign_reference_file)

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,9 @@ params {
   // Cell type annotation options
   singler_label_name = "label.ont" // celldex reference label used for SingleR reference building
 
+  // Merge workflow options
+  repeat_merge = false // if the merge workflow has already been run, skip by default. Use `--repeat_merge` to run this step again.
+
   // Docker container images
   includeConfig 'config/containers.config'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,8 +59,9 @@ params {
   // Cell type annotation options
   singler_label_name = "label.ont" // celldex reference label used for SingleR reference building
 
-  // Merge workflow options
-  repeat_merge = false // if the merge workflow has already been run, skip by default. Use `--repeat_merge` to run this step again.
+  // Merge workflow-specfic options
+  params.reuse_merge = false // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
+
 
   // Docker container images
   includeConfig 'config/containers.config'


### PR DESCRIPTION
Now that one of the merges has completed successfully, it was time to submit the changes I included to reduce memory usage during the merge. 

- I moved some of the SCE trimming to when we read in the files (though I realize this won't matter now that we don't have the miQC object in processed data anyway) .
- I also removed a place where we duplicate the list unnecessarily.
- In probably the biggest effect, I remove the `sce_list` once the merged object is created.
- Threw in some `gc()` calls.


I also added an explicit `long_running` tag to shift to the priority queue more quickly, and bumped up the `mem_max` base memory.

