### PR TITLE
Use new scpcaTools container and bump version to v0.8.7

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,10 +1,10 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:edge'
-SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:edge'
-SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:edge'
-SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:edge'
-SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:edge'
-SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:edge'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:v0.4.2'
+SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.2'
+SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:v0.4.2'
+SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.2'
+SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.2'
+SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:v0.4.2'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,10 +1,10 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:v0.4.1'
-SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.1'
-SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:v0.4.1'
-SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.1'
-SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.1'
-SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:v0.4.1'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:edge'
+SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:edge'
+SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:edge'
+SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:edge'
+SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:edge'
+SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
 BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -86,12 +86,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.8.6` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.8.7` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.8.6 \
+  -r v0.8.7 \
   -config <path to config file>  \
   -profile <name of profile>
 ```
@@ -320,7 +320,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.8.6`, then you will want to set `-r v0.8.6` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.8.7`, then you will want to set `-r v0.8.7` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -96,14 +96,14 @@ Be sure to use the `-r` flag to specify the latest release tag for the workflow,
 For example:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.8.6 -profile ccdl_staging,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.8.7 -profile ccdl_staging,batch --project SCPCP000000
 ```
 
 When that run has completed successfully, check that the outputs are as expected.
 You can then run the workflow using the `ccdl_prod` profile:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.8.6 -profile ccdl_prod,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.8.7 -profile ccdl_prod,batch --project SCPCP000000
 ```
 
 Both of these profiles have `-with-tower` set by default, and will use the [ScPCA workspace](https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch) for monitoring (allowing all team members to see progress).

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   nextflowVersion = '>=24.09'
-  version = 'v0.8.6'
+  version = 'v0.8.7'
   contributors = [
     [
       name: "Allegra Hawkins",


### PR DESCRIPTION
Closes #838 
Towards #837 

Here I'm bumping the `scpcaTools` container to the latest release, `v0.4.2`. I did a test run with the container using `edge` right before I did the release and things work as expected for both the main and merge workflow. 

I also updated the version tag throughout the config and docs in preparation for the release. 