### PR TITLE
Pin nextflow version

### DIFF
--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Nextflow
-        uses: nf-core/setup-nextflow@v2.0.0
+        uses: nf-core/setup-nextflow@v2
+        with:
+          version: 24.10.6
 
       - name: Check Nextflow workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false


### PR DESCRIPTION
As a temporary fix for #867, we want to prevent the action from using the latest version of Nextflow, so here I am pinning to the last working version of Nextflow until we can do some debugging.