### PR TITLE
Account for .h5ad in output feature file

### DIFF
--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -174,8 +174,8 @@ if (!is.null(opt$feature_name)) {
     # convert altExp
   } else {
     # check for output file
-    if (!(stringr::str_ends(opt$output_feature_h5, ".hdf5|.h5"))) {
-      stop("output feature file name must end in .hdf5 or .h5")
+    if (!(stringr::str_ends(opt$output_feature_h5, ".h5ad|.hdf5|.h5"))) {
+      stop("output feature file name must end in .h5ad, .hdf5, or .h5")
     }
 
     # extract altExp


### PR DESCRIPTION
In generating test data, I ran into an error because we missed updating the file extension in one place. This updates the check for the extension for the feature file. 