### PR TITLE
Skip CellAssign if only 1 cell

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -187,7 +187,13 @@ if (!is.null(opt$cellassign_predictions)) {
     stop("Cell type reference metadata filename must be provided")
   }
 
-  predictions <- readr::read_tsv(opt$cellassign_predictions)
+  # if the predictions file isn't emtpy read it in
+  if (file.size(opt$cellassign_predictions) > 0) {
+    predictions <- readr::read_tsv(opt$cellassign_predictions)
+  } else {
+    # if it's empty, then sce could not be converted to anndata and cell assign was not run
+    sce$cellassign_celltype_annotation <- "Not run"
+  }
 
   # if the only column is the barcode column then CellAssign didn't complete successfully
   # otherwise add in cell type annotations and metadata to SCE

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -131,6 +131,11 @@ format_czi <- function(sce) {
 # read in sce
 sce <- readr::read_rds(opt$input_sce_file)
 
+# if not enough cells to convert, quit and don't do anything
+if (ncol(sce) < 2) {
+  quit(save = "no")
+}
+
 # grab sample metadata
 # we need this if we have any feature data that we need to add it o
 sample_metadata <- metadata(sce)$sample_metadata

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -69,16 +69,25 @@ process classify_cellassign {
         --input_sce_file "${processed_rds}" \
         --output_rna_h5 "processed.h5ad"
 
-    # Run CellAssign
-    predict_cellassign.py \
-      --anndata_file "processed.h5ad" \
-      --output_predictions "${cellassign_dir}/cellassign_predictions.tsv" \
-      --reference "${cellassign_reference_file}" \
-      --seed ${params.seed} \
-      --threads ${task.cpus}
+    # only run cell assign if a h5ad file was able to be created
+    # otherwise create an empty predictions file
+    if [[ -e "processed.h5ad" ]]; then
 
-    # write out meta file
-    echo '${meta_json}' > "${cellassign_dir}/scpca-meta.json"
+      # Run CellAssign
+      predict_cellassign.py \
+        --anndata_file "processed.h5ad" \
+        --output_predictions "${cellassign_dir}/cellassign_predictions.tsv" \
+        --reference "${cellassign_reference_file}" \
+        --seed ${params.seed} \
+        --threads ${task.cpus}
+
+      # write out meta file
+      echo '${meta_json}' > "${cellassign_dir}/scpca-meta.json"
+
+    else
+      touch "${cellassign_dir}/cellassign_predictions.tsv"
+    fi
+
     """
   stub:
     cellassign_dir = file(meta.cellassign_dir).name

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -38,6 +38,7 @@ process classify_singler {
     """
     mkdir "${singler_dir}"
     echo '${meta_json}' > "${singler_dir}/scpca-meta.json"
+    touch "${singler_dir}/singler_results.rds"
     """
 }
 
@@ -81,12 +82,12 @@ process classify_cellassign {
         --seed ${params.seed} \
         --threads ${task.cpus}
 
-      # write out meta file
-      echo '${meta_json}' > "${cellassign_dir}/scpca-meta.json"
-
     else
       touch "${cellassign_dir}/cellassign_predictions.tsv"
     fi
+
+    # write out meta file
+      echo '${meta_json}' > "${cellassign_dir}/scpca-meta.json"
 
     """
   stub:
@@ -96,6 +97,7 @@ process classify_cellassign {
     """
     mkdir "${cellassign_dir}"
     echo '${meta_json}' > "${cellassign_dir}/scpca-meta.json"
+    touch "${cellassign_dir}/cellassign_predictions.tsv"
     """
 }
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -130,6 +130,9 @@ if (has_processed) {
 } else {
   has_umap <- FALSE
   has_celltypes <- FALSE
+  has_singler <- FALSE
+  has_cellassign <- FALSE
+  has_submitter <- FALSE
 }
 
 # check for celltypes_report if celltypes are present
@@ -526,12 +529,11 @@ if (skip_miQC) {
     miQC_plot <- miQC::plotMetrics(filtered_sce)
   } else {
     miQC_plot <- miQC::plotModel(filtered_sce, model = miQC_model)
+    # set line thickness
+    line_aes <- list(linewidth = 1, alpha = 0.8)
+    miQC_plot$layers[[2]]$aes_params <- line_aes
+    miQC_plot$layers[[3]]$aes_params <- line_aes
   }
-
-  # set line thickness
-  line_aes <- list(linewidth = 1, alpha = 0.8)
-  miQC_plot$layers[[2]]$aes_params <- line_aes
-  miQC_plot$layers[[3]]$aes_params <- line_aes
 
   miQC_plot +
     coord_cartesian(ylim = c(0, 100)) +

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -129,10 +129,10 @@ if (has_processed) {
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
   has_umap <- FALSE
-  has_celltypes <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
   has_submitter <- FALSE
+  has_celltypes <- FALSE
 }
 
 # check for celltypes_report if celltypes are present


### PR DESCRIPTION
Closes #731 

Here I'm making sure we skip trying to run CellAssign if a processed object only has 1 cell. The problem is that we can't convert an object with 1 cell to an AnnData object, so then there's no AnnData object to use as input to CellAssign. 

To handle this I added a check for the number of cells in the SCE object in `sce_to_anndata.R`. If < 2 cells, then the script just quits and doesn't do any conversions. This means no `.h5ad` file gets created. If that's the case then we skip running the `predict_cellassign.py` script and just make an empty predictions file to output from the process. Then when annotations get added to the SCE object, if the predictions file is empty, all cells get annotated with `Not run`. This is the same value we use when CellAssign isn't run because of too few cells. 

While testing, I ran into small errors in the QC report that I also fixed here. Moving the miQC lines was something we had done on `main`, but seemed to be missing from `development`. 