### PR TITLE
Improve scanpy compatibility

### DIFF
--- a/bin/move_counts_anndata.py
+++ b/bin/move_counts_anndata.py
@@ -3,12 +3,15 @@
 # This script takes an AnnData object and checks for the `logcounts`
 # in layers. If present, `logcounts` is moved to `X` and `X` (which has the raw counts)
 # is moved to `raw.X`
+# In addition, any DataFrames in `obsm` are conerted to ndarrays
+
 
 import argparse
 import os
 import re
 
 import anndata as adata
+import pandas as pd
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -51,5 +54,10 @@ if "logcounts" in object.layers:
     object.uns["X_name"] = "logcounts"
     del object.layers["logcounts"]
 
-    # export object
-    object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)
+# convert DataFrames in obsm to ndarrays
+for key, value in object.obsm.items():
+    if isinstance(value, pd.DataFrame):
+        object.obsm[key] = value.to_numpy()
+
+# export object
+object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)

--- a/bin/move_counts_anndata.py
+++ b/bin/move_counts_anndata.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
+"""
+This script takes an AnnData object and checks for the `logcounts` in layers.
+If present, `logcounts` is moved to `X` and `X` (which has the raw counts) is moved to `raw.X`
 
-# This script takes an AnnData object and checks for the `logcounts`
-# in layers. If present, `logcounts` is moved to `X` and `X` (which has the raw counts)
-# is moved to `raw.X`
-# In addition, any DataFrames in `obsm` are conerted to ndarrays
-
+In addition, any DataFrames in `obsm` are conerted to ndarrays, highly variable genes are converted to a `var` column.
+If a `pca_meta_file` is provided, PCA variance statistics and standard creation values are in the format expected by scanpy.
+"""
 
 import argparse
 import os
 import re
 
-import anndata as adata
+import anndata
 import pandas as pd
 
 parser = argparse.ArgumentParser()
@@ -28,6 +29,12 @@ parser.add_argument(
     action="store_false",
     help="Output an uncompressed HDF5 file",
 )
+parser.add_argument(
+    "--pca_meta_file",
+    dest="pca_meta_file",
+    required=False,
+    help="Path to file with a table of variance explained by each PCA component",
+)
 
 args = parser.parse_args()
 
@@ -39,25 +46,55 @@ if not os.path.exists(args.anndata_file):
     raise FileExistsError("`input_anndata` does not exist.")
 elif not file_ext.search(args.anndata_file):
     raise ValueError(
-        "--input_anndata must end in either .hdf5, .h5, or .h5ad, and contain a processed AnnData object."
+        "input_anndata must end in either .hdf5, .h5, or .h5ad, and contain a processed AnnData adata."
     )
 
+# if there is a pca_meta_file, check that it exists and has a tsv extension
+if args.pca_meta_file:
+    if not os.path.exists(args.pca_meta_file):
+        raise FileExistsError("`pca_meta_file` does not exist.")
+    elif not args.pca_meta_file.endswith(".tsv"):
+        raise ValueError("`pca_meta_file` must end in .tsv.")
+
 # read in anndata
-object = adata.read_h5ad(args.anndata_file)
+adata = anndata.read_h5ad(args.anndata_file)
 
 # if logcounts is present
-if "logcounts" in object.layers:
-    # move X to raw.X by creating the raw object
-    object.raw = object
+if "logcounts" in adata.layers:
+    # move X to raw.X by creating the raw adata
+    adata.raw = adata
     # move logcounts to X and rename
-    object.X = object.layers["logcounts"]
-    object.uns["X_name"] = "logcounts"
-    del object.layers["logcounts"]
+    adata.X = adata.layers["logcounts"]
+    adata.uns["X_name"] = "logcounts"
+    del adata.layers["logcounts"]
 
 # convert DataFrames in obsm to ndarrays
-for key, value in object.obsm.items():
+for key, value in adata.obsm.items():
     if isinstance(value, pd.DataFrame):
-        object.obsm[key] = value.to_numpy()
+        adata.obsm[key] = value.to_numpy()
 
-# export object
-object.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)
+# convert highly variable genes to a column
+adata.var["highly_variable"] = adata.var.gene_ids.isin(
+    adata.uns["highly_variable_genes"]
+)
+
+# add pca adata to uns if pca_meta_file is provided in the format created by scanpy
+if args.pca_meta_file:
+    pca_meta = pd.read_csv(args.pca_meta_file, sep="\t", index_col=0)
+    if "variance" not in pca_meta.columns or "variance_ratio" not in pca_meta.columns:
+        raise ValueError(
+            "`pca_meta_file` must contain columns `variance` and `variance_ratio`"
+        )
+    pca_object = {
+        "param": {
+            "zero_center": True,
+            "use_highly_variable": True,
+            "mask_var": "highly_variable",
+        },
+        "variance": pca_meta["variance"].to_numpy(),
+        "variance_ratio": pca_meta["variance_ratio"].to_numpy(),
+    }
+    adata.uns["pca"] = pca_object
+
+# export adata
+adata.write_h5ad(args.anndata_file, compression="gzip" if args.compress else None)

--- a/bin/predict_cellassign.py
+++ b/bin/predict_cellassign.py
@@ -63,7 +63,7 @@ scvi.settings.seed = args.seed
 scvi.settings.num_threads = args.threads
 
 # compile extension regex
-file_ext = re.compile(r"\.h5ad$|\.hdf5$|.h5$", re.IGNORECASE)
+file_ext = re.compile(r"\.(hdf5|h5|h5ad)$", re.IGNORECASE)
 
 # check that input file exists, if it does exist, make sure it's an h5 file
 if not os.path.exists(args.anndata_file):
@@ -78,7 +78,7 @@ if not os.path.exists(args.reference):
     raise FileExistsError("--reference file not found.")
 
 # make sure output file path is tsv file
-if not args.output_predictions.endswith(".tsv"):
+if not args.output_predictions.casefold().endswith(".tsv"):
     raise ValueError("--output_predictions must provide a file path ending in tsv")
 
 # read in references as marker gene tables

--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -23,17 +23,17 @@ parser.add_argument(
     help="Path to HDF5 file with processed AnnData object",
 )
 parser.add_argument(
+    "--pca_meta_file",
+    dest="pca_meta_file",
+    required=False,
+    help="Path to file with a table of variance explained by each PCA component",
+)
+parser.add_argument(
     "-u",
     "--uncompressed",
     dest="compress",
     action="store_false",
     help="Output an uncompressed HDF5 file",
-)
-parser.add_argument(
-    "--pca_meta_file",
-    dest="pca_meta_file",
-    required=False,
-    help="Path to file with a table of variance explained by each PCA component",
 )
 
 args = parser.parse_args()

--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -38,7 +38,7 @@ parser.add_argument(
     "--mask_var",
     dest="mask_var",
     default="highly_variable",
-    help="Indicate that variable used for highly variable genes. Use the value 'None' if no highly variable genes were used.",
+    help="Indicate the name used to store highly variable genes associated with the PCA present in the exported AnnData object. Use the value 'None' if no highly variable genes were used.",
 )
 parser.add_argument(
     "-u",
@@ -100,8 +100,8 @@ if args.pca_meta_file:
     pca_object = {
         "param": {
             "zero_center": args.pca_centered,
-            "use_highly_variable": args.highly_variable.casefold() != "none",
-            "mask_var": args.highly_variable,
+            "use_highly_variable": args.mask_var.casefold() != "none",
+            "mask_var": args.mask_var,
         },
         "variance": pca_meta["variance"].to_numpy(),
         "variance_ratio": pca_meta["variance_ratio"].to_numpy(),

--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -29,6 +29,18 @@ parser.add_argument(
     help="Path to file with a table of variance explained by each PCA component",
 )
 parser.add_argument(
+    "--pca_not_centered",
+    dest="pca_centered",
+    action="store_false",
+    help="Indicate that the PCA table is not zero-centered",
+)
+parser.add_argument(
+    "--mask_var",
+    dest="mask_var",
+    default="highly_variable",
+    help="Indicate that variable used for highly variable genes. Use the value 'None' if no highly variable genes were used.",
+)
+parser.add_argument(
     "-u",
     "--uncompressed",
     dest="compress",
@@ -87,9 +99,9 @@ if args.pca_meta_file:
         )
     pca_object = {
         "param": {
-            "zero_center": True,
-            "use_highly_variable": True,
-            "mask_var": "highly_variable",
+            "zero_center": args.pca_centered,
+            "use_highly_variable": args.highly_variable.casefold() != "none",
+            "mask_var": args.highly_variable,
         },
         "variance": pca_meta["variance"].to_numpy(),
         "variance_ratio": pca_meta["variance_ratio"].to_numpy(),

--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -39,7 +39,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 # compile extension regex
-file_ext = re.compile(r"\.hdf5$|\.h5$|\.h5ad$", re.IGNORECASE)
+file_ext = re.compile(r"\.(hdf5|h5|h5ad)$", re.IGNORECASE)
 
 # check that input file exists, if it does exist, make sure it's an h5 file
 if not os.path.exists(args.anndata_file):
@@ -53,7 +53,7 @@ elif not file_ext.search(args.anndata_file):
 if args.pca_meta_file:
     if not os.path.exists(args.pca_meta_file):
         raise FileExistsError("`pca_meta_file` does not exist.")
-    elif not args.pca_meta_file.endswith(".tsv"):
+    elif not args.pca_meta_file.casefold().endswith(".tsv"):
         raise ValueError("`pca_meta_file` must end in .tsv.")
 
 # read in anndata

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -120,8 +120,8 @@ format_czi <- function(sce) {
   # so everything gets set to false
   rowData(sce)$feature_is_filtered <- FALSE
 
-  # paste X to any present reduced dim names
-  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+  # paste X to any present reduced dim names, converting to lower case
+  reducedDimNames(sce) <- glue::glue("X_{tolower(reducedDimNames(sce))}")
 
   return(sce)
 }

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -78,7 +78,7 @@ if (!is.null(opt$output_pca_tsv) && !stringr::str_ends(opt$output_pca_tsv, ".tsv
 # this function updates merged object formatting for anndata export
 format_merged_sce <- function(sce) {
   # paste X to any present reduced dim names
-  reducedDimNames(sce) <- glue::glue("X_{reducedDimNames(sce)}")
+  reducedDimNames(sce) <- glue::glue("X_{tolower(reducedDimNames(sce))}")
   return(sce)
 }
 

--- a/merge.nf
+++ b/merge.nf
@@ -109,8 +109,8 @@ process export_anndata {
         ${has_adt ? "--feature_name adt" : ''}
 
       # move normalized counts to X in AnnData
-      move_counts_anndata.py --anndata_file ${rna_h5ad_file}
-      ${has_adt ? "move_counts_anndata.py --anndata_file ${feature_h5ad_file}" : ''}
+      reformat_anndata.py --anndata_file ${rna_h5ad_file}
+      ${has_adt ? "reformat_anndata.py --anndata_file ${feature_h5ad_file}" : ''}
       """
     stub:
       rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"


### PR DESCRIPTION
Closes #773

I'm filing this as a draft because I have not yet really tested it, but I wanted to get something up while it was fresh in my mind.

The goal here is to improve the compatibility with scanpy as described in #773, so I have done 4 main things:

- Use lower case for `X_pca` and `X_umap` to match scanpy.
- Convert the PCA and UMAP matrices to numpy matrices.
- add a `highly_variable` column to the `var` table
- Add PCA metadata to `uns`

The last step involves exporting the variance explained data and then importing that separately, with the assumption that the PCA was centered and highly variable genes were used. I could (and probably should) make those assumptions into arguments for the script just to be safe and maybe a bit future-proof. 

There are probably also a few places where I am making other assumptions that I should check more explicitly. As I said, a draft...

I also renamed the script to be a bit more generally named, but annoyingly there were apparently enough changes that GitHub is not displaying it as a rename but as a deletion and recreation. Probably because it was run through a code formatter automatically. 