### PR TITLE
Add parameter for maximum number of libraries to allow when merging

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -61,7 +61,7 @@ params {
 
   // Merge workflow-specfic options
   params.reuse_merge = false // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
-  params.max_merge_libraries = 100 // maximum number of libraries to merge
+  params.max_merge_libraries = 100 // maximum number of libraries that can be merged
 
   // Docker container images
   includeConfig 'config/containers.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,7 +61,7 @@ params {
 
   // Merge workflow-specfic options
   params.reuse_merge = false // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
-
+  params.max_merge_libraries = 100 // maximum number of libraries to merge
 
   // Docker container images
   includeConfig 'config/containers.config'


### PR DESCRIPTION
Closes #776 

In processing data for the Portal, we have seen that projects with > 100 libraries do not successfully run through the merge workflow due to what we think is limitations of the packages we use. We don't actually know the number of libraries that cause the problem and it's probably based on number of cells and how big the actual matrices are, but as of right now we do not include any [projects with > 100 libraries as merged objects on the Portal](https://scpca.readthedocs.io/en/stable/faq.html#which-projects-can-i-download-as-merged-objects). 

Because of this, I'm adding a parameter to specify the maximum number of libraries allowed in a merged object and setting the default to 100. If any projects have more than this, then we will print a message to the log files and skip processing that sample. 