### PR TITLE
Update Nextflow configs to use recommended structure

### DIFF
--- a/config/ccdl_inputs.config
+++ b/config/ccdl_inputs.config
@@ -1,5 +1,7 @@
 // input file locations for CCDL
-run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-sample_metafile = 's3://ccdl-scpca-data/sample_info/scpca-sample-metadata.tsv'
-cellhash_pool_file = 's3://ccdl-scpca-data/sample_info/scpca-multiplex-pools.tsv'
-project_celltype_metafile = 's3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv'
+params {
+  run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+  sample_metafile = 's3://ccdl-scpca-data/sample_info/scpca-sample-metadata.tsv'
+  cellhash_pool_file = 's3://ccdl-scpca-data/sample_info/scpca-multiplex-pools.tsv'
+  project_celltype_metafile = 's3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv'
+}

--- a/config/ccdl_profiles.config
+++ b/config/ccdl_profiles.config
@@ -1,67 +1,70 @@
-// CCDL-specific settings to run samples for ScPCA with internal paths
-
-// AWS batch profiles
-batch {
-  includeConfig 'profile_awsbatch.config'
-}
-batch_manual {
-  includeConfig 'profile_awsbatch_manual.config'
-}
-
-// CCDL path profiles
-ccdl {
-  params {
-    // input files
-    includeConfig 'ccdl_inputs.config'
-
-    // output base directory
-    outdir = "s3://nextflow-ccdl-results/scpca/processed"
-
-    // paths to output folders, redefined to use `outdir` above
-    checkpoints_dir = "${params.outdir}/checkpoints"
-    results_dir = "${params.outdir}/results"
-
-    // a set of run_ids for testing. used only by the main workflow
-    // one single-cell with bulk, one CITE, one spatial, one multiplexed
-    run_ids = "SCPCS000001,SCPCS000050,SCPCS000203,SCPCL000537"
-
+// CCDL-specific profiles to run samples for ScPCA with internal paths
+profiles {
+  // AWS batch profiles
+  batch {
+    includeConfig 'profile_awsbatch.config'
   }
-}
-
-ccdl_staging {
-  tower.enabled = true
-  tower.workspaceId = '231452676847652' // https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch
-  params {
-    // input files
-    includeConfig 'ccdl_inputs.config'
-
-    // output base directory
-    outdir = "s3://nextflow-ccdl-results/scpca-staging"
-
-    // paths to output folders, redefined to use `outdir` above
-    checkpoints_dir = "${params.outdir}/checkpoints"
-    results_dir = "${params.outdir}/results"
-
-    // staging runs always include celltyping
-    perform_celltyping = true
+  batch_manual {
+    includeConfig 'profile_awsbatch_manual.config'
   }
-}
 
-ccdl_prod {
-  tower.enabled = true
-  tower.workspaceId = '231452676847652' // https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch
-  params {
+  // CCDL path profiles
+  ccdl {
     // input files
     includeConfig 'ccdl_inputs.config'
+    params {
 
-    // output base directory
-    outdir = "s3://nextflow-ccdl-results/scpca-prod"
 
-    // paths to output folders, redefined to use `outdir` above
-    checkpoints_dir = "${params.outdir}/checkpoints"
-    results_dir = "${params.outdir}/results"
+      // output base directory
+      outdir = "s3://nextflow-ccdl-results/scpca/processed"
 
-    // production runs always include celltyping
-    perform_celltyping = true
+      // paths to output folders, redefined to use `outdir` above
+      checkpoints_dir = "${params.outdir}/checkpoints"
+      results_dir = "${params.outdir}/results"
+
+      // a set of run_ids for testing. used only by the main workflow
+      // one single-cell with bulk, one CITE, one spatial, one multiplexed
+      run_ids = "SCPCS000001,SCPCS000050,SCPCS000203,SCPCL000537"
+    }
+  }
+
+  ccdl_staging {
+    tower.enabled = true
+    tower.workspaceId = '231452676847652'
+    // https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch
+    // input files
+    includeConfig 'ccdl_inputs.config'
+    params {
+
+      // output base directory
+      outdir = "s3://nextflow-ccdl-results/scpca-staging"
+
+      // paths to output folders, redefined to use `outdir` above
+      checkpoints_dir = "${params.outdir}/checkpoints"
+      results_dir = "${params.outdir}/results"
+
+      // staging runs always include celltyping
+      perform_celltyping = true
+    }
+  }
+
+  ccdl_prod {
+    tower.enabled = true
+    tower.workspaceId = '231452676847652'
+    // https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch
+    // input files
+    includeConfig 'ccdl_inputs.config'
+    params {
+
+      // output base directory
+      outdir = "s3://nextflow-ccdl-results/scpca-prod"
+
+      // paths to output folders, redefined to use `outdir` above
+      checkpoints_dir = "${params.outdir}/checkpoints"
+      results_dir = "${params.outdir}/results"
+
+      // production runs always include celltyping
+      perform_celltyping = true
+    }
   }
 }

--- a/config/containers.config
+++ b/config/containers.config
@@ -1,21 +1,23 @@
-// Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:v0.4.2'
-SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.2'
-SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:v0.4.2'
-SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.2'
-SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.2'
-SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:v0.4.2'
+params {
+  // Docker container images
+  SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:v0.4.2'
+  SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.2'
+  SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:v0.4.2'
+  SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.2'
+  SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.2'
+  SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:v0.4.2'
 
-ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
-BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
-CELLSNP_CONTAINER = 'quay.io/biocontainers/cellsnp-lite:1.2.2--h22771d5_0'
-FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
-SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1'
-SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
-STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
-TIDYVERSE_CONTAINER = 'rocker/tidyverse:4.4.0'
-VIREO_CONTAINER = 'ghcr.io/alexslemonade/vireo-snp:v0.5.7'
+  ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'
+  BCFTOOLS_CONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
+  CELLSNP_CONTAINER = 'quay.io/biocontainers/cellsnp-lite:1.2.2--h22771d5_0'
+  FASTP_CONTAINER = 'quay.io/biocontainers/fastp:0.23.0--h79da9fb_0'
+  SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1'
+  SAMTOOLS_CONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
+  STAR_CONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
+  TIDYVERSE_CONTAINER = 'rocker/tidyverse:4.4.0'
+  VIREO_CONTAINER = 'ghcr.io/alexslemonade/vireo-snp:v0.5.7'
 
-// 10X software containers not set by default
-CELLRANGER_CONTAINER = null
-SPACERANGER_CONTAINER = null
+  // 10X software containers not set by default
+  CELLRANGER_CONTAINER = null
+  SPACERANGER_CONTAINER = null
+}

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -1,32 +1,34 @@
-// path to reference files
-ref_json     = "${projectDir}/references/scpca-refs.json"
-ref_metadata = "${projectDir}/references/ref-metadata.tsv"
-ref_rootdir  = 's3://scpca-references'
+params {
+  // path to reference files
+  ref_json = "${projectDir}/references/scpca-refs.json"
+  ref_metadata = "${projectDir}/references/ref-metadata.tsv"
+  ref_rootdir = 's3://scpca-references'
 
-// barcode files
-barcode_dir  = "${params.ref_rootdir}/barcodes/10X"
+  // barcode files
+  barcode_dir = "${params.ref_rootdir}/barcodes/10X"
 
-// organism name to use for cell type annotation
-// name must match one of the keys in ref_json
-celltype_organism = "Homo_sapiens.GRCh38.104"
+  // organism name to use for cell type annotation
+  // name must match one of the keys in ref_json
+  celltype_organism = "Homo_sapiens.GRCh38.104"
 
-// cell type references directories
-celltype_ref_dir = "${params.ref_rootdir}/celltype"
+  // cell type references directories
+  celltype_ref_dir = "${params.ref_rootdir}/celltype"
 
-// populated by `build-celltype-ref.nf`, this stores the unaltered reference datasets
-//  from `celldex`. This is not used in `main.nf`.
-singler_references_dir = "${params.celltype_ref_dir}/singler_references"
+  // populated by `build-celltype-ref.nf`, this stores the unaltered reference datasets
+  //  from `celldex`. This is not used in `main.nf`.
+  singler_references_dir = "${params.celltype_ref_dir}/singler_references"
 
-// These directories hold the default SingleR and CellAssign reference files to use during cell typing
-// they are populated by `build-celltype-ref.nf` and consumed by `main.nf` during cell typing
-singler_models_dir = "${params.celltype_ref_dir}/singler_models"
-cellassign_ref_dir = "${params.celltype_ref_dir}/cellassign_references"
+  // These directories hold the default SingleR and CellAssign reference files to use during cell typing
+  // they are populated by `build-celltype-ref.nf` and consumed by `main.nf` during cell typing
+  singler_models_dir = "${params.celltype_ref_dir}/singler_models"
+  cellassign_ref_dir = "${params.celltype_ref_dir}/cellassign_references"
 
-// Reference file used for assigning ontology IDs for CellAssign results and consensus cell types
-// Originally created in the `cell-type-consensus` module of `OpenScPCA-analysis`
-panglao_ref_file = "${projectDir}/references/panglao-cell-type-ontologies.tsv"
-consensus_ref_file = "${projectDir}/references/consensus-cell-type-reference.tsv"
+  // Reference file used for assigning ontology IDs for CellAssign results and consensus cell types
+  // Originally created in the `cell-type-consensus` module of `OpenScPCA-analysis`
+  panglao_ref_file = "${projectDir}/references/panglao-cell-type-ontologies.tsv"
+  consensus_ref_file = "${projectDir}/references/consensus-cell-type-reference.tsv"
 
-// cell type metadata for building references in `build-celltype-ref.nf`; not used by main workflow
-celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"
-panglao_marker_genes_file = "${projectDir}/references/PanglaoDB_markers_2020-03-27.tsv"
+  // cell type metadata for building references in `build-celltype-ref.nf`; not used by main workflow
+  celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"
+  panglao_marker_genes_file = "${projectDir}/references/PanglaoDB_markers_2020-03-27.tsv"
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,22 +13,22 @@ manifest {
       affiliation: "Alex's Lemonade Stand Foundation",
       contribution: ["author"],
       github: "https://github.com/allyhawkins",
-      orcid: "https://orcid.org/0000-0001-6026-3660"
+      orcid: "https://orcid.org/0000-0001-6026-3660",
     ],
     [
       name: "Joshua A. Shapiro",
       affiliation: "Alex's Lemonade Stand Foundation",
       contribution: ["author"],
       github: "https://github.com/jashapiro",
-      orcid: "https://orcid.org/0000-0002-6224-0347"
+      orcid: "https://orcid.org/0000-0002-6224-0347",
     ],
     [
       name: "Stephanie J. Spielman",
       affiliation: "Alex's Lemonade Stand Foundation",
       contribution: ["author"],
       github: "https://github.com/sjspielman",
-      orcid: "https://orcid.org/0000-0002-9090-4788"
-    ]
+      orcid: "https://orcid.org/0000-0002-9090-4788",
+    ],
   ]
 }
 
@@ -61,42 +61,59 @@ params {
   merge_run_ids = "All"
 
   // Processing options
-  af_resolution = 'cr-like-em' // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
-  repeat_mapping = false // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
-  repeat_genetic_demux = false // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_genetic_demux` to run these steps.
-  skip_genetic_demux = false // skip genetic demultiplexing steps, even if bulk data is present
-  publish_fry_outs = false // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
-  spliced_only = false // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
-  perform_celltyping = false // specify whether or not to incorporate cell type annotations
-  repeat_celltyping = false // if cell type annotations already exist, skip cell type classification with SingleR and CellAssign
+  af_resolution = 'cr-like-em'
+  // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
+  repeat_mapping = false
+  // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
+  repeat_genetic_demux = false
+  // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_genetic_demux` to run these steps.
+  skip_genetic_demux = false
+  // skip genetic demultiplexing steps, even if bulk data is present
+  publish_fry_outs = false
+  // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
+  spliced_only = false
+  // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
+  perform_celltyping = false
+  // specify whether or not to incorporate cell type annotations
+  repeat_celltyping = false
+  // if cell type annotations already exist, skip cell type classification with SingleR and CellAssign
 
-  seed = 2021   // random number seed for filtering and post-processing (0 means use system seed)
+  seed = 2021
+  // random number seed for filtering and post-processing (0 means use system seed)
 
   // post processing SCE options
-  prob_compromised_cutoff = 0.75 // probability compromised cutoff used for filtering cells with miQC
-  gene_cutoff = 200 // minimum number of genes per cell cutoff used for filtering cells
-  num_hvg = 2000 // number of high variance genes to use for dimension reduction
-  num_pcs = 50 // number of principal components to retain in the returned SingleCellExperiment object
+  prob_compromised_cutoff = 0.75
+  // probability compromised cutoff used for filtering cells with miQC
+  gene_cutoff = 200
+  // minimum number of genes per cell cutoff used for filtering cells
+  num_hvg = 2000
+  // number of high variance genes to use for dimension reduction
+  num_pcs = 50
+  // number of principal components to retain in the returned SingleCellExperiment object
 
   // SCE clustering options
-  cluster_algorithm = "louvain" // default graph-based clustering algorithm
-  cluster_weighting = "jaccard" // default weighting scheme for graph-based clustering
-  nearest_neighbors = 20 // default nearest neighbors parameter for graph-based clustering
+  cluster_algorithm = "louvain"
+  // default graph-based clustering algorithm
+  cluster_weighting = "jaccard"
+  // default weighting scheme for graph-based clustering
+  nearest_neighbors = 20
+  // default nearest neighbors parameter for graph-based clustering
 
   // Cell type annotation options
-  singler_label_name = "label.ont" // celldex reference label used for SingleR reference building
+  singler_label_name = "label.ont"
+  // celldex reference label used for SingleR reference building
 
   // Merge workflow-specfic options
-  reuse_merge = false // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
-  max_merge_libraries = 100 // maximum number of libraries that can be merged
-
-  // Docker container images
-  includeConfig 'config/containers.config'
-
-  // reference and annotation parameters
-  includeConfig 'config/reference_paths.config'
-
+  reuse_merge = false
+  // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
+  max_merge_libraries = 100
 }
+
+// Docker container images
+includeConfig 'config/containers.config'
+
+// reference and annotation parameters
+includeConfig 'config/reference_paths.config'
 
 // Load base process config with labels
 includeConfig 'config/process_base.config'
@@ -120,6 +137,7 @@ profiles {
   example {
     includeConfig 'config/profile_example.config'
   }
-  // CCDL-specific profiles
-  includeConfig 'config/ccdl_profiles.config'
 }
+
+// CCDL-specific profiles
+includeConfig 'config/ccdl_profiles.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,52 +60,52 @@ params {
   // if running the merge workflow, include all runs in a project by default
   merge_run_ids = "All"
 
-  // Processing options
-  af_resolution = 'cr-like-em'
+  // Processing options //
   // alevin-fry quant resolution method: default is cr-like, can also use full, cr-like-em, parsimony, and trivial
-  repeat_mapping = false
+  af_resolution = 'cr-like-em'
   // if alevin or salmon mapping has already been performed and output files exist, mapping is skipped by default. Use `--repeat_mapping` to perform mapping again
-  repeat_genetic_demux = false
+  repeat_mapping = false
   // if genetic demultiplexing has been performed and output files exist, genetic demux is skipped by default. Use `--repeat_genetic_demux` to run these steps.
-  skip_genetic_demux = false
+  repeat_genetic_demux = false
   // skip genetic demultiplexing steps, even if bulk data is present
-  publish_fry_outs = false
+  skip_genetic_demux = false
   // alevin-fry outputs are not published by default. Use `--publish_fry_outs` to publish these files to the `checkpoints` folder.
-  spliced_only = false
+  publish_fry_outs = false
   // include only spliced reads in counts matrix, by default both unspliced and spliced reads are totaled and found in `counts` asasy of returned SingleCellExperiment object
-  perform_celltyping = false
+  spliced_only = false
   // specify whether or not to incorporate cell type annotations
-  repeat_celltyping = false
+  perform_celltyping = false
   // if cell type annotations already exist, skip cell type classification with SingleR and CellAssign
+  repeat_celltyping = false
 
-  seed = 2021
   // random number seed for filtering and post-processing (0 means use system seed)
+  seed = 2021
 
-  // post processing SCE options
-  prob_compromised_cutoff = 0.75
+  // post processing SCE options //
   // probability compromised cutoff used for filtering cells with miQC
-  gene_cutoff = 200
+  prob_compromised_cutoff = 0.75
   // minimum number of genes per cell cutoff used for filtering cells
-  num_hvg = 2000
+  gene_cutoff = 200
   // number of high variance genes to use for dimension reduction
-  num_pcs = 50
+  num_hvg = 2000
   // number of principal components to retain in the returned SingleCellExperiment object
+  num_pcs = 50
 
-  // SCE clustering options
-  cluster_algorithm = "louvain"
+  // SCE clustering options //
   // default graph-based clustering algorithm
-  cluster_weighting = "jaccard"
+  cluster_algorithm = "louvain"
   // default weighting scheme for graph-based clustering
-  nearest_neighbors = 20
+  cluster_weighting = "jaccard"
   // default nearest neighbors parameter for graph-based clustering
+  nearest_neighbors = 20
 
-  // Cell type annotation options
-  singler_label_name = "label.ont"
+  // Cell type annotation options //
   // celldex reference label used for SingleR reference building
+  singler_label_name = "label.ont"
 
-  // Merge workflow-specfic options
-  reuse_merge = false
+  // Merge workflow-specific options //
   // if later steps fail, you can use `--reuse_merge` reuse the merged RDS object during a rerun
+  reuse_merge = false
   max_merge_libraries = 100
 }
 


### PR DESCRIPTION
While working on #893, I ran into a number of validation errors while using the Nextflow VScode plugin. The crux of these was that we were apparently using `includeConfig` a bit more liberally than they would have liked, such that we were including "fragments" of config files that would not be valid on their own.

From https://www.nextflow.io/docs/latest/config.html:
> Config includes can also be specified within config blocks. However, config files should only be included at the top level or in a profile so that the included config file is valid on its own and in the context in which it is included.

This PR just includes the cleanup to pass validation, which mostly means moving the include blocks up a level to either the top level or the top level of a profile, and adding the appropriate wrapping blocks to the included files.