### PR TITLE
Add cell and read count reporting to change tracking notebook

### DIFF
--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -145,6 +145,5 @@ if (file.size(opt$processed_sce) > 0) {
 jsonlite::write_json(
   metrics,
   path = opt$metrics_json,
-  auto_unbox = TRUE,
   pretty = TRUE
 )

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -117,7 +117,9 @@ if (file.size(opt$filtered_sce) > 0) {
   metrics$filtered_altexp_total <- altexp_totals(filtered_sce)
   metrics$miqc_pass_count <- sum(filtered_sce$miQC_pass)
   metrics$scpca_filter_count <- sum(filtered_sce$scpca_filter == "Keep")
-  metrics$adt_scpca_filter_count <- sum(filtered_sce$adt_scpca_filter == "Keep")
+  if (!is.null(filtered_sce$adt_scpca_filter)) {
+    metrics$adt_scpca_filter_count <- sum(filtered_sce$adt_scpca_filter == "Keep")
+  }
 
   rm(filtered_sce)
 }

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -115,7 +115,11 @@ if (file.size(opt$filtered_sce) > 0) {
   metrics$filtered_total_spliced <- total_spliced(filtered_sce)
   metrics$filtered_expressed_genes <- sum(rowSums(counts(filtered_sce)) > 0)
   metrics$filtered_altexp_total <- altexp_totals(filtered_sce)
-  metrics$miqc_pass_count <- sum(filtered_sce$miQC_pass)
+  metrics$miqc_pass_count <- ifelse(
+    is.null(filtered_sce$miQC_pass),
+    NA_integer_,
+    sum(filtered_sce$miQC_pass)
+  )
   metrics$scpca_filter_count <- sum(filtered_sce$scpca_filter == "Keep")
   metrics$adt_scpca_filter_count <- ifelse(
     is.null(filtered_sce$adt_scpca_filter),

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -117,9 +117,11 @@ if (file.size(opt$filtered_sce) > 0) {
   metrics$filtered_altexp_total <- altexp_totals(filtered_sce)
   metrics$miqc_pass_count <- sum(filtered_sce$miQC_pass)
   metrics$scpca_filter_count <- sum(filtered_sce$scpca_filter == "Keep")
-  if (!is.null(filtered_sce$adt_scpca_filter)) {
-    metrics$adt_scpca_filter_count <- sum(filtered_sce$adt_scpca_filter == "Keep")
-  }
+  metrics$adt_scpca_filter_count <- ifelse(
+    is.null(filtered_sce$adt_scpca_filter),
+    NA_integer_,
+    sum(filtered_sce$adt_scpca_filter == "Keep")
+  )
 
   rm(filtered_sce)
 }
@@ -136,8 +138,16 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
   # cluster counts as unnamed vector
   metrics$cluster_sizes <- as.vector(table(processed_sce$cluster))
-  metrics$singler_reference <- ifelse(is.null(metadata(processed_sce)$singler_reference), NA_character_, metadata(processed_sce)$singler_reference)
-  metrics$cellassign_reference <- ifelse(is.null(metadata(processed_sce)$cellassign_reference), NA_character_, metadata(processed_sce)$cellassign_reference)
+  metrics$singler_reference <- ifelse(
+    is.null(metadata(processed_sce)$singler_reference),
+    NA_character_,
+    metadata(processed_sce)$singler_reference
+  )
+  metrics$cellassign_reference <- ifelse(
+    is.null(metadata(processed_sce)$cellassign_reference),
+    NA_character_,
+    metadata(processed_sce)$cellassign_reference
+  )
   # convert celltype annotation counts to named lists
   metrics$singler_celltypes <- as.list(table(processed_sce$singler_celltype_ontology))
   metrics$cellassign_celltypes <- as.list(table(processed_sce$cellassign_celltype_annotation))

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -319,7 +319,7 @@ if (!has_cell_changes) {
   n_libraries <- dplyr::n_distinct(changed_cell_counts$library_id)
 
   glue::glue("
-    The tables below show changes in cell counts changes between the reference and comparison workflow runs at various stages of processing.<br>
+    The tables below show changes in cell counts between the reference and comparison workflow runs at various stages of processing.<br>
     There {ifelse(n_added == 1, 'is', 'are a total of')} **{n_libraries}** {ifelse(n_libraries == 1, 'library', 'libraries')} with cell count changes
     from **{n_projects}** {ifelse(n_projects == 1, 'project', 'projects')}.
   ") |>

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -261,30 +261,86 @@ report_table(
 
 ### Cell count changes {.tabset}
 
-For each sample, we will want to first compare:
+```{r}
+# calculate the difference between reference and comparison for selected fields
 
-- `unfiltered_cells`
-- `filtered_cells`
-- `processed_cells`
-- `miqc_pass_count`
-- `scpca_filter_count`
-- `adt_scpca_filter_count`
+cell_fields <- c(
+  "unfiltered_cells",
+  "filtered_cells",
+  "processed_cells",
+  "miqc_pass_count",
+  "scpca_filter_count",
+  "adt_scpca_filter_count"
+)
 
-If there are changes in any of those, we will report those, with prominent warnings for any large changes.
-What defines a large change?
-Perhaps start with a change > 0.5% of the total?
-Alternatively, if we see a large fraction of samples changing, we would want to note that.
-If there are any changes to the number of unfiltered cells, that should be highlighted, as we do not expect this to change between runs.
+cell_changes <- metrics_df |>
+  tidyr::drop_na(starts_with("mapped_reads")) |> # remove added/removed libraries
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with(cell_fields)
+  ) |>
+  tidyr::pivot_longer(
+    cols = starts_with(cell_fields),
+    names_pattern = "(.+)\\.(ref|comp)$",
+    names_to = c("field", ".value") # .value separates into `ref` and `comp` fields
+  ) |>
+  dplyr::filter(is.finite(comp) | is.finite(ref)) |> # keep where at least one is finite
+  dplyr::mutate(
+    change = comp - ref,
+    change_frac = change / ref
+  )
+```
+
+
+The tables below show any changes in cell counts at different stages of filtering.
 
 #### Summary
-The main display item would be a summary table, in the first tab:
 
-| Metric | Number of samples changed | % of samples changed | Mean % change |
-| ----- | --------- | --------- | ---------------- |
-| `scpca_filter_count` | 100 | 20 | -10 |
+```{r}
+# Text summary of cell count changes
+cell_summary <- cell_changes |>
+  dplyr::summarise(
+    .by = c("field"),
+    # count where at least one version has a value
+    n = dplyr::n(),
+    n_changed = sum(is.na(change) | change != 0),
+    sample_change_frac = n_changed / n,
+    mean_change_frac = mean(change_frac, na.rm = TRUE)
+  )
+
+report_table(
+  cell_summary,
+  colnames = c("Metric", "Samples", "Number of samples changed", "% of samples changed", "Mean % change")
+) |>
+  DT::formatPercentage(c(4, 5), 2)
+```
+
 
 We will also include a plot with a histogram of the % changes for each metric where at least one sample changed.
 
+```{r}
+change_fields <- cell_summary |>
+  dplyr::filter(n_changed > 0) |>
+  dplyr::pull(field)
+
+cell_plot_df <- cell_changes |>
+  dplyr::filter(field %in% change_fields, change != 0) |>
+  dplyr::mutate(
+    field = factor(field, levels = cell_fields),
+  )
+
+ggplot(cell_plot_df, aes(x = change_frac)) +
+  geom_histogram(bins = 20) +
+  facet_wrap(vars(field)) +
+  labs(
+    title = "Histogram of changes in cell counts",
+    x = "Change proportion",
+    y = "Number of samples"
+  ) +
+  theme_bw()
+```
 
 #### Detail
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -366,7 +366,7 @@ report_table(
   cell_summary,
   colnames = c("Metric", "Libraries", "Number of libraries changed", "% of libraries changed", "Mean % change")
 ) |>
-  DT::formatPercentage(c(4, 5), 2)
+  DT::formatPercentage(c("library_change_frac", "mean_change_frac"), 2)
 ```
 
 
@@ -415,7 +415,7 @@ report_table(
   cell_detail,
   colnames = c("Project", "Sample", "Library", "Metric", "Reference", "Comparison", "Change", "% change")
 ) |>
-  DT::formatPercentage(c(8), 2)
+  DT::formatPercentage("change_frac", 2)
 ```
 
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -378,13 +378,33 @@ ggplot(cell_plot_df, aes(x = change_frac)) +
   theme_bw()
 ```
 
-#### Detail
+```{r, eval=has_cell_changes}
+knitr::asis_output("#### Detail")
+```
 
-A detail table of changed samples/metrics might then look like the following:
+```{r}
+# Detail table of cell count changes
 
-| Sample | Metric | Reference Value | Comparison Value | Change | % change |
-| ------- | ---------------- | --------------- | ---------------- | ------ | -------- |
-| `SCPCS999999` | `unfiltered_cells` | 1000 | 1005 | 5 | 0.5 |
+cell_detail <- cell_changes |>
+  dplyr::filter(change != 0) |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    field,
+    ref,
+    comp,
+    change,
+    change_frac
+  )
+
+report_table(
+  cell_detail,
+  colnames = c("Project", "Sample", "Library", "Metric", "Reference", "Comparison", "Change", "% change")
+) |>
+  DT::formatPercentage(c(8), 2)
+```
+
 
 
 ### Read count changes {.tabset}

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -331,15 +331,15 @@ if (!has_cell_changes) {
 ```{r}
 # warn if any unfiltered cell counts have changed
 unfiltered_cell_changes <- cell_changes |>
-  dplyr::filter(field == "unfiltered_cells") |>
-  dplyr::summarize(n_changed = sum(change != 0)) |>
-  dplyr::pull(n_changed)
+  dplyr::filter(field == "unfiltered_cells", change != 0) |>
+  nrow()
 
 
 if (unfiltered_cell_changes > 0) {
   knitr::asis_output(c(
     "<div class=\"alert alert-danger\">",
-    "**Warning**: Unfiltered cell counts have changed between the reference and comparison runs.",
+    "**Warning**: Unfiltered cell counts have changed between the reference and comparison runs. ",
+    glue::glue("**{unfiltered_cell_changes}** {ifelse(unfiltered_cell_changes == 1, 'library is', 'libraries are')} affected."),
     "</div>"
   ))
 }

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -358,7 +358,7 @@ cell_summary <- cell_changes |>
     # count where at least one version has a value
     n = dplyr::n(),
     n_changed = sum(is.na(change) | change != 0),
-    sample_change_frac = n_changed / n,
+    library_change_frac = n_changed / n,
     mean_change_frac = mean(abs(change_frac), na.rm = TRUE)
   )
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -33,6 +33,22 @@ set.seed(1234)
 # Functions
 #| include: false
 
+
+read_metrics_files <- function(urls) {
+  # read a set of metrics files
+  # url: URL of the metrics files, each in json format
+  # returns: data frame (tibble) of combined metrics
+  purrr::map(urls, \(url) {
+    jsonlite::read_json(url, simplifyVector = TRUE) |>
+      # handle bare NAs, which may be quoted
+      purrr::modify_if(\(x){
+        length(x) == 1 && x == "NA"
+      }, ~NA)
+  }) |>
+    purrr::list_transpose(default = NA) |>
+    tibble::as_tibble()
+}
+
 report_table <- function(df, options = list(), ...) {
   # pass standard settings for report to DT::datatable
   # df: data frame to display
@@ -88,17 +104,8 @@ comp_metrics_paths <- s3fs::s3_dir_ls(
 ```{r, eval=!use_cache}
 #| include: false
 # read metrics files from S3
-ref_data <- purrr::map(ref_metrics_files, \(url) {
-  jsonlite::read_json(url, simplifyVector = TRUE)
-}) |>
-  purrr::list_transpose(default = NA) |>
-  tibble::as_tibble()
-
-comp_data <- purrr::map(comp_metrics_paths, \(url) {
-  jsonlite::read_json(url, simplifyVector = TRUE)
-}) |>
-  purrr::list_transpose(default = NA) |>
-  tibble::as_tibble()
+ref_data <- read_metrics_files(ref_metrics_files)
+comp_data <- read_metrics_files(comp_metrics_paths)
 
 # join the two data frames
 metrics_df <- dplyr::full_join(

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -336,12 +336,12 @@ unfiltered_cell_changes <- cell_changes |>
 
 
 if (unfiltered_cell_changes > 0) {
-  knitr::asis_output(c(
-    "<div class=\"alert alert-danger\">",
-    "**Warning**: Unfiltered cell counts have changed between the reference and comparison runs. ",
-    glue::glue("**{unfiltered_cell_changes}** {ifelse(unfiltered_cell_changes == 1, 'library is', 'libraries are')} affected."),
-    "</div>"
-  ))
+  knitr::asis_output(glue::glue("
+    <div class=\"alert alert-danger\">
+    **Warning**: Unfiltered cell counts have changed between the reference and comparison runs.
+    **{unfiltered_cell_changes}** {ifelse(unfiltered_cell_changes == 1, 'library is', 'libraries are')} affected.
+    </div>
+  "))
 }
 ```
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -292,7 +292,10 @@ cell_changes <- metrics_df |>
     change_frac = change / ref
   )
 
-has_cell_changes <- any(cell_changes$change != 0)
+changed_cell_counts <- cell_changes |>
+  dplyr::filter(is.na(change) | change != 0)
+
+has_cell_changes <- nrow(changed_cell_counts) > 0
 ```
 
 ```{r}
@@ -302,8 +305,8 @@ if (!has_cell_changes) {
     "There are no changes in cell counts between the reference and comparison runs."
   )
 } else {
-  n_projects <- dplyr::n_distinct(cell_changes$project_id)
-  n_libraries <- dplyr::n_distinct(cell_changes$library_id)
+  n_projects <- dplyr::n_distinct(changed_cell_counts$project_id)
+  n_libraries <- dplyr::n_distinct(changed_cell_counts$library_id)
 
   glue::glue("
     The tables below show changes in cell counts changes between the reference and comparison workflow runs at various stages of processing.<br>
@@ -385,8 +388,7 @@ knitr::asis_output("#### Detail")
 ```{r}
 # Detail table of cell count changes
 
-cell_detail <- cell_changes |>
-  dplyr::filter(change != 0) |>
+cell_detail <- changed_cell_counts |>
   dplyr::select(
     project_id,
     sample_id,

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -359,7 +359,7 @@ cell_summary <- cell_changes |>
     n = dplyr::n(),
     n_changed = sum(is.na(change) | change != 0),
     library_change_frac = n_changed / n,
-    mean_change_frac = mean(abs(change_frac), na.rm = TRUE)
+    mean_change_frac = mean(abs(change_frac[which(change != 0)]))
   )
 
 report_table(

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -57,6 +57,7 @@ report_table <- function(df, options = list(), ...) {
   default_opts <- list(
     scroller = TRUE,
     deferRender = TRUE,
+    scrollX = TRUE,
     scrollY = 400,
     scrollCollapse = TRUE,
     language = list(search = "Filter:"),

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -291,15 +291,53 @@ cell_changes <- metrics_df |>
     change = comp - ref,
     change_frac = change / ref
   )
+
+has_cell_changes <- any(cell_changes$change != 0)
 ```
 
+```{r}
+# summary text for cell count section
+if (!has_cell_changes) {
+  knitr::asis_output(
+    "There are no changes in cell counts between the reference and comparison runs."
+  )
+} else {
+  n_projects <- dplyr::n_distinct(cell_changes$project_id)
+  n_libraries <- dplyr::n_distinct(cell_changes$library_id)
 
-The tables below show any changes in cell counts at different stages of filtering.
-
-#### Summary
+  glue::glue("
+    The tables below show changes in cell counts changes between the reference and comparison workflow runs at various stages of processing.<br>
+    There {ifelse(n_added == 1, 'is', 'are a total of')} **{n_libraries}** {ifelse(n_libraries == 1, 'library', 'libraries')} with cell count changes
+    from **{n_projects}** {ifelse(n_projects == 1, 'project', 'projects')}.
+  ") |>
+    knitr::asis_output()
+}
+```
 
 ```{r}
-# Text summary of cell count changes
+# warn if any unfiltered cell counts have changed
+unfiltered_cell_changes <- cell_changes |>
+  dplyr::filter(field == "unfiltered_cells") |>
+  dplyr::summarize(n_changed = sum(change != 0)) |>
+  dplyr::pull(n_changed)
+
+
+if (unfiltered_cell_changes > 0) {
+  knitr::asis_output(c(
+    "<div class=\"alert alert-danger\">",
+    "**Warning**: Unfiltered cell counts have changed between the reference and comparison runs.",
+    "</div>"
+  ))
+}
+```
+
+```{r, eval=has_cell_changes}
+knitr::asis_output("#### Summary")
+```
+
+```{r}
+# Summary table of cell count changes
+
 cell_summary <- cell_changes |>
   dplyr::summarise(
     .by = c("field"),
@@ -318,8 +356,6 @@ report_table(
 ```
 
 
-We will also include a plot with a histogram of the % changes for each metric where at least one sample changed.
-
 ```{r}
 change_fields <- cell_summary |>
   dplyr::filter(n_changed > 0) |>
@@ -333,7 +369,7 @@ cell_plot_df <- cell_changes |>
 
 ggplot(cell_plot_df, aes(x = change_frac)) +
   geom_histogram(bins = 20) +
-  facet_wrap(vars(field)) +
+  facet_wrap(vars(field), ncol = 3) +
   labs(
     title = "Histogram of changes in cell counts",
     x = "Change proportion",

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -358,12 +358,12 @@ cell_summary <- cell_changes |>
     n = dplyr::n(),
     n_changed = sum(is.na(change) | change != 0),
     sample_change_frac = n_changed / n,
-    mean_change_frac = mean(change_frac, na.rm = TRUE)
+    mean_change_frac = mean(abs(change_frac), na.rm = TRUE)
   )
 
 report_table(
   cell_summary,
-  colnames = c("Metric", "Samples", "Number of samples changed", "% of samples changed", "Mean % change")
+  colnames = c("Metric", "Libraries", "Number of libraries changed", "% of libraries changed", "Mean % change")
 ) |>
   DT::formatPercentage(c(4, 5), 2)
 ```

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -59,8 +59,18 @@ report_table <- function(df, options = list(), ...) {
     deferRender = TRUE,
     scrollY = 400,
     scrollCollapse = TRUE,
-    language = list(search = "Filter:")
+    language = list(search = "Filter:"),
+    columnDefs = list(list(
+      # render missing values as "NA" rather than blanks in the table
+      targets = "_all",
+      render = DT::JS(
+        "function(data, type, row, meta) {",
+        "return data === null ? 'NA' : data;",
+        "}"
+      )
+    ))
   )
+
   if (length(options) > 0) {
     # merge default options with user options
     opts <- modifyList(default_opts, options)


### PR DESCRIPTION
Here I am adding the cell count change summaries and detail table to the change report. This is the first half of #853 (but does not fully close it)

There was a bit of error correction I had to do because we are using unboxed JSON for the metrics file, which seems to be causing a bit of a challenge with NA values. But maybe only sometimes? The issue is that we have a few NA values for miQC pass values, which are getting read in as strings. In my testing if we were to export without `auto_unbox`, this would go away. So I added that change for some simplification of reading the file in the future, but for now I had to deal with what we have so there is some added code to be sure the NA values are treated appropriately and the columns turned back into simple vectors where needed. I did pull that out to a separate function at least, which makes other parts a bit simpler anyway.

The remaining code is pretty straightforward as far as building tables goes, I think. The most challenging part was dealing with NA values: we do want to report if a value changed to/from NA, so there is a bit of code I had to add to every `filter()`step to make sure those are retained.  I also added some code in the DT template (adapted from https://github.com/rstudio/DT/issues/322) to make sure they show up as `NA` rather than a blank field in the table. 

I followed the same general plan of attack as before with dynamic text.

I don't know for sure that the plots I made are exactly what we will want to end up with, but it is a bit hard to tell with the number of changes that we have at the moment what those will really look like with real data. So I did not spend too much time on the formatting, but if you have suggestions there, do feel free to make them!

