### PR TITLE
Define umap point size when creating cell type umaps

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -1,5 +1,10 @@
 # Cell type Annotation Summary
 
+<!--
+This file is meant to be run as a child report within either `main_qc_report.rmd` or `celltypes_supplemental_report.rmd`. 
+-->
+
+
 ```{r}
 ## function definitions ##
 
@@ -86,14 +91,14 @@ lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35) {
 #' @param color_variable Column in data frame to color by, not a string.
 #' @param legend_title Title for legend.
 #' @param legend_nrow Number of rows in legend. Default is 2.
-#' @param point_size Point size
+#' @param point_size Point size. Default is 1
 #'
 #' @return UMAP plot as a ggplot2 object
 plot_umap <- function(
     umap_df,
     color_variable,
     legend_title,
-    point_size = point_size,
+    point_size = 1,
     legend_nrow = 2) {
   ggplot(umap_df) +
     aes(
@@ -131,14 +136,14 @@ plot_umap <- function(
 #' @param umap_df Data frame with UMAP1 and UMAP2 columns
 #' @param n_celltypes The number of cell types (facets) displayed in the plot
 #' @param annotation_column Column containing cell type annotations
-#' @param point_size Point size
+#' @param point_size Point size. Default is 1
 #'
 #' @return ggplot object containing a faceted UMAP where each cell type is a facet.
 #'   In each panel, the cell type of interest is colored and all other cells are grey.
 faceted_umap <- function(umap_df,
                          n_celltypes,
                          annotation_column,
-                         point_size = umap_facet_point_size) {
+                         point_size = 1) {
   # Determine legend y-coordinate based on n_celltypes
   if (n_celltypes %in% 7:8) {
     legend_y <- 0.33
@@ -283,6 +288,11 @@ glue::glue("
 ```{r, warning = FALSE}
 # Create data frame of cell types
 celltype_df <- create_celltype_df(processed_sce)
+
+# determine UMAP point sizing
+umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
+umap_point_size <- umap_points_sizes[1]
+umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -402,7 +402,8 @@ glue::glue("
 clusters_plot <- plot_umap(
   umap_df,
   cluster,
-  "Cluster"
+  "Cluster",
+  point_size = umap_point_size
 ) +
   ggtitle("UMAP colored by cluster identity")
 
@@ -447,7 +448,8 @@ if (has_submitter & has_umap) {
 faceted_umap(
   umap_df,
   submitter_n_celltypes,
-  submitter_celltype_annotation_lumped
+  submitter_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
 ) +
   ggtitle("UMAP colored by submitter-provided annotations")
 ```
@@ -469,7 +471,8 @@ if (has_singler & has_umap) {
 faceted_umap(
   umap_df,
   singler_n_celltypes,
-  singler_celltype_annotation_lumped
+  singler_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
 ) +
   ggtitle("UMAP colored by SingleR annotations")
 ```
@@ -490,7 +493,8 @@ if (has_cellassign & has_umap) {
 faceted_umap(
   umap_df,
   cellassign_n_celltypes,
-  cellassign_celltype_annotation_lumped
+  cellassign_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
 ) +
   ggtitle("UMAP colored by CellAssign annotations")
 ```

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -300,11 +300,6 @@ plot_height <- 1
 #  sample_id should be defined with length > 1
 sample_id <- metadata(processed_sce)$sample_id
 has_multiplex <- length(sample_id) > 1
-
-# determine UMAP point sizing
-umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
-umap_point_size <- umap_points_sizes[1]
-umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 <!-- If multiplexed, open with warning  --> 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -144,11 +144,6 @@ if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
 # check if we have multiplex
 has_multiplex <- length(sample_id) > 1
 sample_types <- metadata(unfiltered_sce)$sample_type
-
-# determine UMAP point sizing
-umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
-umap_point_size <- umap_points_sizes[1]
-umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -2,6 +2,14 @@
 
 The below plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
 
+```{r}
+# determine UMAP point sizing
+umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
+umap_point_size <- umap_points_sizes[1]
+umap_facet_point_size <- umap_points_sizes[2]
+```
+
+
 ```{r message=FALSE}
 # create UMAP colored by number of genes detected
 scater::plotUMAP(


### PR DESCRIPTION
In #755 I made a fix to the UMAP point sizes variable that used the global value for a variable as the default for the function. I did that because I didn't see that variable defined anywhere in the report that uses that function, but it's defined in the main and supplemental report. With that change we need to actually define the point size when calling the functions to plot UMAPs. Otherwise, we get a failure when plotting a UMAP, since `point_size` isn't defined. So here, I'm just adding those lines. We could revert the change I made in #755, but I think this is more specific and easier to track what's being defined where, something that tripped me up when I was going back and making fixes in #755. 