### PR TITLE
Process for running cellranger multi with multiplexed samples

### DIFF
--- a/bin/create_cellranger_config.py
+++ b/bin/create_cellranger_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import argparse
 import textwrap
 import re
+import pandas
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -29,6 +30,18 @@ parser.add_argument(
     type=Path,
     help="Path to directory containing input FASTQ files",
 )
+parser.add_argument(
+    "--multiplex_pools_file",
+    required=False,
+    type=Path,
+    help="Path to TSV file containing library IDs, sample IDs, and associated barcode IDs for multiplexed libraries",
+)
+parser.add_argument(
+    "--library_id",
+    required=False,
+    type="str",
+    help="Library ID for multiplexed library. Used to filter the multiplex_pools_file to samples present in the multiplexed library.",
+)
 
 args = parser.parse_args()
 
@@ -46,6 +59,16 @@ if not args.probe_set_reference.exists():
 # check that path to FASTQ directory exists
 if not args.fastq_dir.exists():
     raise FileNotFoundError(f"FASTQ directory not found: {args.fastq_dir}")
+
+# check that multiplex pools file and library id exist
+if args.mutliplex_pools_file:
+    if not args.multiplex_pools_file.exists():
+        raise FileNotFoundError(
+            f"Multiplex pools file not found: {args.multiplex_pools_file}"
+        )
+    if not args.library_id:
+        raise ValueError("A library_id must be provided with the multiplex_pools_file")
+
 
 # build config file content
 config_content = textwrap.dedent(
@@ -80,6 +103,38 @@ if not fastq_ids:
 # add fastq_ids to config content
 for fastq_id in fastq_ids:
     config_content += f"{fastq_id},{fastq_path},Gene_Expression\n"
+
+# add multiplex content if present
+if args.multiplex_pools_file:
+    multiplex_pools = pandas.read_csv(args.multiplex_pools_file, sep="\t")
+
+    # check required columns are present
+    required_columns = {"scpca_library_id", "scpca_sample_id", "barcode_id"}
+    if not required_columns.issubset(multiplex_pools.columns):
+        raise ValueError(
+            f"{args.multiplex_pools_file} must contain columns: {', '.join(required_columns)}"
+        )
+
+    # check that library id is present
+    if not multiplex_pools["scpca_library_id"].str.contains(args.library_id).any():
+        raise ValueError(f"{args.library_id} not found in {args.multiplex_pools_file}")
+
+    # filter to samples in multiplexed library
+    filtered_pools = multiplex_pools[
+        multiplex_pools["scpca_library_id"] == args.library_id
+    ]
+
+    # add [samples] section to config
+    config_content += textwrap.dedent(
+        """
+        [samples]
+        sample_id,probe_barcode_ids
+        """.lstrip()
+    )
+
+    # add a row for each sample to the config file
+    for _, row in filtered_pools.iterrows():
+        config_content += f"{row['scpca_sample_id']},{row['barcode_id']}\n"
 
 # save config content to file
 args.config.write_text(config_content)

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -27,7 +27,7 @@ process cellranger_flex_single {
     # run cellranger multi
     cellranger multi \
       --id=${out_id} \
-      --csv=flex_config.csv
+      --csv=flex_config.csv \
       --localcores=${task.cpus} \
       --localmem=${task.memory.toGiga()}
 

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -152,7 +152,7 @@ workflow flex_quant{
     // run cellranger flex single
     cellranger_flex_single(flex_reads.single)
 
-    // run cellranger multiplexed and then join with single channel 
+    // run cellranger multiplexed
     cellranger_flex_multi(flex_reads.multi, file(pool_file))
 
     // combine single and multi outputs

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -161,8 +161,8 @@ workflow flex_quant{
     // need to join back with skipped reads before outputting
     flex_quants_ch = flex_channel.has_cellranger_flex
       .map{meta -> tuple(
-        Utils.readMeta(file("${meta.cellranger_multi_publish_dir}/scpca-meta.json")),
-        file(meta.cellranger_multi_publish_dir, type: 'dir')
+        Utils.readMeta(file("${meta.cellranger_multi_results_dir}/scpca-meta.json")),
+        file(meta.cellranger_multi_results_dir, type: 'dir')
       )}
 
     // Combine single, multi, and skipped libraries

--- a/modules/cellranger-flex.nf
+++ b/modules/cellranger-flex.nf
@@ -76,7 +76,7 @@ process cellranger_flex_multi {
     # run cellranger multi
     cellranger multi \
       --id=${out_id} \
-      --csv=flex_config.csv
+      --csv=flex_config.csv \
       --localcores=${task.cpus} \
       --localmem=${task.memory.toGiga()}
 


### PR DESCRIPTION
Closes #876 

This PR adds a new process for running `cellranger multi` with a library that contains multiplexed samples to the flex workflow. The main difference here is that we need to add a `[samples]` section to the config file that contains the sample Id and the probe barcode ID for each sample. Everything else is the same between single and multiplexed runs. So I adjusted the config creation script to read in an optional multiplexed pools file and library ID arguments. If provided, then a `[samples]` section is created. One thing to note is that the first version of this used `pandas`, but our Docker image doesn't have `pandas` sadly so I converted to using `csv` in python. I think that's fine for this purpose. 

Within Nextflow, I added a process for the multiplexed samples that I pass the multiplex pools file to. As it is right now, I'm passing the entire pools file without any prior filtering to the python script and then doing the filtering within the Python script. I probably could do some filtering in Nextflow, but it's a small TSV file, so I'm not too concerned about passing the whole file to the process every time. Let me know if you prefer a different approach. 

I made a few other smaller changes while I was here: 

- I updated how we handle the output directories to follow the same format we do with spaceranger where we have output organized as: `checkpoints/cellranger-multi/libraryid/runid-cellranger-multi`. This meant defining both the publish directory and the results directory, again following the same approach we use when running spaceranger. 
- In looking at the outputs, the `SC_MULTI_CS` folder, which contains a bunch of intermediate files, was taking up a lot of space, so I decided to remove it. For the multiplexed run, it was ~80 GB out of the total ~92 GB for the output folder. So now the size of that folder is much more reasonable. 
- I fixed a typo where we were missing a `\` in the singleplexed process. 