### PR TITLE
Account for samples being both PDX and cell line

### DIFF
--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -213,7 +213,8 @@ sample_type <- sample_metadata_df |>
 
 # unname if length is 1, and add to sce metadata
 if (length(sample_type) == 1) {
-  sample_type <- unname(sample_type)
+  sample_type <- unlist(sample_type) |>
+    unname()
 }
 metadata(unfiltered_sce)$sample_type <- sample_type
 

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -197,6 +197,8 @@ sample_type <- sample_metadata_df |>
   dplyr::filter(sample_id %in% sample_ids) |>
   dplyr::mutate(
     sample_type = dplyr::case_when(
+      # account for sample being both cell line and PDX
+      is_xenograft & is_cell_line ~ c("cell line", "patient-derived xenograft"),
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
       # if neither column was provided, note that

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -198,7 +198,7 @@ sample_type <- sample_metadata_df |>
   dplyr::mutate(
     sample_type = dplyr::case_when(
       # account for sample being both cell line and PDX
-      is_xenograft & is_cell_line ~ c("cell line", "patient-derived xenograft"),
+      is_xenograft & is_cell_line ~ "cell line, patient-derived xenograft",
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
       # if neither column was provided, note that
@@ -207,8 +207,9 @@ sample_type <- sample_metadata_df |>
     )
   ) |>
   dplyr::select(sample_id, sample_type) |>
-  # convert into named vector
-  tibble::deframe()
+  # convert into named list
+  tibble::deframe() |>
+  strsplit(sample_type, split = ", ")
 
 # unname if length is 1, and add to sce metadata
 if (length(sample_type) == 1) {

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -209,7 +209,7 @@ sample_type <- sample_metadata_df |>
   dplyr::select(sample_id, sample_type) |>
   # convert into named list
   tibble::deframe() |>
-  strsplit(sample_type, split = ", ")
+  strsplit(split = ", ")
 
 # unname if length is 1, and add to sce metadata
 if (length(sample_type) == 1) {

--- a/bin/generate_unfiltered_sce.R
+++ b/bin/generate_unfiltered_sce.R
@@ -198,7 +198,7 @@ sample_type <- sample_metadata_df |>
   dplyr::mutate(
     sample_type = dplyr::case_when(
       # account for sample being both cell line and PDX
-      is_xenograft & is_cell_line ~ "cell line, patient-derived xenograft",
+      is_xenograft & is_cell_line ~ "cell line;patient-derived xenograft",
       is_xenograft ~ "patient-derived xenograft",
       is_cell_line ~ "cell line",
       # if neither column was provided, note that
@@ -209,7 +209,7 @@ sample_type <- sample_metadata_df |>
   dplyr::select(sample_id, sample_type) |>
   # convert into named list
   tibble::deframe() |>
-  strsplit(split = ", ")
+  strsplit(split = ";")
 
 # unname if length is 1, and add to sce metadata
 if (length(sample_type) == 1) {

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -80,7 +80,7 @@ print_sample_metadata <- function(meta_list) {
       "Age" = url_list$age,
       "Sex" = url_list$sex,
       "Organism" = url_list$organism,
-      "Sample type" = meta_list$sample_type
+      "Sample type" = paste0(meta_list$sample_type, collapse = ", ")
     ) |>
       t() |>
       # account for html links


### PR DESCRIPTION
Closes #808 

This PR makes some minor adjustments to how we handle `sample_type` to account for samples that are both a PDX and a cell line. I modified the existing code so that the `sample_type` option can now be a vector with `cell line` and `patient-derived xenograft`. 

I had to make a small change to the table in the report to combine into a single string, otherwise it printed two columns for the sample table. I tested this with the sample this applies to and did a test run using one of each sample type and everything looks as expected. 

Here's an example of the report for the affected sample. 
[SCPCL001201_qc.html.zip](https://github.com/user-attachments/files/18540965/SCPCL001201_qc.html.zip)
