### PR TITLE
Fix contributors formatting

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -8,28 +8,27 @@ manifest {
   nextflowVersion = '>=24.09'
   version = 'v0.8.6'
   contributors = [
-    {
-      name = "Allegra Hawkins"
-      affiliation = "Alex's Lemonade Stand Foundation"
-      contribution = "author"
-      github = "https://github.com/allyhawkins"
-      orcid = "https://orcid.org/0000-0001-6026-3660"
-
-    },
-    {
-      name = "Joshua A. Shapiro"
-      affiliation = "Alex's Lemonade Stand Foundation"
-      contribution = "author"
-      github = "https://github.com/jashapiro"
-      orcid = "https://orcid.org/0000-0002-6224-0347"
-    },
-    {
-      name = "Stephanie J. Spielman"
-      affiliation = "Alex's Lemonade Stand Foundation"
-      contribution = "author"
-      github = "https://github.com/sjspielman"
-      orcid = "https://orcid.org/0000-0002-9090-4788"
-    }
+    [
+      name: "Allegra Hawkins",
+      affiliation: "Alex's Lemonade Stand Foundation",
+      contribution: "author",
+      github: "https://github.com/allyhawkins",
+      orcid: "https://orcid.org/0000-0001-6026-3660"
+    ],
+    [
+      name: "Joshua A. Shapiro",
+      affiliation: "Alex's Lemonade Stand Foundation",
+      contribution: "author",
+      github: "https://github.com/jashapiro",
+      orcid: "https://orcid.org/0000-0002-6224-0347"
+    ],
+    [
+      name: "Stephanie J. Spielman",
+      affiliation: "Alex's Lemonade Stand Foundation",
+      contribution: "author",
+      github: "https://github.com/sjspielman",
+      orcid: "https://orcid.org/0000-0002-9090-4788"
+    ]
   ]
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,21 +11,21 @@ manifest {
     [
       name: "Allegra Hawkins",
       affiliation: "Alex's Lemonade Stand Foundation",
-      contribution: "author",
+      contribution: ["author"],
       github: "https://github.com/allyhawkins",
       orcid: "https://orcid.org/0000-0001-6026-3660"
     ],
     [
       name: "Joshua A. Shapiro",
       affiliation: "Alex's Lemonade Stand Foundation",
-      contribution: "author",
+      contribution: ["author"],
       github: "https://github.com/jashapiro",
       orcid: "https://orcid.org/0000-0002-6224-0347"
     ],
     [
       name: "Stephanie J. Spielman",
       affiliation: "Alex's Lemonade Stand Foundation",
-      contribution: "author",
+      contribution: ["author"],
       github: "https://github.com/sjspielman",
       orcid: "https://orcid.org/0000-0002-9090-4788"
     ]


### PR DESCRIPTION
Apparently the contributors field requires specific formatting, and I had it wrong. What I had works fine for local runs, but causes trouble when using Seqera Tower. This should now be the correct format.