### PR TITLE
Add bulk TPM output to scpca-nf

### DIFF
--- a/bin/tximport_bulk.R
+++ b/bin/tximport_bulk.R
@@ -2,7 +2,7 @@
 
 # This script grabs the quant.sf output files from Salmon for all samples within a project
 # The files are then imported use tximport to generate a gene x count matrix
-# Output includes a counts matrix as a tab separated tsv file and a .Rds object containing the tximport object
+# Outputs a counts matrix and TPM matrix as separate TSV files.
 
 
 # load needed packages
@@ -23,9 +23,14 @@ option_list <- list(
     help = "Path to text file containing salmon output directories, one per line."
   ),
   make_option(
-    opt_str = c("-o", "--output_file"),
+    opt_str = c("-c", "--counts_file"),
     type = "character",
-    help = "Path to output RDS file, must end in .rds"
+    help = "Path to output counts matrix file."
+  ),
+  make_option(
+    opt_str = c("-m", "--tpm_file"),
+    type = "character",
+    help = "Path to output TPM matrix file."
   ),
   make_option(
     opt_str = c("-t", "--tx2gene"),
@@ -48,8 +53,14 @@ names(salmon_files) <- library_ids
 # import using tximport
 txi_salmon <- tximport(salmon_files, type = "salmon", tx2gene = tx2gene)
 
-# write counts matrix to txt file
+# write counts matrix to text file
 txi_salmon$counts |>
+  as.data.frame() |>
+  tibble::rownames_to_column("gene_id") |>
+  readr::write_tsv(file = opt$count_file)
+
+# write TPM matrix to text file
+txi_salmon$abundance |>
   as.data.frame() |>
   tibble::rownames_to_column("gene_id") |>
   readr::write_tsv(file = opt$output_file)

--- a/bin/tximport_bulk.R
+++ b/bin/tximport_bulk.R
@@ -57,10 +57,10 @@ txi_salmon <- tximport(salmon_files, type = "salmon", tx2gene = tx2gene)
 txi_salmon$counts |>
   as.data.frame() |>
   tibble::rownames_to_column("gene_id") |>
-  readr::write_tsv(file = opt$count_file)
+  readr::write_tsv(file = opt$counts_file)
 
 # write TPM matrix to text file
 txi_salmon$abundance |>
   as.data.frame() |>
   tibble::rownames_to_column("gene_id") |>
-  readr::write_tsv(file = opt$output_file)
+  readr::write_tsv(file = opt$tpm_file)

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -42,6 +42,7 @@ reproducibly
 scpca
 ScPCA
 subdiagnosis
+TPM
 transcriptome
 transcriptomic
 TSV

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -469,18 +469,22 @@ See below for the expected structure of the `results` folder:
 
 ```
 results
-└── sample_id
-    ├── library_id_unfiltered.rds
-    ├── library_id_filtered.rds
-    ├── library_id_processed.rds
-    ├── library_id_unfiltered_rna.h5ad
-    ├── library_id_filtered_rna.h5ad
-    ├── library_id_processed_rna.h5ad
-    ├── library_id_metadata.json
-    └── library_id_qc.html
+└── {project_id}
+    └── {sample_id}
+        ├── {library_id}_unfiltered.rds
+        ├── {library_id}_filtered.rds
+        ├── {library_id}_processed.rds
+        ├── {library_id}_unfiltered_rna.h5ad
+        ├── {library_id}_filtered_rna.h5ad
+        ├── {library_id}_processed_rna.h5ad
+        ├── {library_id}_metadata.json
+        └── {library_id}_qc.html
 ```
 
-If bulk libraries were processed, a `bulk_quant.tsv` and `bulk_metadata.tsv` summarizing the counts data and metadata across all libraries will also be present in the `results` directory.
+If bulk libraries were processed, the following three files will also be present in the `project_id` directory:
+- `{project_id}_bulk_metadata.tsv`: a summary table of metadata across all project bulk libraries
+- `{project_id}_bulk_quant.tsv`: a matrix of gene expression count values for all bulk libraries
+- `{project_id}_bulk_tpm.tsv`: a matrix of gene expression TPM values for all bulk libraries
 
 If you performed cell type annotation, an additional QC report specific to cell typing results called `library_id_celltype-report.html` will also be present in the `results` directory.
 


### PR DESCRIPTION
Closes #815

I was looking at `scpca-nf`, and realized that the changes to add TPM output were quite minimal, so I went ahead and did that. I left the count file name unchanged, despite its ambiguity, and simply added one more output file, in the same directory. 

Since the script name seemed a bit out of date, I modified that as well.