### PR TITLE
Account for 10X flex example data in metadata

### DIFF
--- a/examples/example_multiplex_pools.tsv
+++ b/examples/example_multiplex_pools.tsv
@@ -1,3 +1,7 @@
 scpca_library_id	scpca_sample_id	barcode_id
 library03	sample03	TAG01
 library03	sample04	TAG02
+library07	sample08	BC001
+library07	sample09	BC002
+library07	sample10	BC003
+library07	sample11	BC004

--- a/examples/example_run_metadata.tsv
+++ b/examples/example_run_metadata.tsv
@@ -6,5 +6,5 @@ run04	library03	sample03;sample04	project01	10Xv3.1	EFO:0009922	cell	Mus_musculu
 run05	library03	sample03;sample04	project01	cellhash_10Xv3.1	EFO:0030012	cell	Mus_musculus.GRCm39.104	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]	NA	NA	NA
 run06	library04	sample05	project01	paired_end	EFO:0003747	bulk	Mus_musculus.GRCm39.104	example_fastqs/run06	NA	NA	NA	NA	NA
 run07	library05	sample06	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run07	NA	NA	NA	NA	example_metadata_files/submitter_celltypes.tsv
-run08	library06	sample07	project02	10X_flex_single	EFO:0022606	nucleus	Homo_sapiens.GRCh38.110	example_fastqs/run08	NA	NA	NA	NA	NA
-run09	library07	sample08;sample09;sample10;sample11	project02	10X_flex_multi	EFO:0022606	cell	Homo_sapiens.GRCh38.110	example_fastqs/run09	NA	NA	NA	NA	NA
+run08	library06	sample07	project02	10Xflex_v1.1_single	EFO:0022606	nucleus	Homo_sapiens.GRCh38.110	example_fastqs/run08	NA	NA	NA	NA	NA
+run09	library07	sample08;sample09;sample10;sample11	project02	10Xflex_v1.1_multi	EFO:0022606	cell	Homo_sapiens.GRCh38.110	example_fastqs/run09	NA	NA	NA	NA	NA

--- a/examples/example_run_metadata.tsv
+++ b/examples/example_run_metadata.tsv
@@ -6,3 +6,5 @@ run04	library03	sample03;sample04	project01	10Xv3.1	EFO:0009922	cell	Mus_musculu
 run05	library03	sample03;sample04	project01	cellhash_10Xv3.1	EFO:0030012	cell	Mus_musculus.GRCm39.104	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]	NA	NA	NA
 run06	library04	sample05	project01	paired_end	EFO:0003747	bulk	Mus_musculus.GRCm39.104	example_fastqs/run06	NA	NA	NA	NA	NA
 run07	library05	sample06	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run07	NA	NA	NA	NA	example_metadata_files/submitter_celltypes.tsv
+run08	library06	sample07	project02	10X_flex_single	EFO:0022606	nucleus	Homo_sapiens.GRCh38.110	example_fastqs/run08	NA	NA	NA	NA	NA
+run09	library07	sample08;sample09;sample10;sample11	project02	10X_flex_multi	EFO:0022606	cell	Homo_sapiens.GRCh38.110	example_fastqs/run09	NA	NA	NA	NA	NA

--- a/examples/example_sample_metadata.tsv
+++ b/examples/example_sample_metadata.tsv
@@ -5,3 +5,8 @@ sample03	TRUE	FALSE	diagnosis3	age3
 sample04	FALSE	TRUE	diagnosis4	age4
 sample05	FALSE	FALSE	diagnosis5	age5
 sample06	FALSE	FALSE	diagnosis6	age6
+sample07	FALSE	FALSE	diagnosis7	age7
+sample08	TRUE	FALSE	diagnosis8	age8
+sample09	TRUE	FALSE	diagnosis9	Age9
+sample10	TRUE	FALSE	diagnosis10	Age10
+sample11	TRUE	FALSE	diagnosis11	Age11

--- a/examples/example_sample_metadata.tsv
+++ b/examples/example_sample_metadata.tsv
@@ -7,6 +7,6 @@ sample05	FALSE	FALSE	diagnosis5	age5
 sample06	FALSE	FALSE	diagnosis6	age6
 sample07	FALSE	FALSE	diagnosis7	age7
 sample08	TRUE	FALSE	diagnosis8	age8
-sample09	TRUE	FALSE	diagnosis9	Age9
-sample10	TRUE	FALSE	diagnosis10	Age10
-sample11	TRUE	FALSE	diagnosis11	Age11
+sample09	TRUE	FALSE	diagnosis9	age9
+sample10	TRUE	FALSE	diagnosis10	age10
+sample11	TRUE	FALSE	diagnosis11	age11


### PR DESCRIPTION
Closes #872 

Here I'm adding example 10X flex data to the folder of example FASTQ files and accounting for these two new libraries in the example metadata files. 

- I downloaded the input FASTQ files for a [singleplexed example](https://10x.vercel.app/datasets/Human_Kidney_4k_GEM-X_Flex) and [multiplexed example](https://10x.vercel.app/datasets/80k_Human_PBMCs_PTG_MultiproPanel_IC_4plex) and copied the FASTQ files to `s3://scpca-references/example-data/example_fastqs`. 
  - These are both examples that use the v1.1.0 probe set for 10X flex. 
  - This was the smallest multiplexed example that I could find that also uses the most recent probe set. It does have feature barcoding too, but that information is in separate FASTQ files. So I just copied over the gene expression FASTQ files and treated that sample as if we don't have any antibody information. 
- I accounted for these samples in the example run, sample, and multiplex metadata files. 
  - For technology, I am using `10x_flex_single` and `10x_flex_multi`. Are we okay with these names or would we prefer something else? 
  - I just filled in the sample metadata with dummy data as we do for the other example data. 
  - I filled in the `barcode_id` for the multiplex pools file with the probe IDs specified in the [experimental design for the multiplexed example](https://cf.10xgenomics.com/samples/cell-exp/9.0.0/80k_Human_PBMCs_PTG_MultiproPanel_IC_4plex_PBMC_BC1_AB1_Rested_Unstained/80k_Human_PBMCs_PTG_MultiproPanel_IC_4plex_PBMC_BC1_AB1_Rested_Unstained_web_summary.html). 

With these updates, we should now be able to run the workflow with `-profile example --run_ids run08,run09` to test the 10X flex set up. 