### PR TITLE
Add barcodes column to cellranger SCEs

### DIFF
--- a/bin/generate_unfiltered_sce_cellranger.R
+++ b/bin/generate_unfiltered_sce_cellranger.R
@@ -102,6 +102,8 @@ colnames(unfiltered_sce) <- stringr::str_extract(colnames(unfiltered_sce), "^([A
 
 # remove existing colData
 colData(unfiltered_sce) <- NULL
+# add barcodes column
+unfiltered_sce$barcodes <- colnames(unfiltered_sce)
 
 # select just ID column of rowData and rename
 rowdata_df <- rowData(unfiltered_sce) |>


### PR DESCRIPTION
Closes #902

This PR makes one more small change to make sure everything runs as expected with the 10x flex samples. It looks like making the SCE with `fishpond` adds a `barcodes` column to the `colData`. We use that column later in the workflow for adding cell types, so we need to make sure that exists. This just adds a line to add that column to the unfiltered SCE when reading in cellranger output. 

I was able to run one of the flex samples through with cell typing and all reports look good, so I think once we add this in we can close out #902 🎉 