### PR TITLE
Add read counts

### DIFF
--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -447,6 +447,65 @@ We will also include changes in altExps using the following fields:
 These will require a bit of extra processing, in that we will probably want to extract the altExp names and add those to the field names.
 For example, we would want to use a field like `unfiltered_altexp_total_adt` in the comparison table.
 
+```{r}
+# calculate the read count differences between reference and comparison for selected fields
+read_fields <- c(
+  "unfiltered_total_counts",
+  "unfiltered_total_spliced",
+  "unfiltered_expressed_genes",
+  "filtered_total_counts",
+  "filtered_total_spliced",
+  "filtered_expressed_genes",
+  "processed_total_counts",
+  "processed_total_spliced",
+  "processed_total_logcounts",
+  "processed_expressed_genes",
+  "unfiltered_altexp_total",
+  "filtered_altexp_total",
+  "processed_altexp_total"
+)
+
+read_changes <- metrics_df |>
+  tidyr::drop_na(starts_with("mapped_reads")) |> # remove added/removed libraries
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with(read_fields)
+  ) |>
+  tidyr::unnest_wider( # create columns for separated altexps
+    contains("altexp"),
+    names_sep = "_"
+  ) |>
+  dplyr::rename_with( # rename to keep ref/comp at end
+    \(name) stringr::str_replace(name, "\\.(ref|comp)(_.+)$", "\\2.\\1"),
+    contains("altexp")
+  ) |>
+  tidyr::pivot_longer(
+    cols = starts_with(read_fields),
+    names_pattern = "(.+)\\.(ref|comp)$",
+    names_to = c("field", ".value") # .value separates into `ref` and `comp` fields
+  ) |>
+  dplyr::filter(is.finite(comp) | is.finite(ref)) |> # keep where at least one is finite
+  dplyr::mutate(
+    change = comp - ref,
+    change_frac = change / ref
+  )
+
+changed_read_counts <- read_changes |>
+  dplyr::filter(is.na(change) | change != 0) |>
+  # filter out fields that correspond to known cell count changes
+  dplyr::mutate(
+    # make corresponding field names for cell counts
+    cell_count_field = stringr::str_replace(field, "^(.+?)_.+", "\\1_cells")
+  ) |>
+  dplyr::anti_join( # remove rows that have corresponding cell count changes
+    changed_cell_counts,
+    by = c("project_id", "sample_id", "library_id", "cell_count_field" = "field")
+  )
+```
+
+
 
 Again, we would report only changed metrics, starting with a summary table:
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -522,7 +522,7 @@ unfiltered_read_changes <- changed_read_counts |>
 if (unfiltered_read_changes > 0) {
   glue::glue("
     <div class=\"alert alert-danger\">
-    **Warning**: Unfiltered cell counts have changed between the reference and comparison runs.
+    **Warning**: Total reads for unfiltered cells have changed between the reference and comparison runs.
     **{unfiltered_read_changes}** {ifelse(unfiltered_read_changes == 1, 'library is', 'libraries are')} affected.
     </div>
   ") |>

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -330,10 +330,9 @@ if (!has_cell_changes) {
 
 ```{r}
 # warn if any unfiltered cell counts have changed
-unfiltered_cell_changes <- cell_changes |>
-  dplyr::filter(field == "unfiltered_cells", change != 0) |>
+unfiltered_cell_changes <- changed_cell_counts |>
+  dplyr::filter(stringr::str_detect(field, "^unfiltered_")) |>
   nrow()
-
 
 if (unfiltered_cell_changes > 0) {
   knitr::asis_output(glue::glue("
@@ -494,26 +493,120 @@ read_changes <- metrics_df |>
 
 changed_read_counts <- read_changes |>
   dplyr::filter(is.na(change) | change != 0) |>
-  # filter out fields that correspond to known cell count changes
-  dplyr::mutate(
-    # make corresponding field names for cell counts
+  dplyr::mutate( # make corresponding field names for cell counts
     cell_count_field = stringr::str_replace(field, "^(.+?)_.+", "\\1_cells")
   ) |>
   dplyr::anti_join( # remove rows that have corresponding cell count changes
     changed_cell_counts,
     by = c("project_id", "sample_id", "library_id", "cell_count_field" = "field")
   )
+
+has_read_changes <- nrow(changed_read_counts) > 0
+```
+
+```{r}
+# summary text for read count section
+if (!has_read_changes && !has_cell_changes) {
+  knitr::asis_output(
+    "There are no changes in read counts between the reference and comparison runs."
+  )
+} else if (has_cell_changes) {
+  knitr::asis_output(
+    "There may be changes in read counts, but only those expected due to changes in cell counts as described above."
+  )
+} else {
+  n_projects <- dplyr::n_distinct(changed_read_counts$project_id)
+  n_libraries <- dplyr::n_distinct(changed_read_counts$library_id)
+  glue::glue("
+    The tables below show changes in read counts between the reference and comparison workflow runs at various stages of processing.
+    These include only changes that are not expected based on changes in cell counts.<br>
+    There {ifelse(n_added == 1, 'is', 'are a total of')} **{n_libraries}** {ifelse(n_libraries == 1, 'library', 'libraries')}
+    with read count changes from **{n_projects}** {ifelse(n_projects == 1, 'project', 'projects')}.
+  ") |>
+    knitr::asis_output()
+}
 ```
 
 
+```{r}
+# warn if any unfiltered read counts have changed
+unfiltered_read_changes <- changed_read_counts |>
+  dplyr::filter(stringr::str_detect(field, "^unfiltered_")) |>
+  nrow()
 
-Again, we would report only changed metrics, starting with a summary table:
+if (unfiltered_read_changes > 0) {
+  knitr::asis_output(c(
+    "<div class=\"alert alert-danger\">",
+    "**Warning**: Unfiltered read counts have changed between the reference and comparison runs.",
+    "</div>"
+  ))
+}
+```
 
-| Metric | Number of samples changed | % of samples changed | Mean % change |
-| ----- | --------- | --------- | ---------------- |
-| `scpca_filter_count` | 100 | 20 | -10 |
+```{r, eval=has_read_changes}
+knitr::asis_output("#### Summary")
+```
+```{r}
+# Summary table of read count changes
+read_summary <- read_changes |>
+  dplyr::summarise(
+    .by = c("field"),
+    # count where at least one version has a value
+    n = dplyr::n(),
+    n_changed = sum(is.na(change) | change != 0),
+    sample_change_frac = n_changed / n,
+    mean_change_frac = mean(change_frac, na.rm = TRUE)
+  )
+report_table(
+  read_summary,
+  colnames = c("Metric", "Samples", "Number of samples changed", "% of samples changed", "Mean % change")
+) |>
+  DT::formatPercentage(c(4, 5), 2)
+```
 
-We could then list individual samples with changes, similar to the cell count table.
+```{r eval=has_read_changes}
+# Plot of read count changes
+read_plot_df <- read_changes |>
+  dplyr::filter(field %in% read_fields, change != 0) |>
+  dplyr::mutate(
+    field = factor(field, levels = read_fields),
+  )
+ggplot(read_plot_df, aes(x = change_frac)) +
+  geom_histogram(bins = 20) +
+  facet_wrap(vars(field), ncol = 3) +
+  labs(
+    title = "Histogram of changes in read counts",
+    x = "Change proportion",
+    y = "Number of samples"
+  ) +
+  theme_bw()
+```
+
+```{r, eval=has_read_changes}
+knitr::asis_output("#### Detail")
+```
+
+```{r}
+# Detail table of read count changes
+read_detail <- changed_read_counts |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    field,
+    ref,
+    comp,
+    change,
+    change_frac
+  )
+report_table(
+  read_detail,
+  colnames = c("Project", "Sample", "Library", "Metric", "Reference", "Comparison", "Change", "% change")
+) |>
+  DT::formatPercentage(c(8), 2)
+```
+
+
 
 ## Analysis changes
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -335,12 +335,13 @@ unfiltered_cell_changes <- changed_cell_counts |>
   nrow()
 
 if (unfiltered_cell_changes > 0) {
-  knitr::asis_output(glue::glue("
+  glue::glue("
     <div class=\"alert alert-danger\">
     **Warning**: Unfiltered cell counts have changed between the reference and comparison runs.
     **{unfiltered_cell_changes}** {ifelse(unfiltered_cell_changes == 1, 'library is', 'libraries are')} affected.
     </div>
-  "))
+  ") |>
+    knitr::asis_output()
 }
 ```
 
@@ -351,14 +352,25 @@ knitr::asis_output("#### Summary")
 ```{r}
 # Summary table of cell count changes
 
-cell_summary <- cell_changes |>
+cell_field_n <- cell_changes |>
+  dplyr::count(field)
+
+cell_summary <- changed_cell_counts |>
   dplyr::summarise(
     .by = c("field"),
-    # count where at least one version has a value
-    n = dplyr::n(),
     n_changed = sum(is.na(change) | change != 0),
-    library_change_frac = n_changed / n,
     mean_change_frac = mean(abs(change_frac[which(change != 0)]))
+  ) |>
+  dplyr::left_join(cell_field_n, by = "field") |>
+  dplyr::mutate(
+    library_change_frac = n_changed / n
+  ) |>
+  dplyr::select(
+    field,
+    n,
+    n_changed,
+    library_change_frac,
+    mean_change_frac
   )
 
 report_table(
@@ -370,12 +382,8 @@ report_table(
 
 
 ```{r}
-change_fields <- cell_summary |>
-  dplyr::filter(n_changed > 0) |>
-  dplyr::pull(field)
-
-cell_plot_df <- cell_changes |>
-  dplyr::filter(field %in% change_fields, change != 0) |>
+# summary plot
+cell_plot_df <- changed_cell_counts |>
   dplyr::mutate(
     field = factor(field, levels = cell_fields),
   )
@@ -476,7 +484,7 @@ read_changes <- metrics_df |>
     contains("altexp"),
     names_sep = "_"
   ) |>
-  dplyr::rename_with( # rename to keep ref/comp at end
+  dplyr::rename_with( # rename altexp columns to keep ref/comp at end
     \(name) stringr::str_replace(name, "\\.(ref|comp)(_.+)$", "\\2.\\1"),
     contains("altexp")
   ) |>
@@ -535,39 +543,53 @@ unfiltered_read_changes <- changed_read_counts |>
   nrow()
 
 if (unfiltered_read_changes > 0) {
-  knitr::asis_output(c(
-    "<div class=\"alert alert-danger\">",
-    "**Warning**: Unfiltered read counts have changed between the reference and comparison runs.",
-    "</div>"
-  ))
+  glue::glue("
+    <div class=\"alert alert-danger\">
+    **Warning**: Unfiltered cell counts have changed between the reference and comparison runs.
+    **{unfiltered_read_changes}** {ifelse(unfiltered_read_changes == 1, 'library is', 'libraries are')} affected.
+    </div>
+  ") |>
+    knitr::asis_output()
 }
 ```
 
 ```{r, eval=has_read_changes}
 knitr::asis_output("#### Summary")
 ```
-```{r}
+
+```{r eval=has_read_changes}
 # Summary table of read count changes
-read_summary <- read_changes |>
+read_field_n <- read_changes |>
+  dplyr::count(field)
+
+read_summary <- changed_read_counts |>
   dplyr::summarise(
     .by = c("field"),
-    # count where at least one version has a value
-    n = dplyr::n(),
     n_changed = sum(is.na(change) | change != 0),
-    sample_change_frac = n_changed / n,
-    mean_change_frac = mean(change_frac, na.rm = TRUE)
+    mean_change_frac = mean(abs(change_frac[which(change != 0)]))
+  ) |>
+  dplyr::left_join(read_field_n, by = "field") |>
+  dplyr::mutate(
+    library_change_frac = n_changed / n
+  ) |>
+  dplyr::select(
+    field,
+    n,
+    n_changed,
+    library_change_frac,
+    mean_change_frac
   )
+
 report_table(
   read_summary,
-  colnames = c("Metric", "Samples", "Number of samples changed", "% of samples changed", "Mean % change")
+  colnames = c("Metric", "Libraries", "Number of libraries changed", "% of libraries changed", "Mean % change")
 ) |>
-  DT::formatPercentage(c(4, 5), 2)
+  DT::formatPercentage(c("library_change_frac", "mean_change_frac"), 2)
 ```
 
 ```{r eval=has_read_changes}
 # Plot of read count changes
-read_plot_df <- read_changes |>
-  dplyr::filter(field %in% read_fields, change != 0) |>
+read_plot_df <- changed_read_counts |>
   dplyr::mutate(
     field = factor(field, levels = read_fields),
   )
@@ -586,7 +608,7 @@ ggplot(read_plot_df, aes(x = change_frac)) +
 knitr::asis_output("#### Detail")
 ```
 
-```{r}
+```{r eval=has_read_changes}
 # Detail table of read count changes
 read_detail <- changed_read_counts |>
   dplyr::select(
@@ -603,7 +625,7 @@ report_table(
   read_detail,
   colnames = c("Project", "Sample", "Library", "Metric", "Reference", "Comparison", "Change", "% change")
 ) |>
-  DT::formatPercentage(c(8), 2)
+  DT::formatPercentage("change_frac", 2)
 ```
 
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -384,9 +384,7 @@ report_table(
 ```{r}
 # summary plot
 cell_plot_df <- changed_cell_counts |>
-  dplyr::mutate(
-    field = factor(field, levels = cell_fields),
-  )
+  tidyr::drop_na(change_frac) # remove NAs for plotting
 
 ggplot(cell_plot_df, aes(x = change_frac)) +
   geom_histogram(bins = 20) +
@@ -569,9 +567,8 @@ report_table(
 ```{r eval=has_read_changes}
 # Plot of read count changes
 read_plot_df <- changed_read_counts |>
-  dplyr::mutate(
-    field = factor(field, levels = read_fields),
-  )
+  tidyr::drop_na(change_frac) # remove NAs for plotting
+
 ggplot(read_plot_df, aes(x = change_frac)) +
   geom_histogram(bins = 20) +
   facet_wrap(vars(field), ncol = 3, scales = "free_x") +
@@ -606,8 +603,6 @@ report_table(
 ) |>
   DT::formatPercentage("change_frac", 2)
 ```
-
-
 
 ## Analysis changes
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -219,7 +219,7 @@ has_processing_changes <- nrow(processing_changes) > 0
 
 ```{r}
 # Text summary of processing changes
-if (has_processing_changes) {
+if (!has_processing_changes) {
   knitr::asis_output(
     "All processing fields are the same between the reference and comparison runs."
   )
@@ -429,30 +429,6 @@ report_table(
 
 ### Read count changes {.tabset}
 
-If there are changes in the cell counts, we expect changes in the read counts as well.
-So we may only want to proceed with read count changes for samples where cell counts are unchanged.
-Here again, I think we should warn/highlight any changes > 0.5% of the total.
-Changes to unfiltered counts should also be highlighted, as we do not expect these to change between runs.
-
-- `unfiltered_total_counts`
-- `unfiltered_total_spliced`
-- `unfiltered_expressed_genes`
-- `filtered_total_counts`
-- `filtered_total_spliced`
-- `filtered_expressed_genes`
-- `processed_total_counts`
-- `processed_total_spliced`
-- `processed_total_logcounts`
-- `processed_expressed_genes`
-
-We will also include changes in altExps using the following fields:
-
-- `unfiltered_altexp_total`
-- `filtered_altexp_total`
-- `processed_altexp_total`
-
-These will require a bit of extra processing, in that we will probably want to extract the altExp names and add those to the field names.
-For example, we would want to use a field like `unfiltered_altexp_total_adt` in the comparison table.
 
 ```{r}
 # calculate the read count differences between reference and comparison for selected fields
@@ -501,10 +477,13 @@ read_changes <- metrics_df |>
 
 changed_read_counts <- read_changes |>
   dplyr::filter(is.na(change) | change != 0) |>
-  dplyr::mutate( # make corresponding field names for cell counts
+  dplyr::mutate(
+    # make corresponding field names for cell counts
     cell_count_field = stringr::str_replace(field, "^(.+?)_.+", "\\1_cells")
   ) |>
-  dplyr::anti_join( # remove rows that have corresponding cell count changes
+  dplyr::anti_join(
+    # remove rows that have corresponding cell count changes
+    # adt_scpca_filter_count does not filter cells, so we don't want to include those
     changed_cell_counts,
     by = c("project_id", "sample_id", "library_id", "cell_count_field" = "field")
   )
@@ -518,7 +497,7 @@ if (!has_read_changes && !has_cell_changes) {
   knitr::asis_output(
     "There are no changes in read counts between the reference and comparison runs."
   )
-} else if (has_cell_changes) {
+} else if (!has_read_changes) {
   knitr::asis_output(
     "There may be changes in read counts, but only those expected due to changes in cell counts as described above."
   )
@@ -595,7 +574,7 @@ read_plot_df <- changed_read_counts |>
   )
 ggplot(read_plot_df, aes(x = change_frac)) +
   geom_histogram(bins = 20) +
-  facet_wrap(vars(field), ncol = 3) +
+  facet_wrap(vars(field), ncol = 3, scales = "free_x") +
   labs(
     title = "Histogram of changes in read counts",
     x = "Change proportion",


### PR DESCRIPTION
closes #853 

Here I am adding the read count tables and plots to the report. These follow the same general form as the cell counts, but there were a few extra wrinkles for altexp reporting. The main thing was adding a line to break the list column into a set of columns based on which altExp was being used. `tidyr:unnest_wider` was exactly what I was looking for!

I simplified a few other things along the way: the effort to sort the plots non-alphabetically seemed not worth it, so I ended up removing the code that was dealing with factors there.

One important decision I want feedback on was whether or not to include samples that had cell count changes in the read count tables and plots. It seemed obvious to me that any changes in cell counts would result in changes in read counts, so it seemed like reporting those changes was redundant, and potentially confusing. So I only report the libraries that did not have corresponding cell count changes for a given processing step. I had a thought that we could make an additional table with _all_ changes (in a separate tab), but it still seemed like overkill. But please let me know if you have other thoughts!

Attached is the latest output: [compare-metrics.html.zip](https://github.com/user-attachments/files/20089177/compare-metrics.html.zip)

