### PR TITLE
Update GHA artifacts

### DIFF
--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nextflow-log
           path: nextflow-runs.log

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -8,35 +8,39 @@ on:
       - development
       - main
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+concurrency:
+  # only one run per branch at a time
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # This workflow contains a single job called "spell check"
-  spell-check:
+  spellcheck:
     runs-on: ubuntu-latest
-    container:
-      image: rocker/tidyverse:4.2.3
+    name: Spell check files
+    permissions:
+      contents: read
+      issues: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Install packages
-        run: Rscript --vanilla -e "install.packages(c('spelling'), repos = c(CRAN = '$CRAN'))"
-
-      - name: Run spell check
-        id: spell_check_run
-        run: |
-          results=$(Rscript --vanilla "scripts/spell-check.R")
-          echo "sp_chk_results=$results" >> $GITHUB_OUTPUT
-          cat spell_check_errors.tsv
-
-      - name: Archive spelling errors
-        uses: actions/upload-artifact@v3
+      - name: Spell check action
+        uses: alexslemonade/spellcheck@v0
+        id: spell
         with:
-          name: spell-check-results
+          dictionary: components/dictionary.txt
+
+      - name: Upload spell check errors
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        with:
+          name: spell_check_errors
           path: spell_check_errors.tsv
 
-      # If there are too many spelling errors, this will stop the workflow
-      - name: Check spell check results - fail if too many errors
-        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 0 }}
-        run: exit 1
+      - name: Fail if there are spelling errors
+        if: steps.spell.outputs.error_count > 0
+        run: |
+          echo "There were ${{ steps.spell.outputs.error_count }} errors"
+          column -t spell_check_errors.tsv
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # scpca-nf
 
+speeling
+
 This repository holds a [Nextflow](https://www.nextflow.io) workflow (`scpca-nf`) that is used to process 10X single-cell data as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).
 All dependencies for the workflow outside of the Nextflow workflow engine itself are handled automatically; setup generally requires only organizing the input files and configuring Nextflow for your computing environment.
 Nextflow will also handle parallelizing sample processing as allowed by your environment, minimizing total run time.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # scpca-nf
 
-speeling
-
 This repository holds a [Nextflow](https://www.nextflow.io) workflow (`scpca-nf`) that is used to process 10X single-cell data as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).
 All dependencies for the workflow outside of the Nextflow workflow engine itself are handled automatically; setup generally requires only organizing the input files and configuring Nextflow for your computing environment.
 Nextflow will also handle parallelizing sample processing as allowed by your environment, minimizing total run time.


### PR DESCRIPTION
Closes #805 

This PR updates two workflows:
- The stub workflow gets bumped from artifact v3 -> v4
- The spellcheck workflow gets replaced with a new workflow using our spellcheck repo
  - I did not delete the spell check script since it's used by pre-commit. If we prefer to also use the spellcheck repo for precommit, then we'd need to add a `.pre-commit-hooks.yaml` file to it, which maybe we should just go ahead and do? 

I'm opening this as a draft to confirm first that the GHA works and detects a typo I added in.