### PR TITLE
Fix bugs with generating example data

### DIFF
--- a/config/profile_example.config
+++ b/config/profile_example.config
@@ -4,6 +4,7 @@ params {
   run_metafile = "s3://scpca-references/example-data/example_run_metadata.tsv"
   sample_metafile = "s3://scpca-references/example-data/example_sample_metadata.tsv"
   project_celltype_metafile = "s3://scpca-references/example-data/example_project_celltype_metadata.tsv"
+  cellhash_pool_file = "s3://scpca-references/example-data/example_multiplex_pools.tsv"
 
   outdir = "s3://scpca-references/example-data/scpca_out"
 

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -95,7 +95,7 @@ nextflow run AlexsLemonade/scpca-nf -r v0.8.1 -profile ccdl,batch --project SCPC
 We provide an [example of the expected outputs](./examples/README.md#example-output) after running `scpca-nf` available for external users.
 If there have been major updates to the directory structure or the contents of the output, the example data should be re-processed such that the example output we provide mimics the current expected output from `scpca-nf`.
 
-First, please check the metadata files present in `s3://scpca-references/example-data` are up to date with changes in the workflow.
+First, please check the metadata files present in `s3://scpca-references/example-data` are up to date with changes in the workflow and reflect the contents of the files present in the `examples` directory of this repository.
 Each of these files should be present, with the expected input columns as described in each documentation link.
 
 - `example_run_metadata.tsv` ([documentation](./external-instructions.md#prepare-the-run-metadata-file))

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -101,6 +101,7 @@ Each of these files should be present, with the expected input columns as descri
 - `example_run_metadata.tsv` ([documentation](./external-instructions.md#prepare-the-run-metadata-file))
 - `example_sample_metadata.tsv` ([documentation](./external-instructions.md#prepare-the-sample-metadata-file))
 - `example_project_celltype_metadata.tsv` ([documentation](./external-instructions.md#preparing-the-project-cell-type-metadata-file))
+- `example_multiplex_pools.tsv` ([documentation](./external-instructions.md#multiplexed-cellhash-libraries))
 
 Once you have confirmed that the metadata looks correct, use the following commands to run the workflow and re-process the example data:
 

--- a/main.nf
+++ b/main.nf
@@ -69,7 +69,7 @@ if (!resolution_strategies.contains(params.af_resolution)) {
 }
 
 if (params.cellhash_pool_file && !file(params.cellhash_pool_file).exists()){
-  log.error("The 'cellhash_pool_file' file ${cellhash_pool_file} can not be found.")
+  log.error("The 'cellhash_pool_file' file ${params.cellhash_pool_file} can not be found.")
   param_error = true
 }
 


### PR DESCRIPTION
When working on generating the updated example data for #748, I found a bug in `main.nf` where we were missing a `params.` call before a variable. I also realized we were missing the cellhash pools files in the example config, so it was looking for a file that doesn't exist and giving an error. I added the cellhash pool file that we have in examples to S3 and then to the profile for example. Alternatively, I could have just left it empty in the example config, but since we have the file we mine as well use it. This means that all example metadata files should now also be on S3. 