### PR TITLE
Fix some merge bugs

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -247,8 +247,7 @@ adt_present_columns <- sce_list |>
 
 # ensure that there are indeed no "adt" altExps if adt_present_columns is empty
 adt_altexps <- sce_list |>
-  purrr::map(\(sce) "adt" %in% altExpNames(sce)) |>
-  unlist()
+  purrr::map_lgl(\(sce) "adt" %in% altExpNames(sce))
 if (is.null(adt_present_columns) && sum(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }

--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -247,7 +247,8 @@ adt_present_columns <- sce_list |>
 
 # ensure that there are indeed no "adt" altExps if adt_present_columns is empty
 adt_altexps <- sce_list |>
-  purrr::map(\(sce) "adt" %in% altExpNames(sce))
+  purrr::map(\(sce) "adt" %in% altExpNames(sce)) |>
+  unlist()
 if (is.null(adt_present_columns) && sum(adt_altexps) > 0) {
   stop("Error in determining which adt altExp columns should be retained.")
 }

--- a/merge.nf
+++ b/merge.nf
@@ -178,6 +178,15 @@ workflow {
         log.warn("Not merging ${it.project_id} because it contains multiplexed libraries.")
       }
 
+    // print out warning message for any libraries not included in merging
+    merge_libaries = filtered_libraries_ch
+      .collect{it.library_id}
+    libraries_ch
+    .filter{!(it.library_id in merge_libaries.getVal())}
+    .subscribe{
+      log.warn("Processed files do not exist for ${it.library_id}. This library will not be included in the merged object.")
+    }
+
     grouped_libraries_ch = filtered_libraries_ch.single_sample
       // create tuple of [project id, library_id, processed_sce_file]
       .map{[

--- a/merge.nf
+++ b/merge.nf
@@ -179,7 +179,7 @@ workflow {
       }
 
     // print out warning message for any libraries not included in merging
-    merge_libaries = filtered_libraries_ch
+    merge_libaries = filtered_libraries_ch.single_sample
       .collect{it.library_id}
     libraries_ch
     .filter{!(it.library_id in merge_libaries.getVal())}

--- a/merge.nf
+++ b/merge.nf
@@ -197,7 +197,7 @@ workflow {
         file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
       ]}
       // only include libraries that have been processed through scpca-nf and aren't empty
-      .filter{file(it[2]).exists() && file(it[2]).size() > 0}
+      .filter{it[2].exists() && it[2].size() > 0}
       // only one row per library ID, this removes all the duplicates that may be present due to CITE/hashing
       .unique()
       // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]

--- a/merge.nf
+++ b/merge.nf
@@ -185,8 +185,8 @@ workflow {
         it.library_id,
         file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
       ]}
-      // only include libraries that have been processed through scpca-nf
-      .filter{file(it[2]).exists()}
+      // only include libraries that have been processed through scpca-nf and aren't empty
+      .filter{file(it[2]).exists() && file(it[2]).size() > 0}
       // only one row per library ID, this removes all the duplicates that may be present due to CITE/hashing
       .unique()
       // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]

--- a/merge.nf
+++ b/merge.nf
@@ -179,12 +179,14 @@ workflow {
       }
 
     // print out warning message for any libraries not included in merging
-    merge_libaries = filtered_libraries_ch.single_sample
-      .collect{it.library_id}
-    libraries_ch
-    .filter{!(it.library_id in merge_libaries.getVal())}
+    filtered_libraries_ch.single_sample
+      .map{[
+        it.library_id,
+        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds")
+      ]}
+    .filter{!(it[1].exists() && it[1].size() > 0)}
     .subscribe{
-      log.warn("Processed files do not exist for ${it.library_id}. This library will not be included in the merged object.")
+      log.warn("Processed files do not exist for ${it[0]}. This library will not be included in the merged object.")
     }
 
     grouped_libraries_ch = filtered_libraries_ch.single_sample


### PR DESCRIPTION
In merging the processed data for a project for the Portal, I came across a small error in the `merge_sces.R` script. R was complaining about calculating the `sum()` of a list so I just added an `unlist()` and that fixed that problem. 

The other precautionary measure I took here is to ensure that if a processed file exists but its size is 0, it's not actually included in the merging process. I can imagine that causing problems down the line if we try to read in an empty file. I also added a warning message that should print out any libraries that are not going to be included in the object. 