### PR TITLE
Small fixes for scpca-nf

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -32,7 +32,7 @@ option_list <- list(
     opt_str = c("--singler_model_file"),
     type = "character",
     help = "Name of file containing a single model generated for SingleR annotation.
-            File name is expected to be in form: `<ref_name>_<source>_<version>_model.rds`.",
+            File name is expected to be in form: `<ref_name>_<source>_<version>_<gene_set_version>_<date>_model.rds`.",
     default = ""
   ),
   make_option(
@@ -80,15 +80,27 @@ opt <- parse_args(OptionParser(option_list = option_list))
 #' @extension file extension to consider during parsing
 #'
 #' @return list of reference file components to include in SCE metadata
-get_ref_info <- function(ref_filename, extension) {
+get_ref_info <- function(ref_filename, extension, ref_type) {
   ref_info <- ref_filename |>
     basename() |>
     # select everything before the extension
     stringr::word(1, sep = extension) |>
     # create a vector with name, source, version
     stringr::str_split(pattern = "_") |>
-    unlist() |>
-    purrr::set_names(c("ref_name", "ref_source", "ref_version"))
+    unlist()
+
+  # account for gene_set_version only being in SingleR refs
+  if (ref_type == "SingleR") {
+    # if the length is 3, we are using an older version of the
+    # SingleR reference file that does not have the gene set version or date
+    if (length(ref_info) == 3) {
+      # add NA for gene set version and date
+      ref_info <- c(ref_info, NA, NA)
+    }
+    names(ref_info) <- c("ref_name", "ref_source", "ref_version", "gene_set_version", "date")
+  } else if (ref_type == "CellAssign") {
+    names(ref_info) <- c("ref_name", "ref_source", "ref_version")
+  }
 
   return(ref_info)
 }
@@ -96,7 +108,10 @@ get_ref_info <- function(ref_filename, extension) {
 # check that input file exists and output file ends in rds
 stopifnot(
   "Missing input SCE file" = file.exists(opt$input_sce_file),
-  "output sce file name must end in .rds" = stringr::str_ends(opt$output_sce_file, ".rds")
+  "output sce file name must end in .rds" = stringr::str_ends(
+    opt$output_sce_file,
+    ".rds"
+  )
 )
 
 # read in input files
@@ -107,7 +122,9 @@ sce <- readr::read_rds(opt$input_sce_file)
 has_singler <- file.exists(opt$singler_results)
 if (has_singler) {
   # check singler model has been provided
-  stopifnot("Singler model filename must be provided" = opt$singler_model_file != "")
+  stopifnot(
+    "Singler model filename must be provided" = opt$singler_model_file != ""
+  )
 
   singler_results <- readr::read_rds(opt$singler_results)
 
@@ -168,7 +185,8 @@ if (has_singler) {
   # get reference name, source and version
   singler_ref_info <- get_ref_info(
     ref_filename = opt$singler_model_file,
-    extension = "_model\\.rds"
+    extension = "_model\\.rds",
+    ref_type = "SingleR"
   )
 
   # add singler info to metadata
@@ -177,6 +195,8 @@ if (has_singler) {
   metadata(sce)$singler_reference_label <- label_type
   metadata(sce)$singler_reference_source <- singler_ref_info[["ref_source"]]
   metadata(sce)$singler_reference_version <- singler_ref_info[["ref_version"]]
+  metadata(sce)$singler_gene_set_version <- singler_ref_info[["gene_set_version"]]
+  metadata(sce)$singler_date <- singler_ref_info[["date"]]
 
   # add note about cell type method to metadata
   metadata(sce)$celltype_methods <- c(metadata(sce)$celltype_methods, "singler")
@@ -242,7 +262,8 @@ if (has_cellassign) {
     # get reference name, source and version
     cellassign_ref_info <- get_ref_info(
       ref_filename = opt$cellassign_ref_file,
-      extension = "\\.tsv"
+      extension = "\\.tsv",
+      ref_type = "CellAssign"
     )
 
     # add entire predictions matrix, ref name, and version to metadata

--- a/scripts/aws/run_nextflow.sh
+++ b/scripts/aws/run_nextflow.sh
@@ -125,6 +125,7 @@ if [[ "$RUN_MODE" == "example" ]]; then
   && zip -r scpca_out.zip scpca_out \
   && aws s3 cp scpca_out.zip "s3://scpca-nf-references/example-data/scpca_out.zip" \
   || echo "Error uploading scpca_out.zip to S3" >> run_errors.log
+  rm -rf scpca_out scpca_out.zip
 fi
 
 # Post any errors to slack

--- a/scripts/aws/run_nextflow.sh
+++ b/scripts/aws/run_nextflow.sh
@@ -26,7 +26,7 @@ fi
 export PATH
 
 # Get secrets from AWS Secrets Manager/1Password
-AWS_SECRETS=$(aws secretsmanager get-secret-value --secret-id openscpca_service_account_token | jq -r '.SecretString')
+AWS_SECRETS=$(aws secretsmanager get-secret-value --secret-id scpca_service_account_token | jq -r '.SecretString')
 # AWS secrets are a key-value store: retrieve individual values with jq
 OP_SERVICE_ACCOUNT_TOKEN=$(jq -r '.op_token' <<< $AWS_SECRETS)
 export OP_SERVICE_ACCOUNT_TOKEN


### PR DESCRIPTION
A couple of small fixes for the scpca-nf running in the new account.

The main one is the change to accommodate the new style of cell type reference paths. We might need to incorporate that one into the dev branch sooner rather than later, but probably not right away. I mostly started from copying the version in the flex branch, but I made a few changes to deal with the potential for either file name format. I also added the extra fields to the metadata, because why not. 

The other change is just fixing the AWS secret name.