### PR TITLE
Module to run cellranger multi on singleplexed samples

### DIFF
--- a/config/profile_example.config
+++ b/config/profile_example.config
@@ -17,4 +17,9 @@ params {
 
   // celltyping on
   perform_celltyping = true
+
+  // CCDL private containers needed for processes that use cellranger and spaceranger 
+  CELLRANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:9.0.1'
+  SPACERANGER_CONTAINER = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
+
 }

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -1,0 +1,149 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+process cellranger_flex_single {
+  container params.CELLRANGER_CONTAINER
+  publishDir "${meta.cellranger_multi_publish_dir}", mode: 'copy'
+  tag "${meta.run_id}-cellranger-multi"
+  label 'cpus_12'
+  label 'mem_24'
+  input:
+    tuple val(meta), path(fastq_dir), path(cellranger_index)
+  output:
+    tuple val(meta), path(out_id)
+  script:
+    out_id = file(meta.cellranger_multi_publish_dir).name
+    meta += Utils.getVersions(workflow, nextflow)
+    meta_json = Utils.makeJson(meta)
+    """
+    # create config file
+    config_file="${meta.library_id}-config.csv"
+
+    echo "[gene-expression]" > \$config_file
+    echo "reference,${cellranger_index}" >> \$config_file
+    echo "probe-set,${meta.flex_probeset}" >> \$config_file
+    echo "create-bam,false" >> \$config_file
+    echo "" >> \$config_file
+
+    echo "[libraries]" >> \$config_file
+    echo "fastq_id,fastqs,feature_types" >> \$config_file
+    echo "${meta.cr_sample_id},${fastq_dir},Gene Expression" >> \$config_file
+
+    # run cellranger multi
+    #cellranger multi \
+    #  --id=${out_id} \
+    #  --csv=\$config_file \
+    #  --localcores=${task.cpus} \
+    #  --localmem=${task.memory.toGiga()}
+
+    # write metadata
+    echo '${meta_json}' > ${out_id}/scpca-meta.json
+    """
+  stub:
+    out_id = file(meta.cellranger_multi_publish_dir).name
+    meta += Utils.getVersions(workflow, nextflow)
+    meta_json = Utils.makeJson(meta)
+    """
+    mkdir -p ${out_id}/outs
+    echo '${meta_json}' > ${out_id}/scpca-meta.json
+    """
+}
+
+
+workflow flex_quant{
+  take: 
+    flex_channel // a channel with a map of metadata for each flex library to process
+    flex_probesets // map of probe set files for each technology
+    pool_file // path to file with barcode IDs for each sample when using multiplexed 10x flex
+  main:
+
+    flex_channel = flex_channel
+      // add sample names and output directory to metadata
+      .map{
+        def meta = it.clone();
+        // get sample id in fastq files folder that is required by cellranger
+        // cellranger multi only uses a single sample ID so grab from the first fastq file 
+        def fastq_file = file(meta.files_directory).list().findAll{it.contains('.fastq.gz')}[0];
+        meta.cr_sample_id = (fastq_file =~ /^(.+)_S.+_L.+_[R|I].+.fastq.gz$/)[0][1];
+        meta.cellranger_multi_publish_dir =  "${params.checkpoints_dir}/cellranger-multi/${meta.library_id}";
+        meta.flex_probeset = "${params.probes_dir}/${flex_probesets[meta.technology]}";
+        meta // return modified meta object
+      }
+      .branch{
+        make_cellranger_flex: (
+          // input files exist
+          it.files_directory && file(it.files_directory, type: 'dir').exists() && (
+            params.repeat_mapping
+            || !file(it.cellranger_multi_publish_dir).exists()
+            || Utils.getMetaVal(file("${it.cellranger_multi_publish_dir}/scpca-meta.json"), "ref_assembly") != "${it.ref_assembly}"
+          )
+        )
+        has_cellranger_flex: file(it.cellranger_multi_publish_dir).exists()
+        missing_inputs: true
+      }
+
+    // send run ids in flex_channel.missing_inputs to log
+    flex_channel.missing_inputs
+      .subscribe{
+        log.error("The expected input files or cellranger multi results files for ${it.run_id} are missing.")
+      }
+
+    // tuple of inputs for running cell ranger regardless of multi or single
+    flex_reads = flex_channel.make_cellranger_flex
+      .map{ meta -> tuple(
+        meta, 
+        file(meta.files_directory, type: 'dir'),
+        file(meta.cellranger_index, type: 'dir')
+      )}
+      .branch{ it -> 
+        single: it[0]["technology"].contains("single")
+        multi: it[0]["technology"].contains("multi")
+      }
+    
+    // run cellranger flex single
+    cellranger_flex_single(flex_reads.single)
+
+    // TODO: Update with handling for multiplexed channel  
+    // only run if a pool file is provided and there are multiplexed libraries
+    multiplex_pools_ch = Channel.fromPath(pool_file)
+      .splitCsv(header: true, sep: '\t')
+      .map { pool_meta -> tuple(
+        [pool_meta[0], pool_meta[1]],
+        pool_meta
+      )
+      }
+
+    flex_multi_ch = flex_reads.multi
+      .map{ meta, files_dir, index -> tuple(
+        meta.library_id,
+        meta.sample_id.tokenize(","),
+        meta,
+        files_dir,
+        index
+      )}
+      .transpose()
+      .map{ library_id, sample_id, meta, files_dir, index -> tuple(
+        [library_id, sample_id],
+        meta,
+        files_dir, 
+        index
+      )}
+      // tuple of [[library id, sample id], meta, files_dir, index, barcode]
+      .join(multiplex_pools_ch) // join by both library and sample ID
+
+
+    // TODO: Run cellranger multiplexed and then join with single channel 
+
+    // need to join back with skipped reads before outputting
+    flex_quants_ch = flex_channel.has_cellranger_flex
+      .map{meta -> tuple(
+        Utils.readMeta(file("${meta.cellranger_multi_publish_dir}/scpca-meta.json")),
+        file(meta.cellranger_multi_publish_dir, type: 'dir')
+      )}
+
+    // TODO: Make sure both single and multi are incldued before mixing
+    all_flex_ch = cellranger_flex_single.out.mix(flex_quants_ch)
+
+  emit: all_flex_ch
+
+}

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -13,7 +13,6 @@ process cellranger_flex_single {
     tuple val(meta), path(out_id)
   script:
     out_id = file(meta.cellranger_multi_publish_dir).name
-    index="${task.workDir}/${cellranger_index}"
     meta += Utils.getVersions(workflow, nextflow)
     meta_json = Utils.makeJson(meta)
     """
@@ -22,13 +21,13 @@ process cellranger_flex_single {
 
     echo '
     [gene-expression] 
-    reference,${index}
+    reference,${cellranger_index}
     probe-set,${meta.flex_probeset}
     create-bam,false
 
     [libraries]
     fastq_id,fastqs,feature_types
-    ${meta.cr_sample_id},\$PWD/${fastq_dir},Gene Expression
+    ${meta.cr_sample_id},${fastq_dir},Gene Expression
     ' > \$config_file
 
     cat \$config_file


### PR DESCRIPTION
Towards #876 

This PR adds the initial module to run `cellranger multi` on any of the flex samples. Right now, I'm just adding support for processing the singleplexed samples with some TODO code for how to handle the multiplexed samples. I think that should be a separate PR once we decide on the approach. I think the best way to handle this is going to be to have two processes that run `cellranger multi`, one for singleplexed and one for multiplexed. 

So this PR has the following changes: 

- In the main workflow I added a branch for flex libraries and then pass that along to a sub workflow for processing the 10x flex samples. While doing this, I did a little reorganization of the order things are done in the main workflow. Mainly, I moved processing spatial and bulk to be together at the top since we don't use the outputs for anything else later on. 
- I added a `cellranger-flex.nf` file that has a workflow for processing both the singleplex and multiplex samples. Right now, this only has a process for running `cellranger multi` on singleplexed samples and then a little bit of future code for how I envisioned joining in the probe barcodes for multiplexing and prepping the multiplexing data for processing. I can remove this for now if we want to just focus on singleplexed. 
- I did include support for skipping running cellranger if the directory exists, mirroring what we have in other modules. 

I'm filing this as a draft PR because it doesn't work quite yet. So far I can get it so the config CSV looks correct and cellranger starts to run, but I keep hitting the same error that the reference does not create the correct files. I did notice that the [cellranger docs](https://10x.vercel.app/support/software/cell-ranger/latest/advanced/cr-multi-config-csv-opts) specify providing the absolute path and I think technically nextflow is providing a relative path? But I can't seem to figure out how to provide the full path. 

I also tried to change the name of the index. We were having issues generating an index with `.` in it and I thought maybe that was the case here too, but that did not work and gave the same error message. 

I'm a little bit at a loss so going to tag @jashapiro to see if he has any suggestions and also to take a general look at the design of the module and how I chose to deal with separating single and multiplexed samples. 

Below is an example of the error message. 
```
Command executed:

  # create config file
      config_file="library06-config.csv"
  
      echo '
      [gene-expression] 
      reference,Homo_sapiens.GRCh38.110_cellranger_full
      probe-set,s3://scpca-references/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv
      create-bam,false
  
      [libraries]
      fastq_id,fastqs,feature_types
      Human_Kidney_GEM-X_Flex,run08,Gene Expression
      ' > $config_file
  
      # run cellranger multi
      cellranger multi       --id=library06       --csv=$config_file       --localcores=12       --localmem=72
  
      # write metadata
      echo '{
      "run_id": "run08",
      "library_id": "library06",
      "sample_id": "sample07",
      "project_id": "project02",
      "submitter": "",
      "technology": "10Xflex_v1.1_single",
      "assay_ontology_term_id": "EFO:0022606",
      "seq_unit": "nucleus",
      "submitter_cell_types_file": "",
      "feature_barcode_file": "",
      "feature_barcode_geom": "",
      "files_directory": "s3://scpca-references/example-data/example_fastqs/run08",
      "slide_serial_number": "",
      "slide_section": "",
      "ref_assembly": "Homo_sapiens.GRCh38.110",
      "ref_fasta": "s3://scpca-references/homo_sapiens/ensembl-110/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
      "ref_fasta_index": "s3://scpca-references/homo_sapiens/ensembl-110/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
      "ref_gtf": "s3://scpca-references/homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.gtf.gz",
      "mito_file": "s3://scpca-references/homo_sapiens/ensembl-110/annotation/Homo_sapiens.GRCh38.110.mitogenes.txt",
      "salmon_splici_index": "",
      "t2g_3col_path": "",
      "salmon_bulk_index": "",
      "t2g_bulk_path": "",
      "cellranger_index": "s3://scpca-references/homo_sapiens/ensembl-110/cellranger_index/Homo_sapiens.GRCh38.110_cellranger_full",
      "star_index": "",
      "scpca_version": "v0.8.7",
      "nextflow_version": "25.04.2",
      "cr_sample_id": "Human_Kidney_GEM-X_Flex",
      "cellranger_multi_publish_dir": "s3://scpca-references/example-data/scpca_out/checkpoints/cellranger-multi/library06",
      "flex_probeset": "s3://scpca-references/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv"
  }' > library06/scpca-meta.json

Command exit status:
  1

Command output:
  Martian Runtime - v4.0.13
  Serving UI at http://ip-10-1-1-74.ec2.internal:34061?auth=LIBr7lvCw_14Z4CFC0igRWPu-PkOSMG6kiuh43ieEVM
  
  Running preflight checks (please wait)...
  
  [error] Pipestance failed. Error log at:
  library06/SC_MULTI_CS/MULTI_PREFLIGHT/fork0/chnk0-u00cd3648c3/_errors
  
  Log message:
  Your [gene-expression] reference does not contain the expected files, or they are not readable. Please check your reference folder on ip-10-1-1-74.ec2.internal.
  
  Waiting 6 seconds for UI to do final refresh.
  Pipestance failed. Use --noexit option to keep UI running after failure.
  
  2025-05-27 23:20:41 Shutting down.
  Saving pipestance info to "library06/library06.mri.tgz"
  For assistance, upload this file to 10x Genomics by running:
  
  cellranger upload <your_email> "library06/library06.mri.tgz"

Command error:
  Thank you for using cellranger. To help us improve our product,
  anonymized telemetry data has been collected and sent to 10X Genomics.
  This data helps us understand usage patterns, diagnose issues,
  and prioritize improvements.
  You can inspect the telemetry metrics sent by looking in
  /root/.cache/tenx/telemetry/cellranger/cellranger-9.0.1
  For more details on what data is collected and how it's used, please visit
  https://10xgen.com/pipeline-telemetry
  You can disable telemetry at any time by running the following command:
  	cellranger telemetry disable
  Martian Runtime - v4.0.13
  Serving UI at http://ip-10-1-1-74.ec2.internal:34061?auth=LIBr7lvCw_14Z4CFC0igRWPu-PkOSMG6kiuh43ieEVM
  Running preflight checks (please wait)...
  [error] Pipestance failed. Error log at:
  library06/SC_MULTI_CS/MULTI_PREFLIGHT/fork0/chnk0-u00cd3648c3/_errors
  Log message:
  Your [gene-expression] reference does not contain the expected files, or they are not readable. Please check your reference folder on ip-10-1-1-74.ec2.internal.
  Waiting 6 seconds for UI to do final refresh.
  Pipestance failed. Use --noexit option to keep UI running after failure.
  2025-05-27 23:20:41 Shutting down.
  Saving pipestance info to "library06/library06.mri.tgz"
  For assistance, upload this file to 10x Genomics by running:
  cellranger upload <your_email> "library06/library06.mri.tgz"

Work dir:
  s3://nextflow-ccdl-data/work/78/d45db275b032fbf1276787117c88dc
``` 