### PR TITLE
Only count single cell libraries for max merged

### DIFF
--- a/merge.nf
+++ b/merge.nf
@@ -163,6 +163,7 @@ workflow {
       .map{it.unique()}
 
     oversized_projects = libraries_ch
+      .filter{it.technology.startsWith("10X")} // only count single-cell or single-nuclei libraries, no cell hash, ADT, bulk or spatial
       .map{[
         it.project_id, // pull out project id for grouping
         it


### PR DESCRIPTION
I was going to generate all merged libraries and projects that I wouldn't expect to reach the limit of 100 libraries were not getting processed. Looks like we were counting all libraries in a project including any CITE seq, spatial, or bulk. Here I just add a filtering statement to remove those libraries prior to counting how many are in a project. 

My plan is to merge this in to `development` and then into `main`. 