### PR TITLE
Make test files default (for now) and updates to metrics report

### DIFF
--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1,7 +1,7 @@
 ---
 params:
-  reference_s3: s3://nextflow-ccdl-results/scpca-prod
-  comparison_s3: s3://nextflow-ccdl-results/scpca-staging
+  reference_s3: s3://nextflow-ccdl-results/scpca-prod/results
+  comparison_s3: s3://nextflow-ccdl-results/scpca-staging/results
   project_id: "all"
   use_cache: false
 title: "`scpca-nf` Metrics Comparison"
@@ -65,9 +65,9 @@ report_table <- function(df, options = list(), ...) {
 #| include: false
 # get metrics files by scanning S3
 if (tolower(params$project_id[1]) == "all") {
-  metrics_regex <- "_metrics.json$"
+  metrics_regex <- "SCPCL[0-9]{6}_metrics.json$"
 } else {
-  metrics_regex <- paste0("(", params$project_id, ".+_metrics.json$)", collapse = "|")
+  metrics_regex <- paste0("(", params$project_id, ".+SCPCL[0-9]{6}_metrics.json$)", collapse = "|")
 }
 
 ref_metrics_files <- s3fs::s3_dir_ls(
@@ -212,7 +212,7 @@ if (has_processing_changes) {
   glue::glue("
     The tables below show the processing changes between the reference and comparison workflow runs.<br>
     There {ifelse(n_added == 1, 'is', 'are a total of')} **{n_libraries}** {ifelse(n_libraries == 1, 'library', 'libraries')} with processing changes
-    from **{n_projects}** {ifelse(n_projects == 0, 'project', 'projects')}.
+    from **{n_projects}** {ifelse(n_projects == 1, 'project', 'projects')}.
   ") |>
     knitr::asis_output()
 }

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -91,13 +91,13 @@ comp_metrics_paths <- s3fs::s3_dir_ls(
 ref_data <- purrr::map(ref_metrics_files, \(url) {
   jsonlite::read_json(url, simplifyVector = TRUE)
 }) |>
-  purrr::list_transpose() |>
+  purrr::list_transpose(default = NA) |>
   tibble::as_tibble()
 
 comp_data <- purrr::map(comp_metrics_paths, \(url) {
   jsonlite::read_json(url, simplifyVector = TRUE)
 }) |>
-  purrr::list_transpose() |>
+  purrr::list_transpose(default = NA) |>
   tibble::as_tibble()
 
 # join the two data frames

--- a/scripts/compare-metrics/compare-metrics.R
+++ b/scripts/compare-metrics/compare-metrics.R
@@ -17,7 +17,8 @@ option_list <- list(
   make_option(
     c("-c", "--comp_s3"),
     type = "character",
-    default = "s3://nextflow-ccdl-results/metrics-test",
+    default = "s3://nextflow-ccdl-results/metrics-test", # temporary default for testing
+    # default = "s3://nextflow-ccdl-results/scpca-staging/results", # normal default
     help = "S3 URI for the bucket and prefix for the comparison S3 files"
   ),
   make_option(c("-p", "--project_id"),

--- a/scripts/compare-metrics/compare-metrics.R
+++ b/scripts/compare-metrics/compare-metrics.R
@@ -11,13 +11,13 @@ option_list <- list(
   make_option(
     c("-r", "--ref_s3"),
     type = "character",
-    default = "s3://nextflow-ccdl-results/scpca-prod",
+    default = "s3://nextflow-ccdl-results/scpca-prod/results",
     help = "S3 URI for the bucket and prefix for the reference files"
   ),
   make_option(
     c("-c", "--comp_s3"),
     type = "character",
-    default = "s3://nextflow-ccdl-results/scpca-staging",
+    default = "s3://nextflow-ccdl-results/metrics-test",
     help = "S3 URI for the bucket and prefix for the comparison S3 files"
   ),
   make_option(c("-p", "--project_id"),


### PR DESCRIPTION
closes #852 

I created a set of test files at `s3://nextflow-ccdl-results/metrics-test` which includes projects 1-10. I made this the default for the wrapper script for now. 

I swapped around a few samples, which results in one processing change in the current report, and the removal of lots of projects means there are a lot a changed files.

While I was testing this, I found a few little errors/optimizations that I cleaned up as well.
- I list only the `results` subdirectory, which saves a fair amount of time. It still takes a while to download and parse all the json files, but the listing is _much_ faster.
- I also made the regex more specific, as it turns out there are some `*_metrics.json` files that are produced by Space Ranger, which we want to be sure to skip (these are really only in the checkpoints, but better safe than sorry)
- NULL values turned out to cause some trouble (specifically showing up in libraries where there has not been cell typing done), so I added `default=NA` to the list transpose, which handled the job.
  - I wasn't sure if these projects (`SCPCP000020` and `SCPCP000024`) were _supposed_ to not have cell typing? Do we need to reprocess them? 