### PR TITLE
Build new Ensembl v110 cell ranger index

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -124,6 +124,9 @@ process star_index {
 
 workflow {
 
+  // check which refs to build
+  build_all = params.build_refs == "All"
+
   // read in json file with all reference paths
   ref_paths = Utils.readMeta(file(params.ref_json))
 
@@ -133,21 +136,55 @@ workflow {
     .map{
       def reference_name = "${it.organism}.${it.assembly}.${it.version}";
       // reference name & reference file paths for each organism
-      [reference_name, ref_paths[reference_name]]
+      [
+        reference_name, 
+        ref_paths[reference_name],
+        it.include_salmon?.toUpperCase() == "TRUE",
+        it.include_cellranger?.toUpperCase() == "TRUE",
+        it.include_star?.toUpperCase() == "TRUE"
+        ]
     }
+    // filter to only regenerate specified references
+    .filter{ build_all || it[0] in params.build_refs }
+    // add paths to fasta and gtf files
     .map{it +[
       file("${params.ref_rootdir}/${it[1]["ref_fasta"]}"), // path to fasta
       file("${params.ref_rootdir}/${it[1]["ref_gtf"]}") // path to gtf
     ]}
+    // branch to create salmon, cellranger, and star references
+    .branch{ it -> 
+      salmon: it[2] == true
+      cellranger: it[3] == true
+      star: it[4] == true
+    }
 
+  // drop the boolean flags after branching
+  salmon_ref_ch = ref_ch.salmon
+    .map{ ref_name, meta, include_salmon, include_cellranger, include_star, fasta, gtf -> tuple(
+      ref_name, meta, fasta, gtf
+    )}
+
+  cellranger_ref_ch = ref_ch.cellranger
+    .map{ ref_name, meta, include_salmon, include_cellranger, include_star, fasta, gtf -> tuple(
+      ref_name, meta, fasta, gtf
+    )}
+
+  star_ref_ch = ref_ch.star
+    .map{ ref_name, meta, include_salmon, include_cellranger, include_star, fasta, gtf -> tuple(
+      ref_name, meta, fasta, gtf
+    )}
+
+  // now build all the indexes
 
   // generate splici and spliced cDNA reference fasta
-  generate_reference(ref_ch)
+  generate_reference(salmon_ref_ch)
   // create index using reference fastas
-  salmon_index(generate_reference.out.fasta_files, ref_ch)
+  salmon_index(generate_reference.out.fasta_files, salmon_ref_ch)
+
   // create cellranger index
-  cellranger_index(ref_ch)
+  cellranger_index(cellranger_ref_ch)
+
   // create star index
-  star_index(ref_ch)
+  star_index(star_ref_ch)
 
 }

--- a/build-index.nf
+++ b/build-index.nf
@@ -142,9 +142,9 @@ workflow {
       [
         reference_name, 
         ref_paths[reference_name],
-        it.include_salmon?.toUpperCase() == "TRUE",
-        it.include_cellranger?.toUpperCase() == "TRUE",
-        it.include_star?.toUpperCase() == "TRUE"
+        it.include_salmon.toUpperCase() == "TRUE",
+        it.include_cellranger.toUpperCase() == "TRUE",
+        it.include_star.toUpperCase() == "TRUE"
         ]
     }
     // filter to only regenerate specified references

--- a/build-index.nf
+++ b/build-index.nf
@@ -83,10 +83,13 @@ process cellranger_index {
     gunzip -c ${gtf} > genome.gtf
 
     cellranger mkref \
-      --genome=${cellranger_index} \
+      --genome=temp_index \
       --fasta=genome.fasta \
       --genes=genome.gtf \
       --nthreads=${task.cpus}
+
+    # copy index to output directory and clean up 
+    cp -r temp_index ${cellranger_index} && rm -rf temp_index
     """
 }
 

--- a/config/ccdl_inputs.config
+++ b/config/ccdl_inputs.config
@@ -3,3 +3,7 @@ run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 sample_metafile = 's3://ccdl-scpca-data/sample_info/scpca-sample-metadata.tsv'
 cellhash_pool_file = 's3://ccdl-scpca-data/sample_info/scpca-multiplex-pools.tsv'
 project_celltype_metafile = 's3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv'
+
+// CCDL private containers needed for processes that use cellranger and spaceranger 
+CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:9.0.1'
+SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -3,6 +3,10 @@ ref_json     = "${projectDir}/references/scpca-refs.json"
 ref_metadata = "${projectDir}/references/ref-metadata.tsv"
 ref_rootdir  = 's3://scpca-references'
 
+// reference to build in build-index.nf
+// provide a single ref to build or build all 
+build_refs = "All"
+
 // barcode files
 barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
 

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -173,7 +173,7 @@ Adding additional organisms is handled, in part, by the `build-index.nf` workflo
 Follow the below steps to add support for additional references:
 
 1. Download the desired `fasta` and `gtf` files for the organism of choice from `Ensembl`.
-   Add these to the `S3://scpca-references` bucket with the following directory structure, where the root directory here corresponds to the `organism` and the subdirectory corresponds to the `Ensembl` version:
+   Add these to the `s3://scpca-references` bucket with the following directory structure, where the root directory here corresponds to the `organism` and the subdirectory corresponds to the `Ensembl` version:
 
 ```
 homo_sapiens
@@ -186,9 +186,11 @@ homo_sapiens
 ```
 
 2. Add the `organism`, `assembly`, and `version` associated with the new reference to the `ref-metadata.tsv` file.
+Specify which indexes should be built for this reference version, using the `include_salmon`, `include_cellranger`, and `include_star` columns. 
 3. Generate an updated `scpca-refs.json` by running the script, `create-reference-json.R`, located in the `scripts` directory.
 4. Generate the index files using `nextflow run build-index.nf -profile ccdl,batch` from the root directory of this repository.
-5. Ensure that the new reference files are public and in the correct location on S3 (`s3://scpca-references`).
+To generate the index files for only the new organism, use the `--build_refs` argument at the command line and specify the name of the reference to build, e.g., `nextflow run build-index.nf -profile ccdl,batch --build_refs Homo_sapiens.GRCh38.104`. 
+5. Ensure that the new reference files are public and in the correct location on S3 (`s://scpca-references`).
 
 ### Adding additional cell type references
 

--- a/references/ref-metadata.tsv
+++ b/references/ref-metadata.tsv
@@ -1,3 +1,4 @@
-organism	assembly	version
-Homo_sapiens	GRCh38	104
-Mus_musculus	GRCm39	104
+organism	assembly	version	include_salmon	include_cellranger	include_star
+Homo_sapiens	GRCh38	104	TRUE	TRUE	TRUE
+Homo_sapiens	GRCh38	110	FALSE	TRUE	FALSE
+Mus_musculus	GRCm39	104	TRUE	TRUE	TRUE

--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -12,6 +12,19 @@
     "cellranger_index": "homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full",
     "star_index": "homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx"
   },
+  "Homo_sapiens.GRCh38.110": {
+    "ref_dir": "homo_sapiens/ensembl-110",
+    "ref_fasta": "homo_sapiens/ensembl-110/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
+    "ref_fasta_index": "homo_sapiens/ensembl-110/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
+    "ref_gtf": "homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.gtf.gz",
+    "mito_file": "homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.mitogenes.txt",
+    "t2g_3col_path": null,
+    "t2g_bulk_path": null,
+    "splici_index": null,
+    "salmon_bulk_index": null,
+    "cellranger_index": "homo_sapiens/ensembl-110/cellranger_index/Homo_sapiens.GRCh38.110_cellranger_full",
+    "star_index": null
+  },
   "Mus_musculus.GRCm39.104": {
     "ref_dir": "mus_musculus/ensembl-104",
     "ref_fasta": "mus_musculus/ensembl-104/fasta/Mus_musculus.GRCm39.dna.primary_assembly.fa.gz",

--- a/references/scripts/create-reference-json.R
+++ b/references/scripts/create-reference-json.R
@@ -32,6 +32,9 @@ create_ref_entry <- function(
     organism,
     assembly,
     version,
+    include_salmon,
+    include_cellranger,
+    include_star,
     reference_name) {
   # create base reference directory
   ref_dir <- file.path(
@@ -59,32 +62,73 @@ create_ref_entry <- function(
     mito_file = file.path(
       annotation_dir,
       glue::glue("{reference_name}.mitogenes.txt")
-    ),
-    t2g_3col_path = file.path(
-      annotation_dir,
-      glue::glue("{reference_name}.spliced_intron.tx2gene_3col.tsv")
-    ),
-    t2g_bulk_path = file.path(
-      annotation_dir,
-      glue::glue("{reference_name}.spliced_cdna.tx2gene.tsv")
-    ),
-    splici_index = file.path(
-      ref_dir, "salmon_index",
-      glue::glue("{reference_name}.spliced_intron.txome")
-    ),
-    salmon_bulk_index = file.path(
-      ref_dir, "salmon_index",
-      glue::glue("{reference_name}.spliced_cdna.txome")
-    ),
-    cellranger_index = file.path(
-      ref_dir, "cellranger_index",
-      glue::glue("{reference_name}_cellranger_full")
-    ),
-    star_index = file.path(
-      ref_dir, "star_index",
-      glue::glue("{reference_name}.star_idx")
     )
   )
+
+  # fill in values related to salmon/alevin-fry index
+  if (include_salmon) {
+    json_entry <- c(
+      json_entry,
+      list(
+        t2g_3col_path = file.path(
+          annotation_dir,
+          glue::glue("{reference_name}.spliced_intron.tx2gene_3col.tsv")
+        ),
+        t2g_bulk_path = file.path(
+          annotation_dir,
+          glue::glue("{reference_name}.spliced_cdna.tx2gene.tsv")
+        ),
+        splici_index = file.path(
+          ref_dir, "salmon_index",
+          glue::glue("{reference_name}.spliced_intron.txome")
+        ),
+        salmon_bulk_index = file.path(
+          ref_dir, "salmon_index",
+          glue::glue("{reference_name}.spliced_cdna.txome")
+        )
+      )
+    )
+  } else {
+    json_entry <- c(
+      json_entry,
+      list(
+        t2g_3col_path = NA,
+        t2g_bulk_path = NA,
+        splici_index = NA,
+        salmon_bulk_index = NA
+      )
+    )
+  }
+
+  # fill in values related to cellranger index
+  if (include_cellranger) {
+    json_entry <- c(
+      json_entry,
+      list(
+        cellranger_index = file.path(
+          ref_dir, "cellranger_index",
+          glue::glue("{reference_name}_cellranger_full")
+        )
+      )
+    )
+  } else {
+    json_entry$cellranger_index <- NA
+  }
+
+  # fill in values related to star index
+  if (include_star) {
+    json_entry <- c(
+      json_entry,
+      list(
+        star_index = file.path(
+          ref_dir, "star_index",
+          glue::glue("{reference_name}.star_idx")
+        )
+      )
+    )
+  } else {
+    json_entry$star_index <- NA
+  }
 
   return(json_entry)
 }

--- a/references/scripts/create-reference-json.R
+++ b/references/scripts/create-reference-json.R
@@ -4,7 +4,8 @@
 # used with scpca-nf. The output of this script will create a json file where each key corresponds
 # to an organism and contains a dictionary of reference paths. The paths included here are specific
 # to the organization used for storing references in `s3://scpca-references`.
-# To create the json file, use a TSV file that contains three columns, `organism`, `assembly`, and `version`
+# To create the json file, use a TSV file that contains the following columns:
+# `organism`, `assembly`, `version`, `include_salmon`, `include_cellranger`, `include_star`
 
 library(optparse)
 project_root <- rprojroot::find_root(rprojroot::has_dir(".git"))
@@ -62,72 +63,50 @@ create_ref_entry <- function(
     mito_file = file.path(
       annotation_dir,
       glue::glue("{reference_name}.mitogenes.txt")
-    )
+    ),
+    # fill in optional entries with NA
+    t2g_3col_path = NA,
+    t2g_bulk_path = NA,
+    splici_index = NA,
+    salmon_bulk_index = NA,
+    cellranger_index = NA,
+    star_index = NA
   )
 
   # fill in values related to salmon/alevin-fry index
   if (include_salmon) {
-    json_entry <- c(
-      json_entry,
-      list(
-        t2g_3col_path = file.path(
-          annotation_dir,
-          glue::glue("{reference_name}.spliced_intron.tx2gene_3col.tsv")
-        ),
-        t2g_bulk_path = file.path(
-          annotation_dir,
-          glue::glue("{reference_name}.spliced_cdna.tx2gene.tsv")
-        ),
-        splici_index = file.path(
-          ref_dir, "salmon_index",
-          glue::glue("{reference_name}.spliced_intron.txome")
-        ),
-        salmon_bulk_index = file.path(
-          ref_dir, "salmon_index",
-          glue::glue("{reference_name}.spliced_cdna.txome")
-        )
-      )
+    json_entry$t2g_3col_path <- file.path(
+      annotation_dir,
+      glue::glue("{reference_name}.spliced_intron.tx2gene_3col.tsv")
     )
-  } else {
-    json_entry <- c(
-      json_entry,
-      list(
-        t2g_3col_path = NA,
-        t2g_bulk_path = NA,
-        splici_index = NA,
-        salmon_bulk_index = NA
-      )
+    json_entry$t2g_bulk_path <- file.path(
+      annotation_dir,
+      glue::glue("{reference_name}.spliced_cdna.tx2gene.tsv")
+    )
+    json_entry$splici_index <- file.path(
+      ref_dir, "salmon_index",
+      glue::glue("{reference_name}.spliced_intron.txome")
+    )
+    json_entry$salmon_bulk_index <- file.path(
+      ref_dir, "salmon_index",
+      glue::glue("{reference_name}.spliced_cdna.txome")
     )
   }
 
   # fill in values related to cellranger index
   if (include_cellranger) {
-    json_entry <- c(
-      json_entry,
-      list(
-        cellranger_index = file.path(
-          ref_dir, "cellranger_index",
-          glue::glue("{reference_name}_cellranger_full")
-        )
-      )
+    json_entry$cellranger_index <- file.path(
+      ref_dir, "cellranger_index",
+      glue::glue("{reference_name}_cellranger_full")
     )
-  } else {
-    json_entry$cellranger_index <- NA
   }
 
   # fill in values related to star index
   if (include_star) {
-    json_entry <- c(
-      json_entry,
-      list(
-        star_index = file.path(
-          ref_dir, "star_index",
-          glue::glue("{reference_name}.star_idx")
-        )
-      )
+    json_entry$star_index <- file.path(
+      ref_dir, "star_index",
+      glue::glue("{reference_name}.star_idx")
     )
-  } else {
-    json_entry$star_index <- NA
   }
 
   return(json_entry)


### PR DESCRIPTION
Closes #874 

Here I am making a number of adjustments to accommodate building the index for `cellranger` with the fasta from Ensembl v110. I definitely could have just added a new entry to the metadata file and re-ran the workflow and generated all the indices for this Ensembl version, but we don't really need to store any extra index files. And with the changes I'm making here, it should make our index building more modular. 

- I added new columns to the `ref-metadata.tsv` file that are boolean columns indicating whether or not to include an index specific to salmon, cellranger, or star for that reference version. 
- I updated the script that builds the ref json file to only include paths to relevant files and everything else is null. 
- The `build-index.nf` workflow now uses those new columns to indicate which indices should be built for the specified reference. 
- I also wanted the capability to just build this new index and not re-build our previous indices, so I added a parameter to specify which index to build. By default it builds all of them, but now we can add a new reference and then specify to only build that new reference at the command line. 
- Along the way we lost our cellranger and spaceranger containers, so I defined those in the `ccdl_inputs.config` file so that it's only used when using the `ccdl`, `ccdl_staging`, and `ccdl_prod` profiles. 
- Also, the [new cell ranger no longer supports `.` in the name of the index output folders](https://www.10xgenomics.com/support/software/cell-ranger/latest/resources/cr-command-line-arguments#mkref), so we get this error message: 
```
error: invalid value 'Homo_sapiens.GRCh38.110_cellranger_full' for '--genome <GENOME_NAMES>': must contain only letters, digits, underscores, and dashes.

For more information, try '--help'.
```

I don't think we want to touch any of our existing index folders. So to keep the naming consistent, I send the index to a temp folder when calling `mkref` and then copy that to the output folder within the same process. Honestly not sure why we used periods in the first place, but updating that would affect the metadata files for samples on the Portal and I don't think we want to do that. Alternatively, we could update the names of the folders but still keep the reference name the same within the metadata files. 