### PR TITLE
Use empty strings instead of null in refs json

### DIFF
--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -18,12 +18,12 @@
     "ref_fasta_index": "homo_sapiens/ensembl-110/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
     "ref_gtf": "homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.gtf.gz",
     "mito_file": "homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.mitogenes.txt",
-    "t2g_3col_path": null,
-    "t2g_bulk_path": null,
-    "splici_index": null,
-    "salmon_bulk_index": null,
+    "t2g_3col_path": "",
+    "t2g_bulk_path": "",
+    "splici_index": "",
+    "salmon_bulk_index": "",
     "cellranger_index": "homo_sapiens/ensembl-110/cellranger_index/Homo_sapiens.GRCh38.110_cellranger_full",
-    "star_index": null
+    "star_index": ""
   },
   "Mus_musculus.GRCm39.104": {
     "ref_dir": "mus_musculus/ensembl-104",

--- a/references/scripts/create-reference-json.R
+++ b/references/scripts/create-reference-json.R
@@ -64,7 +64,7 @@ create_ref_entry <- function(
       annotation_dir,
       glue::glue("{reference_name}.mitogenes.txt")
     ),
-    # fill in optional entries with NA
+    # fill in optional entries with empty strings
     t2g_3col_path = "",
     t2g_bulk_path = "",
     splici_index = "",

--- a/references/scripts/create-reference-json.R
+++ b/references/scripts/create-reference-json.R
@@ -65,12 +65,12 @@ create_ref_entry <- function(
       glue::glue("{reference_name}.mitogenes.txt")
     ),
     # fill in optional entries with NA
-    t2g_3col_path = NA,
-    t2g_bulk_path = NA,
-    splici_index = NA,
-    salmon_bulk_index = NA,
-    cellranger_index = NA,
-    star_index = NA
+    t2g_3col_path = "",
+    t2g_bulk_path = "",
+    splici_index = "",
+    salmon_bulk_index = "",
+    cellranger_index = "",
+    star_index = ""
   )
 
   # fill in values related to salmon/alevin-fry index


### PR DESCRIPTION
Based on https://github.com/AlexsLemonade/scpca-nf/pull/881#pullrequestreview-2865394976, I went ahead and updated the json file and the script to make the json to use empty strings instead of Null. 