### PR TITLE
Move bulk output to separate bulk directory

### DIFF
--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -68,7 +68,7 @@ process salmon {
 process merge_bulk_quants {
   container params.SCPCATOOLS_SLIM_CONTAINER
   label 'mem_8'
-  publishDir "${params.results_dir}/${meta.project_id}", mode: 'copy'
+  publishDir "${params.results_dir}/${meta.project_id}/bulk", mode: 'copy'
   tag "${meta.project_id}"
   input:
     tuple val(meta), path(salmon_directories), path(t2g_bulk)


### PR DESCRIPTION
Closes #766 
Closes #764 

Here I just added a `bulk` directory to the existing `publishDir` for the bulk output. This will mean both the quant and metadata files will be saved to `project_id/bulk`. 

While I was here I decided to update the order of the bulk metadata to match the project metadata and `single_cell_metadata.tsv` files that are on the Portal. 