### PR TITLE
Fix bugs for dealing with processed objects with only 1 cell

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -191,13 +191,13 @@ if (!is.null(opt$cellassign_predictions)) {
   if (file.size(opt$cellassign_predictions) > 0) {
     predictions <- readr::read_tsv(opt$cellassign_predictions)
   } else {
-    # if it's empty, then sce could not be converted to anndata and cell assign was not run
-    sce$cellassign_celltype_annotation <- "Not run"
+    predictions <- NULL
   }
 
-  # if the only column is the barcode column then CellAssign didn't complete successfully
+  # if the only column is the barcode column or if the predictions file was empty
+  # then CellAssign didn't complete successfully
   # otherwise add in cell type annotations and metadata to SCE
-  if (all(colnames(predictions) == "barcode")) {
+  if (is.null(predictions) | all(colnames(predictions) == "barcode")) {
     # if failed then note that in the cell type column
     sce$cellassign_celltype_annotation <- "Not run"
   } else {

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -197,7 +197,7 @@ if (!is.null(opt$cellassign_predictions)) {
   # if the only column is the barcode column or if the predictions file was empty
   # then CellAssign didn't complete successfully
   # otherwise add in cell type annotations and metadata to SCE
-  if (is.null(predictions) | all(colnames(predictions) == "barcode")) {
+  if (is.null(predictions) || all(colnames(predictions) == "barcode")) {
     # if failed then note that in the cell type column
     sce$cellassign_celltype_annotation <- "Not run"
   } else {

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -285,17 +285,20 @@ if (opt$celltype_report_file != "") {
     stop("Supplemental cell types report template not found.")
   }
 
-  # render report
-  rmarkdown::render(
-    input = opt$celltype_report_template,
-    output_file = basename(opt$celltype_report_file),
-    output_dir = dirname(opt$celltype_report_file),
-    intermediates_dir = tempdir(),
-    knit_root_dir = tempdir(),
-    envir = new.env(),
-    params = list(
-      library = metadata_list$library_id,
-      processed_sce = processed_sce
+  # only render supplemental report if there's more than one cell
+  if (ncol(processed_sce) > 1) {
+    # render report
+    rmarkdown::render(
+      input = opt$celltype_report_template,
+      output_file = basename(opt$celltype_report_file),
+      output_dir = dirname(opt$celltype_report_file),
+      intermediates_dir = tempdir(),
+      knit_root_dir = tempdir(),
+      envir = new.env(),
+      params = list(
+        library = metadata_list$library_id,
+        processed_sce = processed_sce
+      )
     )
-  )
+  }
 }

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -370,7 +370,7 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 ```
 
 
-```{r, eval = has_umap & has_clusters}
+```{r, eval = has_umap && has_clusters}
 knitr::asis_output(glue::glue("
 ## UMAPs
 
@@ -398,7 +398,7 @@ glue::glue("
 ```
 
 
-```{r eval = has_umap & has_clusters, message=FALSE, warning=FALSE}
+```{r eval = has_umap && has_clusters, message=FALSE, warning=FALSE}
 clusters_plot <- plot_umap(
   umap_df,
   cluster,
@@ -418,7 +418,7 @@ if (length(levels(umap_df$cluster)) <= 8) {
 ```
 
 
-```{r, eval = has_umap & has_celltypes}
+```{r, eval = has_umap && has_celltypes}
 knitr::asis_output(
   'Next, we show UMAPs colored by cell types.
 For each cell typing method, we show a separate faceted UMAP.

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -93,7 +93,7 @@ plot_umap <- function(
     umap_df,
     color_variable,
     legend_title,
-    point_size = umap_point_size,
+    point_size = point_size,
     legend_nrow = 2) {
   ggplot(umap_df) +
     aes(
@@ -370,7 +370,7 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 ```
 
 
-```{r, eval = has_umap}
+```{r, eval = has_umap & has_clusters}
 knitr::asis_output(glue::glue("
 ## UMAPs
 
@@ -388,7 +388,7 @@ umap_df <- lump_wrap_celltypes(celltype_df)
 
 <!-- First UMAP: clusters -->
 
-```{r, eval = has_umap && has_multiplex, results='asis'}
+```{r, eval = has_umap && has_multiplex && has_clusters, results='asis'}
 glue::glue("
   <div class=\"alert alert-info\">
     This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
@@ -398,7 +398,7 @@ glue::glue("
 ```
 
 
-```{r eval = has_umap, message=FALSE, warning=FALSE}
+```{r eval = has_umap & has_clusters, message=FALSE, warning=FALSE}
 clusters_plot <- plot_umap(
   umap_df,
   cluster,
@@ -418,7 +418,7 @@ if (length(levels(umap_df$cluster)) <= 8) {
 ```
 
 
-```{r, eval = has_umap}
+```{r, eval = has_umap & has_celltypes}
 knitr::asis_output(
   'Next, we show UMAPs colored by cell types.
 For each cell typing method, we show a separate faceted UMAP.

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -416,7 +416,7 @@ glue::glue("
 ```
 
 <!-- If not multiplexed, show the header, text, and heatmap --> 
-```{r, eval = !has_multiplex, results='asis'}
+```{r, eval = !has_multiplex & has_clusters, results='asis'}
 glue::glue("
   ## Unsupervised clustering
 
@@ -448,7 +448,7 @@ plot_height <- calculate_plot_height(
 ```
 
 
-```{r, eval = !has_multiplex, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
+```{r, eval = !has_multiplex & has_clusters, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters",

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -420,7 +420,7 @@ glue::glue("
 ```
 
 <!-- If not multiplexed, show the header, text, and heatmap --> 
-```{r, eval = !has_multiplex & has_clusters, results='asis'}
+```{r, eval = !has_multiplex && has_clusters, results='asis'}
 glue::glue("
   ## Unsupervised clustering
 
@@ -452,7 +452,7 @@ plot_height <- calculate_plot_height(
 ```
 
 
-```{r, eval = !has_multiplex & has_clusters, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
+```{r, eval = !has_multiplex && has_clusters, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
 jaccard_cluster_matrices |>
   create_heatmap_list(
     column_title = "Clusters",

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -264,7 +264,7 @@ has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
 has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
   !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
-# check for umap
+# check for umap and clusters
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
 has_clusters <- "cluster" %in% names(colData(processed_sce))
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -264,6 +264,9 @@ has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
 has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
   !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
+# If at least 1 is present, we have cell type annotations.
+has_celltypes <- any(has_singler, has_cellassign, has_submitter)
+
 # check for umap and clusters
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
 has_clusters <- "cluster" %in% names(colData(processed_sce))

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -266,6 +266,7 @@ has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
 
 # check for umap
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
+has_clusters <- "cluster" %in% names(colData(processed_sce))
 
 # what celltypes are available?
 available_celltypes <- c(

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -117,7 +117,7 @@ if (has_cellhash) {
 # check for umap and celltypes, but need to be sure that processed_sce exists first
 if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
-
+  has_clusters <- "cluster" %in% names(colData(processed_sce))
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
@@ -129,6 +129,7 @@ if (has_processed) {
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
   has_umap <- FALSE
+  has_clusters <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
   has_submitter <- FALSE

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -117,6 +117,7 @@ if (has_cellhash) {
 # check for umap and celltypes, but need to be sure that processed_sce exists first
 if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
+  has_clusters <- "cluster" %in% names(colData(processed_sce))
 
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
@@ -129,6 +130,7 @@ if (has_processed) {
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
   has_umap <- FALSE
+  has_clusters <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
   has_submitter <- FALSE

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -117,7 +117,6 @@ if (has_cellhash) {
 # check for umap and celltypes, but need to be sure that processed_sce exists first
 if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
-  has_clusters <- "cluster" %in% names(colData(processed_sce))
 
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
@@ -130,7 +129,6 @@ if (has_processed) {
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
   has_umap <- FALSE
-  has_clusters <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
   has_submitter <- FALSE


### PR DESCRIPTION
While processing data for the Portal, I found an object that only has 1 cell in the processed object so it tested out some of the code we added to handle that scenario. There were a few issues that I had to fix to get this to work and then I also made a design change that we will need to decide on if it's the right move or not. 

- If any object only has 1 cell then it doesn't have PCA or clusters. We have a check for PCA/UMAP when generating the reports, but not for clusters. Here I added a `has_clusters` variable to make sure no plots that use clusters are created. 
- There was also a small error in the `add_celltypes_to_sce.R` where we were still attempting to add in cell type annotations if the predictions file was empty. So I adjusted the logic there to account for the missing file properly. 

The other thing I did was choose to not create the supplemental report if there's only 1 cell in the object. The report was just some text with one table showing the assignment of that single cell in SingleR, but no other plots. This doesn't seem super informative to me, and we would still have the table in the main QC report. What do others think of this choice? This should not affect very many samples, but we would want to make sure we check how this affects zipping up the files for the Portal. 

@davidsmejia Would you guys have to make changes when zipping up the files for the Portal if a sample was missing the `celltype-report.html` file? I assume you have checks to make sure the files are all there, so would we be able to make the existence of this file optional? 