### PR TITLE
Account for no cells being assigned to a sample when demultiplexing

### DIFF
--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -239,12 +239,9 @@ if (multiplexed) {
   # get cell count estimates
   demux_column <- paste0(demux_method, "_sampleid")
   demux_counts <- colData(filtered_sce)[[demux_column]] |>
+    factor(levels = sample_ids) |> # use a factor get any zero counts
     table() |>
     as.list() # save as a list for json output
-
-  # for any ids that have no cells, set count to 0
-  missing_sample_ids <- setdiff(sample_ids, names(demux_counts))
-  demux_counts[missing_sample_ids] <- 0
 
   # add demux info to the metadata list
   metadata_list <- append(

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -251,7 +251,7 @@ if (multiplexed) {
     metadata_list,
     list(
       demux_method = demux_method,
-      demux_samples = sample_ids,
+      demux_samples = names(demux_counts), # make sure order of sample ids matches counts order
       sample_cell_estimates = demux_counts
     )
   )

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -242,6 +242,10 @@ if (multiplexed) {
     table() |>
     as.list() # save as a list for json output
 
+  # for any ids that have no cells, set count to 0
+  missing_sample_ids <- setdiff(sample_ids, names(demux_counts))
+  demux_counts[missing_sample_ids] <- 0
+
   # add demux info to the metadata list
   metadata_list <- append(
     metadata_list,


### PR DESCRIPTION
Apparently, with our test data using `hashedDrops` doesn't assign cells to any of our samples. This prints out an empty list again, which we want to avoid. I checked, and using `HTODemux` only assigns cells to one sample but not all of them. This leads to a list with just one value while the list of sample IDs is longer. This would mean there is no way to match which cell count goes to which sample. 

If no cells are assigned, we should set to 0 rather than having an empty list. This PR makes that adjustment by looking for any missing sample IDs and then assigning those to 0. 
