### PR TITLE
convert addParams to take

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -31,10 +31,10 @@ celltype_report_template_file = "celltypes_supplemental_report.rmd"
 report_template_tuple = tuple(report_template_dir, report_template_file, celltype_report_template_file)
 
 // include processes from modules
-include { map_quant_rna } from './modules/af-rna.nf' addParams(cell_barcodes: cell_barcodes)
-include { map_quant_feature } from './modules/af-features.nf' addParams(cell_barcodes: cell_barcodes)
+include { map_quant_rna } from './modules/af-rna.nf'
+include { map_quant_feature } from './modules/af-features.nf'
 include { bulk_quant_rna } from './modules/bulk-salmon.nf'
-include { genetic_demux_vireo } from './modules/genetic-demux.nf' addParams(cell_barcodes: cell_barcodes, bulk_techs: bulk_techs)
+include { genetic_demux_vireo } from './modules/genetic-demux.nf'
 include { spaceranger_quant } from './modules/spaceranger.nf'
 include { generate_sce; generate_merged_sce; cellhash_demux_sce; genetic_demux_sce; post_process_sce} from './modules/sce-processing.nf'
 include { cluster_sce } from './modules/cluster-sce.nf'
@@ -202,7 +202,7 @@ workflow {
   bulk_quant_rna(runs_ch.bulk)
 
   // **** Process RNA-seq data ****
-  map_quant_rna(runs_ch.rna)
+  map_quant_rna(runs_ch.rna, cell_barcodes)
 
   // get RNA-only libraries
   rna_quant_ch = map_quant_rna.out
@@ -222,7 +222,7 @@ workflow {
     }
 
   // **** Process feature data ****
-  map_quant_feature(runs_ch.feature)
+  map_quant_feature(runs_ch.feature, cell_barcodes)
 
   // join feature & RNA quants for feature reads
   feature_rna_quant_ch = map_quant_feature.out
@@ -266,7 +266,7 @@ workflow {
   // **** Perform Genetic Demultiplexing ****
   genetic_multiplex_run_ch = runs_ch.rna
     .filter{it.library_id in genetic_multiplex_libs.getVal()}
-  genetic_demux_vireo(genetic_multiplex_run_ch, unfiltered_runs_ch)
+  genetic_demux_vireo(genetic_multiplex_run_ch, unfiltered_runs_ch, cell_barcodes, bulk_techs)
 
 
   // join demux result with SCE output (fail if there are any missing or extra libraries)

--- a/modules/af-features.nf
+++ b/modules/af-features.nf
@@ -138,8 +138,9 @@ process fry_quant_feature {
 
 
 workflow map_quant_feature {
-  take: feature_channel
-  // a channel with a groovy map of metadata for each feature barcode library to process
+  take:
+    feature_channel // a channel with a groovy map of metadata for each feature barcode library to process
+    cell_barcodes // map of cell barcode files for each technology
   main:
     //get and map the feature barcode files
     feature_barcodes_ch = feature_channel
@@ -156,7 +157,7 @@ workflow map_quant_feature {
         def meta = it.clone();
         meta.feature_rad_publish_dir = "${params.checkpoints_dir}/rad/${meta.library_id}";
         meta.feature_rad_dir = "${meta.feature_rad_publish_dir}/${meta.run_id}-features";
-        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
+        meta.barcode_file = "${params.barcode_dir}/${cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
       // branch based on whether mapping should be run (make_rad) or skipped (has_rad)

--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -108,8 +108,10 @@ process fry_quant_rna {
 
 
 workflow map_quant_rna {
-  take: rna_channel
-  // a channel with a map of metadata for each rna library to process
+
+  take:
+    rna_channel // a channel with a map of metadata for each rna library to process
+    cell_barcodes // map of cell barcode files for each technology
   main:
     // add rad publish directory, rad directory, and barcode file to meta
     rna_channel = rna_channel
@@ -117,7 +119,7 @@ workflow map_quant_rna {
         def meta = it.clone();
         meta.rad_publish_dir = "${params.checkpoints_dir}/rad/${meta.library_id}";
         meta.rad_dir = "${meta.rad_publish_dir}/${meta.run_id}-rna";
-        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
+        meta.barcode_file = "${params.barcode_dir}/${cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
        // branch based on whether mapping should be run (make_rad) or skipped (has_rad)

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -10,6 +10,8 @@ workflow genetic_demux_vireo {
   take:
     multiplex_run_ch
     unfiltered_runs_ch
+    cell_barcodes // map of cell barcode files for each technology
+    bulk_techs // list of bulk technologies
   main:
     // add vireo publish directory, vireo directory, and barcode file to meta
     multiplex_ch = multiplex_run_ch
@@ -17,7 +19,7 @@ workflow genetic_demux_vireo {
         def meta = it.clone();
         meta.vireo_publish_dir = "${params.checkpoints_dir}/vireo";
         meta.vireo_dir = "${meta.vireo_publish_dir}/${meta.library_id}-vireo";
-        meta.barcode_file = "${params.barcode_dir}/${params.cell_barcodes[meta.technology]}";
+        meta.barcode_file = "${params.barcode_dir}/${cell_barcodes[meta.technology]}";
         meta // return modified meta object
       }
        // split based in whether repeat_genetic_demux is true and a previous dir exists
@@ -48,7 +50,7 @@ workflow genetic_demux_vireo {
 
     // make a channel of the bulk samples we need to process
     bulk_ch = unfiltered_runs_ch
-      .filter{it.technology in params.bulk_techs}
+      .filter{it.technology in bulk_techs}
       .filter{it.sample_id in bulk_samples.getVal()}
 
     // map bulk samples

--- a/modules/genetic-demux.nf
+++ b/modules/genetic-demux.nf
@@ -60,7 +60,7 @@ workflow genetic_demux_vireo {
     pileup_multibulk(multiplex_ch.make_demux, star_bulk.out)
 
     // map multiplexed single cell samples
-    starsolo_map(multiplex_ch.make_demux)
+    starsolo_map(multiplex_ch.make_demux, cell_barcodes)
 
     // call cell snps and genotype cells
     cellsnp_vireo(starsolo_map.out.bam,  starsolo_map.out.quant, pileup_multibulk.out)

--- a/modules/starsolo.nf
+++ b/modules/starsolo.nf
@@ -57,6 +57,7 @@ process starsolo {
 workflow starsolo_map {
   take:
     singlecell_ch
+    cell_barcodes
 
   main:
     sc_reads_ch = singlecell_ch
@@ -64,7 +65,7 @@ workflow starsolo_map {
         meta,
         file("${meta.files_directory}/*_R1_*.fastq.gz"),
         file("${meta.files_directory}/*_R2_*.fastq.gz"),
-        file("${params.barcode_dir}/${params.cell_barcodes[meta.technology]}"),
+        file("${params.barcode_dir}/${cell_barcodes[meta.technology]}"),
         file(meta.star_index, type: 'dir')
       )}
     starsolo(sc_reads_ch)


### PR DESCRIPTION
When doing some testing related to #792 with newer versions of Nextflow, I got warnings that the `addParams()` function was deprecated, so I made some changes to remove that syntax, instead using `take:` to pass the values. Turns out I like this syntax better anyway!

closes #791 

