### PR TITLE
Add script to detect doublets

### DIFF
--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -50,7 +50,7 @@ stopifnot(
 
 # set up multiprocessing params
 if (opt$threads > 1) {
-  bp_param <- BiocParallel::MulticoreParam(opt$threads, RNGSeed = opt$seed)
+  bp_param <- BiocParallel::MulticoreParam(opt$threads)
 } else {
   bp_param <- BiocParallel::SerialParam()
 }


### PR DESCRIPTION
Closes #928 

This PR adds a script to detect doublets on a given SCE file*. There are a few main things to be aware of:
- I run `scDblFinder` at defaults which seems fine to me for the goal of this addition
- I save 3 bits of information to the SCE:
  - the crux values are saved in the `colData` directly: the classification and the associated doublet score
  - the full table that `scDblFinder` exports is saved in `metadata`. It's a not-huge DataFrame and seemed worth including for transparency in the same way that we include the full SingleR output.

*Note I was agnostic about the process stage of this input file in how I named this argument, because I wondered if we want to be running this on filtered and not processed? Feel free to weigh in as part of review! https://github.com/AlexsLemonade/scpca-nf/issues/929#issuecomment-3133020583