### PR TITLE
Add consensus cell type assignments to processed objects

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -298,7 +298,7 @@ if (has_singler & has_cellassign) {
         "singler_celltype_ontology" = "blueprint_ontology",
         "cellassign_celltype_ontology" = "panglao_ontology"
       ),
-      relationship = "many-to-many"
+      relationship = "many-to-many" # account for multiple of the same cell type
     ) |>
     # use unknown for NA annotation but keep ontology ID as NA
     # if the sample type is cell line, keep as NA

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -106,7 +106,7 @@ sce <- readr::read_rds(opt$input_sce_file)
 
 if (file.exists(opt$singler_results)) {
   # check singler model has been provided
-  stopifnot("Singler model file does not exist" = file.exists(opt$singler_model_file))
+  stopifnot("Singler model filename must be provided" = opt$singler_model_file != "")
 
   has_singler <- TRUE # use to decide if we should assign consensus labels
   singler_results <- readr::read_rds(opt$singler_results)
@@ -187,11 +187,11 @@ if (file.exists(opt$singler_results)) {
 # CellAssign results -----------------------------------------------------------
 
 if (file.exists(opt$cellassign_predictions)) {
-  # check that cellassign predictions file exists
+  # check that cellassign reference info is provided
   stopifnot(
-    "CellAssign reference file does not exist" = file.exists(opt$cellassign_ref_file),
+    "CellAssign reference filename must be provided" = opt$cellassign_ref_file != "",
     "Cell type reference metadata file does not exist" = file.exists(opt$celltype_ref_metafile),
-    "Panglo ontology reference file does not exist" = !is.null(opt$panglao_ontology_ref)
+    "Panglo ontology reference file does not exist" = file.exists(opt$panglao_ontology_ref)
   )
 
   # read in panglao ontology reference
@@ -291,8 +291,7 @@ if (has_singler & has_cellassign) {
       consensus_ref_df,
       by = c(
         "singler_celltype_ontology" = "blueprint_ontology",
-        "cellassign_celltype_ontology" = "panglao_ontology",
-        "panglao_ontology"
+        "cellassign_celltype_ontology" = "panglao_ontology"
       )
     ) |>
     # use unknown for NA annotation but keep ontology ID as NA

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -22,6 +22,11 @@ singler_references_dir = "${params.celltype_ref_dir}/singler_references"
 singler_models_dir = "${params.celltype_ref_dir}/singler_models"
 cellassign_ref_dir = "${params.celltype_ref_dir}/cellassign_references"
 
+// Reference file used for assigning ontology IDs for CellAssign results and consensus cell types
+// Originally created in the `cell-type-consensus` module of `OpenScPCA-analysis`
+panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
+consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
+
 // cell type metadata for building references in `build-celltype-ref.nf`; not used by main workflow
 celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"
 panglao_marker_genes_file = "${projectDir}/references/PanglaoDB_markers_2020-03-27.tsv"

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -24,8 +24,8 @@ cellassign_ref_dir = "${params.celltype_ref_dir}/cellassign_references"
 
 // Reference file used for assigning ontology IDs for CellAssign results and consensus cell types
 // Originally created in the `cell-type-consensus` module of `OpenScPCA-analysis`
-panglao_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv'
-consensus_ref_file = 'https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv'
+panglao_ref_file = "${projectDir}/references/panglao-cell-type-ontologies.tsv"
+consensus_ref_file = "${projectDir}/references/consensus-cell-type-reference.tsv"
 
 // cell type metadata for building references in `build-celltype-ref.nf`; not used by main workflow
 celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -216,7 +216,7 @@
         },
         "panglao_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv",
+          "default": "${projectDir}/references/panglao-cell-type-ontologies.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",
@@ -224,7 +224,7 @@
         },
         "consensus_ref_file": {
           "type": "string",
-          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
+          "default": "${projectDir}/references/consensus-cell-type-reference.tsv",
           "pattern": "\\.tsv$",
           "format": "file-path",
           "mimetype": "text/tab-separated-values",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -213,6 +213,22 @@
           "mimetype": "text/tab-separated-values",
           "hidden": true,
           "description": "Panglao marker genes file, used in `build-celltype-ref.nf`."
+        },
+        "panglao_ref_file": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv",
+          "pattern": "\\.tsv$",
+          "format": "file-path",
+          "mimetype": "text/tab-separated-values",
+          "description": "PanglaoDB cell type reference file containing Cell Ontology terms for PanglaoDB cell types"
+        },
+        "consensus_ref_file": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/tags/v0.2.2/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
+          "pattern": "\\.tsv$",
+          "format": "file-path",
+          "mimetype": "text/tab-separated-values",
+          "description": "Consensus cell types reference file"
         }
       }
     },

--- a/references/README.md
+++ b/references/README.md
@@ -19,3 +19,28 @@ These files are used by `build-celltype-ref.nf` to generate cell type annotation
 
 - `celltype-reference-metadata.tsv` provides information about the name, source, and contents of cell type annotation references established by the Data Lab for use with `SingleR` and `CellAssign`.
 - `PanglaoDB_markers_<date>.tsv` is the full set of marker genes exported from [PanglaoDB](https://panglaodb.se), versioned at the given date.
+
+These files are copies of reference files that were created as part of `OpenScPCA`. 
+See the [`cell-type-consensus` module as part of the `OpenScPCA-analysis` repository](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-consensus) to learn more about how these file were originally created. 
+
+- `panglao-cell-type-ontologies.tsv` contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `PanglaoDB` reference used when running `CellAssign`. 
+The table includes the following columns:
+
+|  |   |
+| --- | --- |
+| `ontology_id` | [cell type (CL) ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) |
+| `human_readable_value` | Label associated with the cell type ontology term |
+| `panglao_cell_type` | Original name for the cell type as set by `PanglaoDB` |
+
+- `consensus-cell-type-reference.tsv` contains a table with all cell type combinations between the `PanglaoDB` reference and `BlueprintEncodeData` reference for which a consensus cell type is identified.  
+The table includes the following columns: 
+
+|  |   |
+| --- | --- |
+| `panglao_ontology` | Cell type ontology term for `PanglaoDB` cell type |
+| `panglao_annotation` | Name for the `panglao_ontology` term as defined by [Cell Ontology](https://www.ebi.ac.uk/ols4/ontologies/cl) |
+| `original_panglao_name` | Original name for the cell type as set by `PanglaoDB` |
+| `blueprint_ontology` | Cell type ontology term for `BlueprintEncodeData` cell type |
+| `blueprint_annotation_cl` | Name for the `blueprint_ontology` term as defined by [Cell Ontology](https://www.ebi.ac.uk/ols4/ontologies/cl) |
+| `consensus_ontology` | Cell type ontology term for consensus cell type |
+| `consensus_annotation` | Name for the `consensus_ontology` term as defined by [Cell Ontology](https://www.ebi.ac.uk/ols4/ontologies/cl) |

--- a/references/README.md
+++ b/references/README.md
@@ -21,7 +21,7 @@ These files are used by `build-celltype-ref.nf` to generate cell type annotation
 - `PanglaoDB_markers_<date>.tsv` is the full set of marker genes exported from [PanglaoDB](https://panglaodb.se), versioned at the given date.
 
 These files are copies of reference files that were created as part of `OpenScPCA`. 
-See the [`cell-type-consensus` module as part of the `OpenScPCA-analysis` repository](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-consensus) to learn more about how these file were originally created. 
+See the [`cell-type-consensus` module as part of the `OpenScPCA-analysis` repository](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/v0.2.2/analyses/cell-type-consensus) to learn more about how these file were originally created. 
 
 - `panglao-cell-type-ontologies.tsv` contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `PanglaoDB` reference used when running `CellAssign`. 
 The table includes the following columns:

--- a/references/consensus-cell-type-reference.tsv
+++ b/references/consensus-cell-type-reference.tsv
@@ -1,0 +1,331 @@
+panglao_ontology	panglao_annotation	original_panglao_name	blueprint_ontology	blueprint_annotation_cl	consensus_ontology	consensus_annotation
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000775	neutrophil	CL:0000094	granulocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000775	neutrophil	CL:0000094	granulocyte
+CL:0000235	macrophage	Macrophages	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000775	neutrophil	CL:0000775	neutrophil
+CL:0000092	osteoclast	Osteoclasts	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000129	microglial cell	Microglia	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000775	neutrophil	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000576	monocyte	CL:0000766	myeloid leukocyte
+CL:0000451	dendritic cell	Dendritic cells	CL:0000576	monocyte	CL:0000113	mononuclear phagocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000576	monocyte	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000576	monocyte	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000576	monocyte	CL:0000576	monocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000576	monocyte	CL:0000576	monocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000576	monocyte	CL:0000766	myeloid leukocyte
+CL:0000784	plasmacytoid dendritic cell	Plasmacytoid dendritic cells	CL:0000576	monocyte	CL:0000113	mononuclear phagocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000576	monocyte	CL:0000766	myeloid leukocyte
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000050	megakaryocyte-erythroid progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000050	megakaryocyte-erythroid progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000084	T cell	T cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000624	CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000624	CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000624	CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000815	regulatory T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000815	regulatory T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000815	regulatory T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000898	naive T cell	T cells naive	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000815	regulatory T cell	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000815	regulatory T cell	CL:0000815	regulatory T cell
+CL:0000084	T cell	T cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000623	natural killer cell	NK cells	CL:0000623	natural killer cell	CL:0000623	natural killer cell
+CL:0001069	group 2 innate lymphoid cell	Nuocytes	CL:0000623	natural killer cell	CL:0001065	innate lymphoid cell
+CL:0000236	B cell	B cells	CL:0000788	naive B cell	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000788	naive B cell	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000788	naive B cell	CL:0000785	mature B cell
+CL:0000788	naive B cell	B cells naive	CL:0000788	naive B cell	CL:0000788	naive B cell
+CL:0000236	B cell	B cells	CL:0000787	memory B cell	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000787	memory B cell	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000787	memory B cell	CL:0000787	memory B cell
+CL:0000788	naive B cell	B cells naive	CL:0000787	memory B cell	CL:0000785	mature B cell
+CL:0000236	B cell	B cells	CL:0000972	class switched memory B cell	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000972	class switched memory B cell	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000972	class switched memory B cell	CL:0000787	memory B cell
+CL:0000788	naive B cell	B cells naive	CL:0000972	class switched memory B cell	CL:0000785	mature B cell
+CL:0000646	basal cell	Basal cells	CL:0000037	hematopoietic stem cell	CL:0000723	somatic stem cell
+CL:0002322	embryonic stem cell	Embryonic stem cells	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0000352	epiblast cell	Epiblast cells	CL:0000037	hematopoietic stem cell	CL:0000723	somatic stem cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000037	hematopoietic stem cell	CL:0000037	hematopoietic stem cell
+CL:0005026	hepatoblast	Hepatoblasts	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0002248	pluripotent stem cell	Pluripotent stem cells	CL:0000037	hematopoietic stem cell	CL:0000723	somatic stem cell
+CL:0002672	retinal progenitor cell	Retinal progenitor cells	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0002664	cardioblast	Cardiac stem and precursor cells	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0002250	intestinal crypt stem cell	Crypt cells	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000037	hematopoietic stem cell	CL:0008001	hematopoietic precursor cell
+CL:0000324	metanephric mesenchyme stem cell	Kidney progenitor cells	CL:0000037	hematopoietic stem cell	CL:0000034	stem cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000837	hematopoietic multipotent progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000837	hematopoietic multipotent progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000051	common lymphoid progenitor	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000051	common lymphoid progenitor	CL:0008001	hematopoietic precursor cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000557	granulocyte monocyte progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000557	granulocyte monocyte progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000235	macrophage	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000235	macrophage	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000235	macrophage	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000235	macrophage	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000235	macrophage	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000235	macrophage	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000235	macrophage	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000235	macrophage	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000235	macrophage	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000235	macrophage	CL:0000235	macrophage
+CL:0000084	T cell	T cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000625	CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000625	CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000625	CD8-positive, alpha-beta T cell	CL:0002419	mature T cell
+CL:0000765	erythroblast	Erythroblasts	CL:0000232	erythrocyte	CL:0000764	erythroid lineage cell
+CL:0000558	reticulocyte	Reticulocytes	CL:0000232	erythrocyte	CL:0000764	erythroid lineage cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000232	erythrocyte	CL:0000764	erythroid lineage cell
+CL:0000556	megakaryocyte	Megakaryocytes	CL:0000556	megakaryocyte	CL:0000556	megakaryocyte
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000049	common myeloid progenitor	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000049	common myeloid progenitor	CL:0008001	hematopoietic precursor cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000863	inflammatory macrophage	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000863	inflammatory macrophage	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000863	inflammatory macrophage	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000863	inflammatory macrophage	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000863	inflammatory macrophage	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000890	alternatively activated macrophage	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000890	alternatively activated macrophage	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000890	alternatively activated macrophage	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000890	alternatively activated macrophage	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000890	alternatively activated macrophage	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000890	alternatively activated macrophage	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000890	alternatively activated macrophage	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000890	alternatively activated macrophage	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000890	alternatively activated macrophage	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000890	alternatively activated macrophage	CL:0000235	macrophage
+CL:0000115	endothelial cell	Endothelial cells	CL:0000115	endothelial cell	CL:0000115	endothelial cell
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)	CL:0000115	endothelial cell	CL:0000115	endothelial cell
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)	CL:0000115	endothelial cell	CL:0000115	endothelial cell
+CL:0000451	dendritic cell	Dendritic cells	CL:0000451	dendritic cell	CL:0000451	dendritic cell
+CL:0000576	monocyte	Monocytes	CL:0000451	dendritic cell	CL:0000113	mononuclear phagocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000451	dendritic cell	CL:0000113	mononuclear phagocyte
+CL:0000784	plasmacytoid dendritic cell	Plasmacytoid dendritic cells	CL:0000451	dendritic cell	CL:0000451	dendritic cell
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000451	dendritic cell	CL:0000451	dendritic cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000771	eosinophil	CL:0000094	granulocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000771	eosinophil	CL:0000771	eosinophil
+CL:0000235	macrophage	Macrophages	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000771	eosinophil	CL:0000094	granulocyte
+CL:0000092	osteoclast	Osteoclasts	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000129	microglial cell	Microglia	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000771	eosinophil	CL:0000766	myeloid leukocyte
+CL:0000236	B cell	B cells	CL:0000786	plasma cell	CL:0000945	lymphocyte of B lineage
+CL:0000786	plasma cell	Plasma cells	CL:0000786	plasma cell	CL:0000786	plasma cell
+CL:0000787	memory B cell	B cells memory	CL:0000786	plasma cell	CL:0000945	lymphocyte of B lineage
+CL:0000788	naive B cell	B cells naive	CL:0000786	plasma cell	CL:0000945	lymphocyte of B lineage
+CL:0000138	chondrocyte	Chondrocytes	CL:0000138	chondrocyte	CL:0000138	chondrocyte
+CL:2000002	decidual cell	Decidual cells	CL:0000138	chondrocyte	CL:0000499	stromal cell
+CL:0000632	hepatic stellate cell	Hepatic stellate cells	CL:0000138	chondrocyte	CL:0000327	extracellular matrix secreting cell
+CL:0000499	stromal cell	Stromal cells	CL:0000138	chondrocyte	CL:0000499	stromal cell
+CL:0000708	leptomeningeal cell	Meningeal cells	CL:0000138	chondrocyte	CL:0000327	extracellular matrix secreting cell
+CL:0000057	fibroblast	Fibroblasts	CL:0000057	fibroblast	CL:0000057	fibroblast
+CL:0000632	hepatic stellate cell	Hepatic stellate cells	CL:0000057	fibroblast	CL:0000057	fibroblast
+CL:0002410	pancreatic stellate cell	Pancreatic stellate cells	CL:0000057	fibroblast	CL:0000057	fibroblast
+CL:0002334	preadipocyte	Adipocyte progenitor cells	CL:0000057	fibroblast	CL:0000057	fibroblast
+CL:0000192	smooth muscle cell	Smooth muscle cells	CL:0000192	smooth muscle cell	CL:0000192	smooth muscle cell
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells	CL:0000192	smooth muscle cell	CL:0000192	smooth muscle cell
+CL:0000746	cardiac muscle cell	Cardiomyocytes	CL:0000192	smooth muscle cell	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Myocytes	CL:0000192	smooth muscle cell	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells	CL:0000192	smooth muscle cell	CL:0000192	smooth muscle cell
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells	CL:0000192	smooth muscle cell	CL:0000192	smooth muscle cell
+CL:0002068	Purkinje myocyte	Purkinje fiber cells	CL:0000192	smooth muscle cell	CL:0000187	muscle cell
+CL:0000622	acinar cell	Acinar cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:1000488	cholangiocyte	Cholangiocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000584	enterocyte	Enterocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000164	enteroendocrine cell	Enteroendocrine cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000065	ependymal cell	Ependymal cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000066	epithelial cell	Epithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000160	goblet cell	Goblet cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000501	granulosa cell	Granulosa cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000182	hepatocyte	Hepatocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0005006	ionocyte	Ionocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000312	keratinocyte	Keratinocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000077	mesothelial cell	Mesothelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000185	myoepithelial cell	Myoepithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002167	olfactory epithelial cell	Olfactory epithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000510	paneth cell	Paneth cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000162	parietal cell	Parietal cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002481	peritubular myoid cell	Peritubular myoid cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000652	pinealocyte	Pinealocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000653	podocyte	Podocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000209	taste receptor cell	Taste receptor cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000731	urothelial cell	Urothelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002368	respiratory epithelial cell	Airway epithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002370	respiratory goblet cell	Airway goblet cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000171	pancreatic A cell	Alpha cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000169	type B pancreatic cell	Beta cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000158	club cell	Clara cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002250	intestinal crypt stem cell	Crypt cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000173	pancreatic D cell	Delta cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002305	epithelial cell of distal tubule	Distal tubule cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002079	pancreatic ductal cell	Ductal cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000504	enterochromaffin-like cell	Enterochromaffin cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0005019	pancreatic epsilon cell	Epsilon cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002258	thyroid follicular cell	Follicular cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002179	foveolar cell of stomach	Foveolar cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000696	PP cell	Gamma (PP) cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000155	peptic cell	Gastric chief cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002292	type I cell of carotid body	Glomus cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0005010	renal intercalated cell	Intercalated cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:1000909	kidney loop of Henle epithelial cell	Loop of Henle cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002326	luminal epithelial cell of mammary gland	Luminal epithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002327	mammary gland epithelial cell	Mammary epithelial cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000682	M cell of gut	Microfold cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002199	oxyphil cell of parathyroid gland	Oxyphil cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000446	chief cell of parathyroid gland	Parathyroid chief cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0005009	renal principal cell	Principal cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002306	epithelial cell of proximal tubule	Proximal tubule cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:1001596	salivary gland glandular cell	Salivary mucous cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002140	acinar cell of sebaceous gland	Sebocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000216	Sertoli cell	Sertoli cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002562	hair germinal matrix cell	Trichocytes	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0002204	brush cell	Tuft cells	CL:0000066	epithelial cell	CL:0000066	epithelial cell
+CL:0000148	melanocyte	Melanocytes	CL:0000148	melanocyte	CL:0000148	melanocyte
+CL:0000594	skeletal muscle satellite cell	Satellite cells	CL:0000188	cell of skeletal muscle	CL:0000188	cell of skeletal muscle
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0000065	ependymal cell	Ependymal cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0000312	keratinocyte	Keratinocytes	CL:0000312	keratinocyte	CL:0000312	keratinocyte
+CL:0000077	mesothelial cell	Mesothelial cells	CL:0000312	keratinocyte	CL:0000076	squamous epithelial cell
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0002167	olfactory epithelial cell	Olfactory epithelial cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0002481	peritubular myoid cell	Peritubular myoid cells	CL:0000312	keratinocyte	CL:0000076	squamous epithelial cell
+CL:0000652	pinealocyte	Pinealocytes	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0002292	type I cell of carotid body	Glomus cells	CL:0000312	keratinocyte	CL:0002077	ecto-epithelial cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000312	keratinocyte	CL:0000312	keratinocyte
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells	CL:0000312	keratinocyte	CL:0000076	squamous epithelial cell
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells	CL:0000312	keratinocyte	CL:0000076	squamous epithelial cell
+CL:0002140	acinar cell of sebaceous gland	Sebocytes	CL:0000312	keratinocyte	CL:0000362	epidermal cell
+CL:0000216	Sertoli cell	Sertoli cells	CL:0000312	keratinocyte	CL:0000076	squamous epithelial cell
+CL:0002562	hair germinal matrix cell	Trichocytes	CL:0000312	keratinocyte	CL:0000362	epidermal cell
+CL:0000115	endothelial cell	Endothelial cells	CL:2000008	microvascular endothelial cell	CL:0000115	endothelial cell
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)	CL:2000008	microvascular endothelial cell	CL:0000071	blood vessel endothelial cell
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)	CL:2000008	microvascular endothelial cell	CL:2000008	microvascular endothelial cell
+CL:0000192	smooth muscle cell	Smooth muscle cells	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Cardiomyocytes	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Myocytes	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0002068	Purkinje myocyte	Purkinje fiber cells	CL:0000187	muscle cell	CL:0000187	muscle cell
+CL:0000136	adipocyte	Adipocytes	CL:0000136	adipocyte	CL:0000136	adipocyte
+CL:0000109	adrenergic neuron	Adrenergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000108	cholinergic neuron	Cholinergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000700	dopaminergic neuron	Dopaminergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0007011	enteric neuron	Enteric neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:1001509	glycinergic neuron	Glycinergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000099	interneuron	Interneurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000100	motor neuron	Motor neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000540	neuron	Neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0008025	noradrenergic neuron	Noradrenergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000210	photoreceptor cell	Photoreceptor cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000740	retinal ganglion cell	Retinal ganglion cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000850	serotonergic neuron	Serotonergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:4023169	trigeminal neuron	Trigeminal neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000695	Cajal-Retzius cell	Cajal-Retzius cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000617	GABAergic neuron	GABAergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000679	glutamatergic neuron	Glutaminergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000121	Purkinje cell	Purkinje neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000598	pyramidal neuron	Pyramidal cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000650	mesangial cell	Mesangial cells	CL:0000669	pericyte	CL:0000669	pericyte
+CL:0000669	pericyte	Pericytes	CL:0000669	pericyte	CL:0000669	pericyte
+CL:0000127	astrocyte	Astrocytes	CL:0000127	astrocyte	CL:0000127	astrocyte
+CL:0000065	ependymal cell	Ependymal cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0000128	oligodendrocyte	Oligodendrocytes	CL:0000127	astrocyte	CL:0000126	macroglial cell
+CL:0002085	tanycyte	Tanycytes	CL:0000127	astrocyte	CL:0000127	astrocyte
+CL:0000644	Bergmann glial cell	Bergmann glia	CL:0000127	astrocyte	CL:0000127	astrocyte
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:4040002	enteroglial cell	Enteric glia cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:4042021	neuronal-restricted precursor	Immature neurons	CL:0000127	astrocyte	CL:0000095	neuron associated cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000127	astrocyte	CL:0000095	neuron associated cell
+CL:0000129	microglial cell	Microglia	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0000636	Mueller cell	Müller cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0002453	oligodendrocyte precursor cell	Oligodendrocyte progenitor cells	CL:0000127	astrocyte	CL:0000095	neuron associated cell
+CL:0002573	Schwann cell	Peri-islet Schwann cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0002573	Schwann cell	Schwann cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0000681	radial glial cell	Radial glia cells	CL:0000127	astrocyte	CL:0000125	glial cell
+CL:0000516	perineural satellite cell	Satellite glial cells	CL:0000127	astrocyte	CL:0000095	neuron associated cell
+CL:0000650	mesangial cell	Mesangial cells	CL:0000650	mesangial cell	CL:0000650	mesangial cell
+CL:0000669	pericyte	Pericytes	CL:0000650	mesangial cell	CL:0000669	pericyte

--- a/references/panglao-cell-type-ontologies.tsv
+++ b/references/panglao-cell-type-ontologies.tsv
@@ -1,0 +1,179 @@
+ontology_id	human_readable_value	panglao_cell_type
+CL:0000236	B cell	B cells
+CL:0000084	T cell	T cells
+CL:0002038	T follicular helper cell	T follicular helper cells
+CL:0000622	acinar cell	Acinar cells
+CL:0000136	adipocyte	Adipocytes
+CL:0000109	adrenergic neuron	Adrenergic neurons
+CL:0000583	alveolar macrophage	Alveolar macrophages
+CL:0000127	astrocyte	Astrocytes
+CL:0000646	basal cell	Basal cells
+CL:0000767	basophil	Basophils
+CL:1000488	cholangiocyte	Cholangiocytes
+CL:0000108	cholinergic neuron	Cholinergic neurons
+CL:0000138	chondrocyte	Chondrocytes
+CL:0000166	chromaffin cell	Chromaffin cells
+CL:0000064	ciliated cell	Ciliated cells
+CL:2000002	decidual cell	Decidual cells
+CL:0000451	dendritic cell	Dendritic cells
+CL:0000700	dopaminergic neuron	Dopaminergic neurons
+CL:0002322	embryonic stem cell	Embryonic stem cells
+CL:0000115	endothelial cell	Endothelial cells
+CL:0007011	enteric neuron	Enteric neurons
+CL:0000584	enterocyte	Enterocytes
+CL:0000164	enteroendocrine cell	Enteroendocrine cells
+CL:0000771	eosinophil	Eosinophils
+CL:0000065	ependymal cell	Ependymal cells
+CL:0000352	epiblast cell	Epiblast cells
+CL:0000066	epithelial cell	Epithelial cells
+CL:0000765	erythroblast	Erythroblasts
+CL:0000057	fibroblast	Fibroblasts
+CL:0000586	germ cell	Germ cells
+CL:1001509	glycinergic neuron	Glycinergic neurons
+CL:0000160	goblet cell	Goblet cells
+CL:0000501	granulosa cell	Granulosa cells
+CL:0002418	hemangioblast	Hemangioblasts
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells
+CL:0000632	hepatic stellate cell	Hepatic stellate cells
+CL:0005026	hepatoblast	Hepatoblasts
+CL:0000182	hepatocyte	Hepatocytes
+CL:0000099	interneuron	Interneurons
+CL:0005006	ionocyte	Ionocytes
+CL:0000312	keratinocyte	Keratinocytes
+CL:0000175	luteal cell	Luteal cells
+CL:0000235	macrophage	Macrophages
+CL:0000097	mast cell	Mast cells
+CL:0000556	megakaryocyte	Megakaryocytes
+CL:0000148	melanocyte	Melanocytes
+CL:0000650	mesangial cell	Mesangial cells
+CL:0000077	mesothelial cell	Mesothelial cells
+CL:0000576	monocyte	Monocytes
+CL:0000100	motor neuron	Motor neurons
+CL:0000056	myoblast	Myoblasts
+CL:0000185	myoepithelial cell	Myoepithelial cells
+CL:0000165	neuroendocrine cell	Neuroendocrine cells
+CL:0000540	neuron	Neurons
+CL:0000775	neutrophil	Neutrophils
+CL:0008025	noradrenergic neuron	Noradrenergic neurons
+CL:0002167	olfactory epithelial cell	Olfactory epithelial cells
+CL:0000128	oligodendrocyte	Oligodendrocytes
+CL:0000062	osteoblast	Osteoblasts
+CL:0000092	osteoclast	Osteoclasts
+CL:0000137	osteocyte	Osteocytes
+CL:0002410	pancreatic stellate cell	Pancreatic stellate cells
+CL:0000510	paneth cell	Paneth cells
+CL:0000162	parietal cell	Parietal cells
+CL:0000669	pericyte	Pericytes
+CL:0002481	peritubular myoid cell	Peritubular myoid cells
+CL:0000210	photoreceptor cell	Photoreceptor cells
+CL:0000652	pinealocyte	Pinealocytes
+CL:0000786	plasma cell	Plasma cells
+CL:0000784	plasmacytoid dendritic cell	Plasmacytoid dendritic cells
+CL:0000233	platelet	Platelets
+CL:0002248	pluripotent stem cell	Pluripotent stem cells
+CL:0000653	podocyte	Podocytes
+CL:0000558	reticulocyte	Reticulocytes
+CL:0000740	retinal ganglion cell	Retinal ganglion cells
+CL:0002672	retinal progenitor cell	Retinal progenitor cells
+CL:0000850	serotonergic neuron	Serotonergic neurons
+CL:0000192	smooth muscle cell	Smooth muscle cells
+CL:0000017	spermatocyte	Spermatocytes
+CL:0000499	stromal cell	Stromal cells
+CL:0002085	tanycyte	Tanycytes
+CL:0000209	taste receptor cell	Taste receptor cells
+CL:0000893	thymocyte	Thymocytes
+CL:4023169	trigeminal neuron	Trigeminal neurons
+CL:0000351	trophoblast cell	Trophoblast cells
+CL:0000731	urothelial cell	Urothelial cells
+CL:0002334	preadipocyte	Adipocyte progenitor cells
+CL:0002368	respiratory epithelial cell	Airway epithelial cells
+CL:0002370	respiratory goblet cell	Airway goblet cells
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells
+CL:0000171	pancreatic A cell	Alpha cells
+CL:2000004	pituitary gland cell	Anterior pituitary gland cells
+CL:0000787	memory B cell	B cells memory
+CL:0000788	naive B cell	B cells naive
+CL:0000644	Bergmann glial cell	Bergmann glia
+CL:0000169	type B pancreatic cell	Beta cells
+CL:0000695	Cajal-Retzius cell	Cajal-Retzius cells
+CL:0002664	cardioblast	Cardiac stem and precursor cells
+CL:0000746	cardiac muscle cell	Cardiomyocytes
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells
+CL:0000158	club cell	Clara cells
+CL:0002250	intestinal crypt stem cell	Crypt cells
+CL:0000173	pancreatic D cell	Delta cells
+CL:0002305	epithelial cell of distal tubule	Distal tubule cells
+CL:0002079	pancreatic ductal cell	Ductal cells
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)
+CL:4040002	enteroglial cell	Enteric glia cells
+CL:0000504	enterochromaffin-like cell	Enterochromaffin cells
+CL:0005019	pancreatic epsilon cell	Epsilon cells
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells
+CL:0002258	thyroid follicular cell	Follicular cells
+CL:0002179	foveolar cell of stomach	Foveolar cells
+CL:0000617	GABAergic neuron	GABAergic neurons
+CL:0000696	PP cell	Gamma (PP) cells
+CL:0000798	gamma-delta T cell	Gamma delta T cells
+CL:0000155	peptic cell	Gastric chief cells
+CL:0002292	type I cell of carotid body	Glomus cells
+CL:0000679	glutamatergic neuron	Glutaminergic neurons
+CL:0010007	His-Purkinje system cell	His bundle cells
+CL:4042021	neuronal-restricted precursor	Immature neurons
+CL:0005010	renal intercalated cell	Intercalated cells
+CL:1000618	juxtaglomerular complex cell	Juxtaglomerular cells
+CL:0000324	metanephric mesenchyme stem cell	Kidney progenitor cells
+CL:0000091	Kupffer cell	Kupffer cells
+CL:0000453	Langerhans cell	Langerhans cells
+CL:0000178	Leydig cell	Leydig cells
+CL:1000909	kidney loop of Henle epithelial cell	Loop of Henle cells
+CL:0002326	luminal epithelial cell of mammary gland	Luminal epithelial cells
+CL:0002327	mammary gland epithelial cell	Mammary epithelial cells
+CL:0000708	leptomeningeal cell	Meningeal cells
+CL:0000242	Merkel cell	Merkel cells
+CL:0000682	M cell of gut	Microfold cells
+CL:0000129	microglial cell	Microglia
+CL:0000636	Mueller cell	Müller cells
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells
+CL:0000746	cardiac muscle cell	Myocytes
+CL:0000186	myofibroblast cell	Myofibroblasts
+CL:0000814	mature NK T cell	Natural killer T cells
+CL:0000047	neural stem cell	Neural stem/precursor cells
+CL:0000338	neuroblast (sensu Nematoda and Protostomia)	Neuroblasts
+CL:0000623	natural killer cell	NK cells
+CL:0001069	group 2 innate lymphoid cell	Nuocytes
+CL:0002453	oligodendrocyte precursor cell	Oligodendrocyte progenitor cells
+CL:0000576	monocyte	Osteoclast precursor cells
+CL:0002199	oxyphil cell of parathyroid gland	Oxyphil cells
+CL:0002351	progenitor cell of endocrine pancreas	Pancreatic progenitor cells
+CL:0000446	chief cell of parathyroid gland	Parathyroid chief cells
+CL:0002573	Schwann cell	Peri-islet Schwann cells
+CL:0005009	renal principal cell	Principal cells
+CL:0002306	epithelial cell of proximal tubule	Proximal tubule cells
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells
+CL:0002068	Purkinje myocyte	Purkinje fiber cells
+CL:0000121	Purkinje cell	Purkinje neurons
+CL:0000598	pyramidal neuron	Pyramidal cells
+CL:0000681	radial glial cell	Radial glia cells
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages
+CL:1001596	salivary gland glandular cell	Salivary mucous cells
+CL:0000594	skeletal muscle satellite cell	Satellite cells
+CL:0000516	perineural satellite cell	Satellite glial cells
+CL:0002573	Schwann cell	Schwann cells
+CL:0002140	acinar cell of sebaceous gland	Sebocytes
+CL:0000216	Sertoli cell	Sertoli cells
+CL:0000019	sperm	Spermatozoa
+CL:0000898	naive T cell	T cells naive
+CL:0000910	cytotoxic T cell	T cytotoxic cells
+CL:0000912	helper T cell	T helper cells
+CL:0000813	memory T cell	T memory cells
+CL:0000815	regulatory T cell	T regulatory cells
+NA	NA	Transient cells
+CL:0002562	hair germinal matrix cell	Trichocytes
+CL:0000351	trophoblast cell	Trophoblast progenitor cells
+CL:0000351	trophoblast cell	Trophoblast stem cells
+CL:0002204	brush cell	Tuft cells
+NA	NA	Undefined placental cells
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells


### PR DESCRIPTION
Closes #824 

Here I am adding the consensus cell types to the processed objects within the `add_celltypes_to_sce.R` script that gets used to add the `SingleR` and `CellAssign` cell types to the `colData` of the object. 

- I added two new parameters, one for the panglao ontology ID reference and one for the consensus cell type reference. The parameters for both of these files point to their location in `OpenScPCA-analysis`.
- Since part of creating the consensus labels included assigning ontology ID terms to the cell types in `PanglaoDB`, I first am adding in a new column, `cellassign_celltype_ontology` which includes the assigned ontology terms for the `CellAssign` cell types. 
- Then if both `CellAssign` and `SingleR` results exist, I add in the consensus annotation and ontology. 
  - If `CellAssign` had an empty predictions file and therefore the values are `Not run`, I do not do any consensus cell type assignments. 
  - Right now, the `consensus_celltype_annotation` and `consensus_celltype_ontology` columns only exist if both `SingleR` and `CellAssign` were successful, otherwise these columns do not exist. Are we okay with that approach or should we fill in with `NA` if one of the items is not run? 
  - In testing, I had one sample with cells in the `CellAssign` predictions file that were no longer present in the filtered object (it was only a handful). To account for this scenario, I added a filtering step to only include barcodes that are in the object when obtaining the annotations. 
- While working in this script I also made some updates to how we handle errors to use `stopifnot` and set some defaults to "". 