### PR TITLE
Update versions and bug fix for v0.8.3

### DIFF
--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -40,7 +40,7 @@ parser.add_argument(
     default="highly_variable_genes",
     help=(
         "Indicate the name used to store highly variable genes associated with the PCA in the exported AnnData object."
-        " Use the value 'none' if no highly variable genes were not used."
+        " Use the value 'none' if no highly variable genes were used."
     ),
 )
 parser.add_argument(

--- a/bin/reformat_anndata.py
+++ b/bin/reformat_anndata.py
@@ -40,7 +40,7 @@ parser.add_argument(
     default="highly_variable_genes",
     help=(
         "Indicate the name used to store highly variable genes associated with the PCA in the exported AnnData object."
-        " Use the value 'none' if no highly variable genes were used."
+        "Use the value 'none' if no highly variable genes were used."
     ),
 )
 parser.add_argument(

--- a/bin/sce_to_anndata.R
+++ b/bin/sce_to_anndata.R
@@ -232,5 +232,6 @@ if (!is.null(opt$feature_name)) {
         ")
       )
     }
+    message("Exported alt")
   }
 }

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -86,12 +86,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.8.2` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.8.3` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.8.2 \
+  -r v0.8.3 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -325,7 +325,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.8.2`, then you will want to set `-r v0.8.2` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.8.3`, then you will want to set `-r v0.8.3` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -87,7 +87,7 @@ Please refer to our [`CONTRIBUTING.md`](CONTRIBUTING.md#stub-workflows) for more
 When running the workflow for a project or group of samples that is ready to be released on ScPCA portal, please use the tag for the latest release:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.8.2 -profile ccdl,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.8.3 -profile ccdl,batch --project SCPCP000000
 ```
 
 ### Processing example data

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -28,7 +28,7 @@ process export_anndata {
         reformat_anndata.py --anndata_file ${rna_h5ad_file} --pca_meta_file ${pca_meta_file}
         # move counts in feature data, if the file exists
         if [ -f "${feature_h5ad_file}" ]; then
-          reformat_anndata.py --anndata_file ${feature_h5ad_file}
+          reformat_anndata.py --anndata_file ${feature_h5ad_file} --hvg_name "none"
         fi
       fi
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   homePage = 'https://github.com/AlexsLemonade/scpca-nf'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = 'v0.8.2'
+  version = 'v0.8.3'
 }
 
 // global parameters for workflows


### PR DESCRIPTION
Here I'm updating the release version to be v0.8.3. 

I also did a test run and found a small bug where we were trying to access hvg's in the ADT AnnData objects, which don't exist. So I fixed that by using the `--hvg_name "none"` option. 