### PR TITLE
Test new docker image and add test samples to profile config

### DIFF
--- a/config/profile_ccdl.config
+++ b/config/profile_ccdl.config
@@ -11,7 +11,9 @@ params {
   results_dir = "${params.outdir}/results"
 
   // a set of run_ids for testing. used only by the main workflow
-  run_ids = "SCPCR000001,SCPCS000101"
+  // one single-cell with bulk, one CITE, one spatial, one multiplexed
+  run_ids = "SCPCS000001,SCPCS000050,SCPCS000203,SCPCL000537"
+
   // include all runs in a merged project. used only by the merged workflow
   merge_run_ids = "All"
 


### PR DESCRIPTION
Closes #761 

I did some testing of the workflow using the changes from #762 and everything ran successfully 🎉 I did not however run anything through `CellAssign`... I can do that though if we would like before closing the testing out. 

To do the testing I was going to create a new test profile, but we already have a `ccdl` profile that specifies a subset of run IDs to run. So rather than create a new profile I'm using the existing `ccdl` profile but have updated the `run_ids` param to include one sample or library from each of the possible modalities - one single-cell with bulk, one CITE, one multiplexed, and one spatial. I think I got everything? 