### PR TITLE
Use new, slimmer sometimes, containers 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         args: [--update-only, --title=**Table of Contents**]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff for linting and formatting python
-    rev: v0.3.3
+    rev: v0.4.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -40,7 +40,7 @@ repos:
       - id: ruff-format
   - repo: https://github.com/lorenzwalthert/precommit
     # R styling and linting
-    rev: v0.4.0
+    rev: v0.4.2
     hooks:
       - id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
@@ -48,12 +48,12 @@ repos:
       - id: parsable-R
   - repo: https://github.com/pre-commit/mirrors-prettier
     # Format YAML and other languages
-    rev: v3.0.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         exclude: '\.md$'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=200"]

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,10 @@
 // Docker container images
 SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:edge'
+SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:edge'
+SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:edge'
+SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:edge'
+SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:edge'
+SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,5 +1,5 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:v0.3.2'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
@@ -8,7 +8,7 @@ FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
 SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1'
 SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
 STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
-TIDYVERSE_CONTAINER = 'rocker/tidyverse:4.3.1'
+TIDYVERSE_CONTAINER = 'rocker/tidyverse:4.4.0'
 VIREO_CONTAINER = 'ghcr.io/alexslemonade/vireo-snp:v0.5.7'
 
 // 10X software containers not set by default

--- a/merge.nf
+++ b/merge.nf
@@ -28,7 +28,7 @@ if (param_error) {
 
 // merge individual SCE objects into one SCE object
 process merge_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   tag "${merge_group_id}"
   label 'mem_max'
   label 'long_running'
@@ -60,7 +60,7 @@ process merge_sce {
 
 // create merge report
 process generate_merge_report {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_REPORTS_CONTAINER
   tag "${merge_group_id}"
   publishDir "${params.results_dir}/${merge_group_id}/merged"
   label 'mem_max'
@@ -88,7 +88,7 @@ process generate_merge_report {
 }
 
 process export_anndata {
-    container params.SCPCATOOLS_CONTAINER
+    container params.SCPCATOOLS_ANNDATA_CONTAINER
     label 'mem_max'
     label 'long_running'
     tag "${merge_group_id}"

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -66,7 +66,7 @@ process salmon {
 }
 
 process merge_bulk_quants {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
   publishDir "${params.results_dir}/${meta.project_id}", mode: 'copy'
   tag "${meta.project_id}"

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -44,7 +44,7 @@ process classify_singler {
 
 
 process classify_cellassign {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_CELLASSIGN_CONTAINER
     publishDir (
       path: "${meta.celltype_checkpoints_dir}",
       mode: 'copy',
@@ -103,7 +103,7 @@ process classify_cellassign {
 }
 
 process add_celltypes_to_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_4'
   label 'cpus_2'
   tag "${meta.library_id}"

--- a/modules/cluster-sce.nf
+++ b/modules/cluster-sce.nf
@@ -1,6 +1,6 @@
 // perform graph-based clustering on a processed SCE object
 process cluster_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
   input:

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -1,7 +1,7 @@
 
 // process for converting rds files containing an SCE to h5 containing anndata containing the RNA data
 process export_anndata {
-    container params.SCPCATOOLS_CONTAINER
+    container params.SCPCATOOLS_ANNDATA_CONTAINER
     label 'mem_16'
     tag "${meta.library_id}"
     publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'

--- a/modules/qc-report.nf
+++ b/modules/qc-report.nf
@@ -2,7 +2,7 @@
 // generate QC report from unfiltered and filtered SCE.rds files using scpcaTools
 
 process sce_qc_report {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_REPORTS_CONTAINER
   label 'mem_16'
   tag "${meta.library_id}"
   publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -2,7 +2,7 @@
 
 // RNA only libraries
 process make_unfiltered_sce {
-    container params.SCPCATOOLS_CONTAINER
+    container params.SCPCATOOLS_SLIM_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
     input:

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -2,7 +2,7 @@
 
 // RNA only libraries
 process make_unfiltered_sce {
-    container params.SCPCATOOLS_SLIM_CONTAINER
+    container params.SCPCATOOLS_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
     input:

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -2,7 +2,7 @@
 
 // RNA only libraries
 process make_unfiltered_sce {
-    container params.SCPCATOOLS_CONTAINER
+    container params.SCPCATOOLS_SLIM_CONTAINER
     label 'mem_8'
     tag "${meta.library_id}"
     input:
@@ -48,7 +48,7 @@ process make_unfiltered_sce {
 process make_merged_unfiltered_sce {
     label 'mem_8'
     tag "${rna_meta.library_id}"
-    container params.SCPCATOOLS_CONTAINER
+    container params.SCPCATOOLS_SLIM_CONTAINER
     input:
         tuple val(feature_meta), path(feature_alevin_dir),
               val(rna_meta), path(alevin_dir),
@@ -105,7 +105,7 @@ process make_merged_unfiltered_sce {
 }
 
 process filter_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
   input:
@@ -138,7 +138,7 @@ process filter_sce {
 }
 
 process genetic_demux_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
   input:
@@ -192,7 +192,7 @@ process cellhash_demux_sce {
 }
 
 process post_process_sce {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
   tag "${meta.library_id}"
   input:

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -45,7 +45,7 @@ process spaceranger {
 }
 
 process spaceranger_publish {
-  container params.SCPCATOOLS_CONTAINER
+  container params.SCPCATOOLS_SLIM_CONTAINER
   tag "${meta.library_id}"
   publishDir "${params.results_dir}/${meta.project_id}/${meta.sample_id}", mode: 'copy'
   input:

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -289,7 +289,27 @@
       "properties": {
         "SCPCATOOLS_CONTAINER": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-tools:edge"
+          "default": "ghcr.io/alexslemonade/scpcatools:edge"
+        },
+        "SCPCATOOLS_SLIM_CONTAINER": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-slim:edge"
+        },
+        "SCPCATOOLS_ANNDATA_CONTAINER": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-anndata:edge"
+        },
+        "SCPCATOOLS_REPORTS_CONTAINER": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-reports:edge"
+        },
+        "SCPCATOOLS_SEURAT_CONTAINER": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-seurat:edge"
+        },
+        "SCPCATOOLS_SCVI_CONTAINER": {
+          "type": "string",
+          "default": "ghcr.io/alexslemonade/scpcatools-scvi:edge"
         },
         "ALEVINFRY_CONTAINER": {
           "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -345,7 +345,7 @@
         },
         "TIDYVERSE_CONTAINER": {
           "type": "string",
-          "default": "rocker/tidyverse:4.3.1"
+          "default": "rocker/tidyverse:4.4.0"
         },
         "VIREO_CONTAINER": {
           "type": "string",


### PR DESCRIPTION
Closes #760

This PR adds the new scpcaTools containers which upgrade everything to R 4.4.0 and Bioconductor 3.19. I tried to use the slimmest container I could find for each task, and I think I got them all correct, but a bit more testing will be required to be sure that all code paths are tests (which is what #761 is for!)

Before merging these into `main` we will need to cut a release of scpcaTools to fix the docker versions, which are currently set to `edge`.