### PR TITLE
Account for different HVG name in merged object

### DIFF
--- a/merge.nf
+++ b/merge.nf
@@ -109,8 +109,8 @@ process export_anndata {
         ${has_adt ? "--feature_name adt" : ''}
 
       # move normalized counts to X in AnnData
-      reformat_anndata.py --anndata_file ${rna_h5ad_file}
-      ${has_adt ? "reformat_anndata.py --anndata_file ${feature_h5ad_file}" : ''}
+      reformat_anndata.py --anndata_file ${rna_h5ad_file} --hvg_name "merged_highly_variable_genes"
+      ${has_adt ? "reformat_anndata.py --anndata_file ${feature_h5ad_file} --hvg_name 'none' " : ''}
       """
     stub:
       rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"


### PR DESCRIPTION
One more fix for the merged object workflow. They have a different name for HVGs that need to be specified using the new reformatting script so I updated that here. Note that I tested this on an object that was failing and it worked as expected. 