### PR TITLE
Update 10x flex multiplexed filename outputs and document docker requirements

### DIFF
--- a/external-instructions.md
+++ b/external-instructions.md
@@ -612,7 +612,12 @@ We have provided an example multiplex pool file for reference that can be found 
 Libraries processed with the [GEM-X Flex Gene Expression protocol from 10x Genomics](https://www.10xgenomics.com/products/flex-gene-expression) using either single or multiplexing will be quantified using [`cellranger multi`](https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-flex-multi-frp) instead of `salmon` and `alevin-fry`. 
 *Note:* Currently only libraries processed using the v1.1.0 probe set are supported. 
 
-There are no special considerations for singleplexed libraries other than indicating the appropriate `technology` in the `run_metadata.tsv` file, `10Xflex_v1.1_single`. 
+You will need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Cell Ranger software from 10X Genomics](https://www.10xgenomics.com/support/software/cell-ranger/downloads).
+For licensing reasons, we cannot provide a Docker container with Cell Ranger for you.
+As an example, the Dockerfile that we used to build Cell Ranger can be found [here](https://github.com/AlexsLemonade/alsf-scpca/tree/main/images/cellranger).
+After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.CELLRANGER_CONTAINER` to the registry location and image ID in the `user_template.config` file.
+
+There are no special considerations for singleplexed libraries other than indicating the appropriate `technology` in the `run_metadata.tsv` file, `10Xflex_v1.1_single`.
 
 If the libraries are multiplexed, the appropriate `technology` term, `10Xflex_v1.1_multi`, will need to be indicated in the `run_metadata.tsv` file and an additional TSV file, `cellhash_pool_file`, must be provided. 
 When processing multiplexed libraries, demultiplexing will be performed by `cellranger multi`, so the quantified gene expression data for each sample will be output separately.  

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -11,7 +11,7 @@ process export_anndata {
       tuple val(meta), path("${file_prefix}_${file_type}_*.h5ad"), val(file_type)
     script:
       // set output file names based on having 10x flex multiplexed or not 
-      if (meta.technology == "10Xflex_v1.1_multi"){
+      if (meta.technology in ["10Xflex_v1.1_multi"]){
         file_prefix = "${meta.library_id}-${meta.sample_id}"
       } else {
         file_prefix = "${meta.library_id}"
@@ -42,7 +42,7 @@ process export_anndata {
       """
     stub:
       // set output file names based on having 10x flex multiplexed or not 
-      if (meta.technology == "10Xflex_v1.1_multi"){
+      if (meta.technology in ["10Xflex_v1.1_multi"]){
         file_prefix = "${meta.library_id}-${meta.sample_id}"
       } else {
         file_prefix = "${meta.library_id}"

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -8,11 +8,18 @@ process export_anndata {
     input:
       tuple val(meta), path(sce_file), val(file_type)
     output:
-      tuple val(meta), path("${meta.library_id}_${file_type}_*.h5ad"), val(file_type)
+      tuple val(meta), path("${file_prefix}_${file_type}_*.h5ad"), val(file_type)
     script:
-      rna_h5ad_file = "${meta.library_id}_${file_type}_rna.h5ad"
-      feature_h5ad_file = "${meta.library_id}_${file_type}_${meta.feature_type}.h5ad"
-      pca_meta_file = "${meta.library_id}_${file_type}_pca.tsv"
+      // set output file names based on having 10x flex multiplexed or not 
+      if (meta.technology == "10Xflex_v1.1_multi"){
+        file_prefix = "${meta.library_id}-${meta.sample_id}"
+      } else {
+        file_prefix = "${meta.library_id}"
+      }
+
+      rna_h5ad_file = "${file_prefix}_${file_type}_rna.h5ad"
+      feature_h5ad_file = "${file_prefix}_${file_type}_${meta.feature_type}.h5ad"
+      pca_meta_file = "${file_prefix}_${file_type}_pca.tsv"
       feature_present = meta.feature_type in ["adt"]
       """
       sce_to_anndata.R \
@@ -34,8 +41,15 @@ process export_anndata {
 
       """
     stub:
-      rna_h5ad_file = "${meta.library_id}_${file_type}_rna.h5ad"
-      feature_h5ad_file = "${meta.library_id}_${file_type}_${meta.feature_type}.h5ad"
+      // set output file names based on having 10x flex multiplexed or not 
+      if (meta.technology == "10Xflex_v1.1_multi"){
+        file_prefix = "${meta.library_id}-${meta.sample_id}"
+      } else {
+        file_prefix = "${meta.library_id}"
+      }
+
+      rna_h5ad_file = "${file_prefix}_${file_type}_rna.h5ad"
+      feature_h5ad_file = "${file_prefix}_${file_type}_${meta.feature_type}.h5ad"
       feature_present = meta.feature_type in ["adt"]
       """
       touch ${rna_h5ad_file}

--- a/modules/publish-sce.nf
+++ b/modules/publish-sce.nf
@@ -19,7 +19,7 @@ process qc_publish_sce {
     workflow_version = workflow.revision ?: workflow.manifest.version
 
     // set output file names based on having 10x flex multiplexed or not 
-    if (meta.technology == "10Xflex_v1.1_multi"){
+    if (meta.technology in ["10Xflex_v1.1_multi"]){
       file_prefix = "${meta.library_id}-${meta.sample_id}"
     } else {
       file_prefix = "${meta.library_id}"
@@ -79,7 +79,7 @@ process qc_publish_sce {
       --metrics_json "${metrics_json}"
     """
   stub:
-    if (meta.technology == "10Xflex_v1.1_multi"){
+    if (meta.technology in ["10Xflex_v1.1_multi"]){
       file_prefix = "${meta.library_id}-${meta.sample_id}"
     } else {
       file_prefix = "${meta.library_id}"

--- a/modules/publish-sce.nf
+++ b/modules/publish-sce.nf
@@ -18,18 +18,25 @@ process qc_publish_sce {
     workflow_url = workflow.repository ?: workflow.manifest.homePage
     workflow_version = workflow.revision ?: workflow.manifest.version
 
+    // set output file names based on having 10x flex multiplexed or not 
+    if (meta.technology == "10Xflex_v1.1_multi"){
+      file_prefix = "${meta.library_id}-${meta.sample_id}"
+    } else {
+      file_prefix = "${meta.library_id}"
+    }
+
     // names for final output files
-    unfiltered_out = "${meta.library_id}_unfiltered.rds"
-    filtered_out = "${meta.library_id}_filtered.rds"
-    processed_out = "${meta.library_id}_processed.rds"
-    qc_report = "${meta.library_id}_qc.html"
-    metadata_json = "${meta.library_id}_metadata.json"
-    metrics_json = "${meta.library_id}_metrics.json"
+    unfiltered_out = "${file_prefix}_unfiltered.rds"
+    filtered_out = "${file_prefix}_filtered.rds"
+    processed_out = "${file_prefix}_processed.rds"
+    qc_report = "${file_prefix}_qc.html"
+    metadata_json = "${file_prefix}_metadata.json"
+    metrics_json = "${file_prefix}_metrics.json"
 
     // check for cell types
     // only provide report template if cell typing was performed and either singler or cellassign was used
     has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
-    celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
+    celltype_report = "${file_prefix}_celltype-report.html" // rendered HTML
 
     """
     # move files for output
@@ -72,15 +79,21 @@ process qc_publish_sce {
       --metrics_json "${metrics_json}"
     """
   stub:
-    unfiltered_out = "${meta.library_id}_unfiltered.rds"
-    filtered_out = "${meta.library_id}_filtered.rds"
-    processed_out = "${meta.library_id}_processed.rds"
-    qc_report = "${meta.library_id}_qc.html"
-    metadata_json = "${meta.library_id}_metadata.json"
-    metrics_json = "${meta.library_id}_metrics.json"
+    if (meta.technology == "10Xflex_v1.1_multi"){
+      file_prefix = "${meta.library_id}-${meta.sample_id}"
+    } else {
+      file_prefix = "${meta.library_id}"
+    }
+
+    unfiltered_out = "${file_prefix}_unfiltered.rds"
+    filtered_out = "${file_prefix}_filtered.rds"
+    processed_out = "${file_prefix}_processed.rds"
+    qc_report = "${file_prefix}_qc.html"
+    metadata_json = "${file_prefix}_metadata.json"
+    metrics_json = "${file_prefix}_metrics.json"
 
     has_celltypes = params.perform_celltyping && (meta.singler_model_file || meta.cellassign_reference_file)
-    celltype_report = "${meta.library_id}_celltype-report.html" // rendered HTML
+    celltype_report = "${file_prefix}_celltype-report.html" // rendered HTML
 
     """
     touch ${unfiltered_out}


### PR DESCRIPTION
Closes #901 
Closes #907 

Here I'm updating the two processes that publish the SCE and AnnData files to rename any multiplexed 10x flex samples to have `<library_id>-<sample_id>` as the file prefix instead of just library id. This was a pretty simple fix and I just checked for the 10X flex technology before defining the prefix to use for the files. Is there a different approach that would be preferred? 

While I was here, I went ahead and updated the instructions to use Docker to address #907. I mostly copied the same language we have in the spatial section, but updated it for cellranger. 