### PR TITLE
Update QC report tables to account for cellranger-multi processing 

### DIFF
--- a/bin/generate_unfiltered_sce_cellranger.R
+++ b/bin/generate_unfiltered_sce_cellranger.R
@@ -135,16 +135,16 @@ if (file.exists(opt$metrics_file)) {
     stringr::str_remove_all(",") |>
     as.numeric()
 
-  # calculate total mapped reads and reformat
-  mapped_reads <- metrics_df |>
+  # grab percentage of total mapped reads and reformat
+  pct_mapped_reads <- metrics_df |>
     dplyr::filter(metric == "Confidently mapped reads in cells") |>
     dplyr::pull(value) |>
     # mapped reads is provided as % of reads in cells so convert to number
     stringr::str_remove("%") |>
-    as.numeric() * total_reads
+    as.numeric()
 } else {
   total_reads <- NA
-  mapped_reads <- NA
+  pct_mapped_reads <- NA
 }
 
 # make metadata list with scpca information and add to object
@@ -156,9 +156,9 @@ metadata_list <- list(
   reference_index = basename(opt$reference_index),
   reference_probeset = basename(opt$reference_probeset),
   total_reads = total_reads,
-  mapped_reads = mapped_reads,
+  pct_mapped_reads = pct_mapped_reads,
   mapping_tool = "cellranger-multi",
-  cellranger_num_cells = nrow(unfiltered_sce),
+  cellranger_num_cells = ncol(unfiltered_sce),
   tech_version = opt$technology,
   assay_ontology_term_id = opt$assay_ontology_term_id,
   seq_unit = opt$seq_unit,

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -118,7 +118,7 @@ process make_unfiltered_sce_cellranger {
     label 'mem_8'
     tag "${meta.library_id}"
     input:
-        tuple val(meta), path(cellranger_dir), path(versions_file), path(ref_gtf), path(submitter_cell_types_file)
+        tuple val(meta), path(cellranger_dir), path(versions_file), path(metrics_file), path(ref_gtf), path(submitter_cell_types_file)
         path sample_metafile
     output:
         tuple val(meta), path(unfiltered_rds)
@@ -129,6 +129,7 @@ process make_unfiltered_sce_cellranger {
           --cellranger_dir ${cellranger_dir} \
           --unfiltered_file ${unfiltered_rds} \
           --versions_file ${versions_file} \
+          --metrics_file ${metrics_file} \
           --reference_index ${meta.cellranger_index} \
           --reference_probeset ${meta.flex_probeset} \
           --technology ${meta.technology} \

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -257,21 +257,39 @@ if (!has_multiplex) {
 ```{r }
 # extract sce metadata containing processing information as table
 unfiltered_meta <- metadata(unfiltered_sce)
+mapping_tool <- unfiltered_meta$mapping_tool
 
 library_information <- tibble::tibble(
   "Library id" = library_id,
   "Sample id" = paste(sample_id, collapse = ", "),
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Data modalities" = paste(modalities, collapse = ", "),
-  "Cells reported by alevin-fry" =
-    format(unfiltered_meta$af_num_cells, big.mark = ",", scientific = FALSE),
-  "Number of genes assayed" =
-    format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE),
   "Number of RNA-seq reads sequenced" =
     format(unfiltered_meta$total_reads, big.mark = ",", scientific = FALSE),
   "Percent of RNA-seq reads mapped to transcripts" =
-    paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%")
+    paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%"),
+  mapping_tool = format(mapping_tool)
 )
+
+if (mapping_tool == "alevin-fry") {
+  library_information <- library_information |>
+    mutate(
+      "Cells reported by alevin-fry" =
+        format(unfiltered_meta$af_num_cells, big.mark = ",", scientific = FALSE),
+      "Number of genes assayed" =
+        format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE),
+    )
+}
+
+if (mapping_tool == "cellranger-multi") {
+  library_information <- library_information |>
+    mutate(
+      "Cells reported by cellranger multi" =
+        format(unfiltered_meta$cellranger_num_cells, big.mark = ",", scientific = FALSE),
+      "Number of probes assayed" =
+        format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE)
+    )
+}
 
 if (has_adt) {
   adt_exp <- altExp(filtered_sce, "adt") # must be filtered_sce in case has_processed is FALSE
@@ -323,20 +341,32 @@ knitr::kable(library_information, align = "r") |>
 # define transcript type
 transcript_type <- paste(unfiltered_meta$transcript_type, collapse = " ")
 
-processing_info <- tibble::tibble(
-  "Salmon version" = format(unfiltered_meta$salmon_version),
-  "Alevin-fry version" = format(unfiltered_meta$alevinfry_version),
-  "Transcriptome index" = format(unfiltered_meta$reference_index),
-  "Alevin-fry droplet detection" = format(unfiltered_meta$af_permit_type),
-  "Resolution" = format(unfiltered_meta$af_resolution),
-  "Transcripts included" = dplyr::case_when(
-    transcript_type == "total spliced" ~ "Total and spliced only",
-    transcript_type == "spliced" ~ "Spliced only",
-    TRUE ~ transcript_type
-  )
-) |>
-  reformat_nulls() |>
-  t()
+if (mapping_tool == "alevin-fry") {
+  processing_info <- tibble::tibble(
+    "Salmon version" = format(unfiltered_meta$salmon_version),
+    "Alevin-fry version" = format(unfiltered_meta$alevinfry_version),
+    "Transcriptome index" = format(unfiltered_meta$reference_index),
+    "Alevin-fry droplet detection" = format(unfiltered_meta$af_permit_type),
+    "Resolution" = format(unfiltered_meta$af_resolution),
+    "Transcripts included" = dplyr::case_when(
+      transcript_type == "total spliced" ~ "Total and spliced only",
+      transcript_type == "spliced" ~ "Spliced only",
+      TRUE ~ transcript_type
+    )
+  ) |>
+    reformat_nulls() |>
+    t()
+}
+
+if (mapping_tool == "cellranger-multi") {
+  processing_info <- tibble::tibble(
+    "Cellranger version" = format(unfiltered_meta$cellranger_version),
+    "Transcriptome index" = format(unfiltered_meta$reference_index),
+    "Reference probe set" = format(unfiltered_meta$reference_probeset)
+  ) |>
+    reformat_nulls() |>
+    t()
+}
 
 
 # make table with processing information
@@ -405,7 +435,7 @@ if (
     <div class=\"alert alert-warning\">
 
     This library may contain a low number of cells and was unable to be filtered using `DropletUtils`.
-    Droplets with a total UMI count ≥ {metadata(filtered_sce)$umi_cutoff} are included in the filtered `SingleCellExperiment` object.
+    Droplets with a total UMI count <U+2265> {metadata(filtered_sce)$umi_cutoff} are included in the filtered `SingleCellExperiment` object.
 
     </div>
   ")

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -264,10 +264,6 @@ library_information <- tibble::tibble(
   "Sample id" = paste(sample_id, collapse = ", "),
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Data modalities" = paste(modalities, collapse = ", "),
-  "Number of RNA-seq reads sequenced" =
-    format(unfiltered_meta$total_reads, big.mark = ",", scientific = FALSE),
-  "Percent of RNA-seq reads mapped to transcripts" =
-    paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%"),
   mapping_tool = format(mapping_tool)
 )
 
@@ -278,6 +274,10 @@ if (mapping_tool == "alevin-fry") {
         format(unfiltered_meta$af_num_cells, big.mark = ",", scientific = FALSE),
       "Number of genes assayed" =
         format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE),
+      "Number of RNA-seq reads sequenced" =
+        format(unfiltered_meta$total_reads, big.mark = ",", scientific = FALSE),
+      "Percent of RNA-seq reads mapped to transcripts" =
+        paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%"),
     )
 }
 
@@ -287,7 +287,11 @@ if (mapping_tool == "cellranger-multi") {
       "Cells reported by cellranger multi" =
         format(unfiltered_meta$cellranger_num_cells, big.mark = ",", scientific = FALSE),
       "Number of probes assayed" =
-        format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE)
+        format(nrow(unfiltered_sce), big.mark = ",", scientific = FALSE),
+      "Number of RNA-seq reads sequenced" =
+        format(unfiltered_meta$total_reads, big.mark = ",", scientific = FALSE),
+      "Percent of RNA-seq reads mapped to probes" =
+        paste0(unfiltered_meta$pct_mapped_reads, "%"),
     )
 }
 


### PR DESCRIPTION
Closes #896 

This PR includes changes to the tables shown in the QC report to account for samples that were processed with `cellranger-multi` instead of `alevin-fry`. I ended up grabbing the `mapping_tool` from the metadata and modifying the raw library metrics and pre-processing information tables depending on which mapping tool is used. 
Here's an example of the updated report with a cellranger run:
[library06_qc 2.html.zip](https://github.com/user-attachments/files/20929558/library06_qc.2.html.zip)

One thing that we display in the table is the total reads and the percentage of reads mapped to the transcriptome. This information lives in the `metrics_summary.csv` file output in the `per_sample_outs` folder by `cellranger-multi`. So I made a few changes to the actual workflow to ensure we grab that file and read that into the script used to generate the unfiltered SCE object. Because it lives in the `per_sample_outs` regardless of library type and the raw file is either in `multi` or `per_sample_outs`, I had to emit those folders in the same output for singleplexed samples to avoid a bunch of joining. I then realized we weren't actually using the separate outputs, so I just combined them which I think is totally fine since we then select the files we need for downstream later. 

I then use the `metrics_summary.csv` to grab the total reads and the mapped reads. Note that in `alevin-fry` they report a number of reads for the mapped reads, but `cellranger-multi` reports a percentage. I ended up just keeping the % rather than converting to the actual number of reads since in the report we show the %, but let me know if you would like me to change it? 

Also, grabbing the metrics themselves was a little weird... There are a lot of very similarly worded names for the metrics in the summary file. The cellranger docs direct you to look at the web summary for definitions of each of the metrics. 
<img width="581" alt="Screenshot 2025-06-26 at 11 02 47 AM" src="https://github.com/user-attachments/assets/d851bd60-8479-4bd6-8f05-f3710040cf28" />

So I used the web summary from one of the libraries to find the row with the description of what I think is the total percentage of reads that were mapped. 
<img width="1267" alt="Screenshot 2025-06-26 at 11 03 03 AM" src="https://github.com/user-attachments/assets/aa50713e-5886-4463-9988-f153a7c5e06d" />
Here's an example of the metrics file for reference. 
[metrics_summary.csv](https://github.com/user-attachments/files/20929516/metrics_summary.csv)

So I chose to use the `Confidently mapped reads in cells` number. This metric appears twice in the metrics summary, but once where `Group Name` is empty and once where it has `GEX_1`. For singleplexed the number is the same each time it shows up, but for multiplexed the number is different and the `GEX_1` number corresponds to what's shown in the summary report... So I filtered to that group before grabbing the metrics. 