### PR TITLE
Only check for paired end files if paired end used

### DIFF
--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
-          version: 24.10.6
+          version: latest
 
       - name: Check Nextflow workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -163,8 +163,8 @@ workflow bulk_quant_rna {
     bulk_reads_ch = bulk_channel.make_quants
       .map{meta -> tuple(
         meta,
-        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true)
+        files("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
+        files("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
       )}
 
     // run fastp and salmon for libraries that are not skipping salmon

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -163,8 +163,8 @@ workflow bulk_quant_rna {
     bulk_reads_ch = bulk_channel.make_quants
       .map{meta -> tuple(
         meta,
-        files("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-        files("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
+        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
+        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
       )}
 
     // run fastp and salmon for libraries that are not skipping salmon

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -39,7 +39,7 @@ workflow star_bulk {
         .map{meta -> tuple(
           meta,
           file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-          file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true),
+          file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end'),
           file(meta.star_index, type: 'dir', checkIfExists: true)
         )}
     // map and index


### PR DESCRIPTION
Closes #867

The with #867 was actually closing a longstanding bug where glob expressions didn't actually check if the files exist. Now they do, so we were getting failures with non-paired-end reads. The fix is to only check for existence when we expect them. This worked with a local stub check and Nextflow 25.04, so I expect it to work here as well. 