### PR TITLE
Remove SPATIAL_RNA_COUNTER_CS

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -31,6 +31,9 @@ process spaceranger {
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
 
+    # remove Space Ranger intermediates directory
+    rm -rf ${out_id}/SPATIAL_RNA_COUNTER_CS
+
     # remove bam and bai files
     rm ${out_id}/outs/*.bam*
     """


### PR DESCRIPTION
Closes #818, if we want to. 

This is a very small PR, but as noted in #818, it may actually have some substantial savings both in storage costs and maybe even a bit of run time (since it prevents copying files to and from the work directory). 

I can't see a downside at the moment, but I am well aware I could be missing something. 