### PR TITLE
Add some documentation around 10x flex support

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -57,7 +57,6 @@ SCE
 scpca
 ScPCA
 Seqera
-Singleplexed
 singleplexed
 SingleR
 subdiagnosis

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -58,6 +58,7 @@ scpca
 ScPCA
 Seqera
 Singleplexed
+singleplexed
 SingleR
 subdiagnosis
 tabset

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -26,6 +26,7 @@ et
 fastq
 FASTQ
 formatter
+GEX
 Github
 glioblastoma
 GRCh
@@ -47,6 +48,7 @@ nf
 Oligos
 PanglaoDB
 parallelizing
+PBMCs
 pixi
 pre
 reproducibility
@@ -55,6 +57,7 @@ SCE
 scpca
 ScPCA
 Seqera
+Singleplexed
 SingleR
 subdiagnosis
 tabset

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -622,6 +622,7 @@ _Note: The workflow is currently set up to work only with spatial transcriptomic
 ### 10x Flex gene expression libraries 
 
 Libraries processed with the [GEM-X Flex Gene Expression protocol from 10x Genomics](https://www.10xgenomics.com/products/flex-gene-expression) using either single or multiplexing will be quantified using [`cellranger multi`](https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-flex-multi-frp) instead of `salmon` and `alevin-fry`. 
+*Note:* Currently only libraries processed using the v1.1.0 probe set are supported. 
 
 There are no special considerations for singleplexed libraries other than indicating the appropriate `technology` in the `run_metadata.tsv` file, `10Xflex_v1.1_single`. 
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -26,8 +26,8 @@
 - [Special considerations for specific data types](#special-considerations-for-specific-data-types)
   - [Libraries with additional feature data (ADT or cellhash)](#libraries-with-additional-feature-data-adt-or-cellhash)
   - [Multiplexed (cellhash) libraries](#multiplexed-cellhash-libraries)
-  - [Spatial transcriptomics libraries](#spatial-transcriptomics-libraries)
   - [10x Flex gene expression libraries](#10x-flex-gene-expression-libraries)
+  - [Spatial transcriptomics libraries](#spatial-transcriptomics-libraries)
 - [Additional workflow settings](#additional-workflow-settings)
   - [Repeating mapping steps](#repeating-mapping-steps)
 - [The `merge.nf` workflow](#the-mergenf-workflow)
@@ -607,18 +607,6 @@ Other columns may be included for reference (such as the `feature_barcode_file` 
 
 We have provided an example multiplex pool file for reference that can be found in [`examples/example_multiplex_pools.tsv`](examples/example_multiplex_pools.tsv).
 
-### Spatial transcriptomics libraries
-
-To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated `.jpg` file must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file).
-The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
-
-You will also need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Space Ranger software from 10X Genomics](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest).
-For licensing reasons, we cannot provide a Docker container with Space Ranger for you.
-As an example, the Dockerfile that we used to build Space Ranger can be found [here](https://github.com/AlexsLemonade/alsf-scpca/tree/main/images/spaceranger).
-
-After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.SPACERANGER_CONTAINER` to the registry location and image ID in the `user_template.config` file.
-_Note: The workflow is currently set up to work only with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods._
-
 ### 10x Flex gene expression libraries 
 
 Libraries processed with the [GEM-X Flex Gene Expression protocol from 10x Genomics](https://www.10xgenomics.com/products/flex-gene-expression) using either single or multiplexing will be quantified using [`cellranger multi`](https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-flex-multi-frp) instead of `salmon` and `alevin-fry`. 
@@ -637,6 +625,19 @@ This file will contain one row for each library-sample pair (i.e. a library cont
 | `scpca_library_id` | Multiplexed library ID matching values in the run metadata file. |
 | `scpca_sample_id`  | Sample ID for a sample contained in the listed multiplexed library |
 | `barcode_id`       | The probe barcode ID used for the sample within the library (e.g., `BC001`) |
+
+
+### Spatial transcriptomics libraries
+
+To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated `.jpg` file must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file).
+The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
+
+You will also need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Space Ranger software from 10X Genomics](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest).
+For licensing reasons, we cannot provide a Docker container with Space Ranger for you.
+As an example, the Dockerfile that we used to build Space Ranger can be found [here](https://github.com/AlexsLemonade/alsf-scpca/tree/main/images/spaceranger).
+
+After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.SPACERANGER_CONTAINER` to the registry location and image ID in the `user_template.config` file.
+_Note: The workflow is currently set up to work only with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods._
 
 
 ## Additional workflow settings

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -7,6 +7,7 @@
   - [Testing the workflow with stub processes](#testing-the-workflow-with-stub-processes)
   - [Running `scpca-nf` for ScPCA Portal release](#running-scpca-nf-for-scpca-portal-release)
   - [Processing example data](#processing-example-data)
+    - [Processing example 10x Flex data](#processing-example-10x-flex-data)
 - [Maintaining references for `scpca-nf`](#maintaining-references-for-scpca-nf)
   - [Adding additional organisms](#adding-additional-organisms)
   - [Adding additional cell type references](#adding-additional-cell-type-references)
@@ -135,6 +136,26 @@ nextflow run AlexsLemonade/scpca-nf -r development -profile example,batch
 
 After successful completion of the run, the `scpca_out` folder containing the outputs from `scpca-nf` should be zipped up and stored at the following location: `s3://scpca-references/example-data/scpca_out.zip`.
 Make sure to adjust the settings to make the zip file publicly accessible.
+
+#### Processing example 10x Flex data 
+
+Any samples that are processed using the [GEM-X Flex Gene Expression protocol from 10x Genomics](https://www.10xgenomics.com/products/flex-gene-expression) are quantified using [`cellranger multi`](https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-flex-multi-frp) instead of `alevin-fry`. 
+
+There are two example datasets available on S3 that can be used for testing changes to the `cellranger-flex.nf` module.
+FASTQ files were downloaded from 10x Genomics, unzipped, and then copied to `s3://scpca-references/example-data/example_fastqs`. 
+The information for these datasets were then added to `examples/example_run_metadata.tsv`, `examples/example_sample_metadata.tsv`, and `example_multiplex_pools.tsv`. 
+The datasets used are listed below: 
+
+1. [library06 - Human Kidney Nuclei - Singleplexed](https://10x.vercel.app/datasets/Human_Kidney_4k_GEM-X_Flex)
+2. [library07 - Human PBMCs - Multiplexed](https://10x.vercel.app/datasets/80k_Human_PBMCs_PTG_MultiproPanel_IC_4plex)
+
+For the second dataset (Human PBMCs), only the GEX FASTQ files were saved to S3. 
+
+To process these datasets, use the `example` profile and specify the appropriate run, library, or sample IDs: 
+
+```sh
+nextflow run AlexsLemonade/scpca-nf -r <branch or revision> -profile example,batch --run_ids library06,library07
+```
 
 ## Maintaining references for `scpca-nf`
 


### PR DESCRIPTION
Closes #888 

Here I am adding some documentation around running samples with 10x flex. 

- For internal instructions, I just added a section that mentions the example datasets and how to run the workflow to process those samples. I didn't think it needed much, but I just wanted to note where the example datasets came from and also how to actually run those samples with the `example` profile. 
- While I was here, I updated the external documentation to note that flex samples can be used. 
  - I updated the `technology` column options to include 10x flex.
  - I added a section within the special considerations section for using 10x flex data. The main thing I wanted to note is that `cellranger multi` is used and how multiplexed samples are dealt with. Let me know if you think there is more that we should add here? 