### PR TITLE
Incorporate doublet detection into workflow

### DIFF
--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -62,7 +62,7 @@ sce <- readr::read_rds(opt$input_sce_file)
 doublet_result <- scDblFinder::scDblFinder(
   sce,
   BPPARAM = bp_param,
-  resultType = "table" # keep as table in case we eventually want to provide additional output
+  returnType = "table" # keep as table in case we eventually want to provide additional output
 )
 
 # store the `score` and `class` columns in the colData

--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -13,13 +13,13 @@ library(SingleCellExperiment)
 # Set up optparse options
 option_list <- list(
   make_option(
-    opt_str = c("--input_sce_file"),
+    opt_str = c("-i", "--input_sce_file"),
     type = "character",
     default = "",
     help = "Path to RDS file that contains the SCE object to perform doublet detection on."
   ),
   make_option(
-    opt_str = c("--output_sce_file"),
+    opt_str = c("-o", "--output_sce_file"),
     type = "character",
     default = "",
     help = "Path to output RDS file to save SCE with detected doublets."

--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -25,7 +25,7 @@ option_list <- list(
     help = "Number of multiprocessing threads to use."
   ),
   make_option(
-    opt_str = c("--seed"),
+    opt_str = c("--random_seed"),
     type = "integer",
     default = 2024,
     help = "Random seed for reproducibility"
@@ -34,7 +34,7 @@ option_list <- list(
 
 # Setup ------------------------------
 opt <- parse_args(OptionParser(option_list = option_list))
-set.seed(opt$seed)
+set.seed(opt$random_seed)
 
 # check SCE file
 stopifnot("`sce_file` is missing." = file.exists(opt$sce_file))

--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -4,7 +4,7 @@
 #
 # This script reads in an RDS file containing an SCE and runs scDblFinder.
 # Classifications and doublet scores are stored in the SCE's colData slot.
-# The SCE is then exported.
+# The SCE is then exported to the same file as was inputted.
 
 # import libraries
 library(optparse)
@@ -13,16 +13,10 @@ library(SingleCellExperiment)
 # Set up optparse options
 option_list <- list(
   make_option(
-    opt_str = c("--input_sce_file"),
+    opt_str = c("--sce_file"),
     type = "character",
     default = "",
     help = "Path to RDS file that contains the SCE object to perform doublet detection on."
-  ),
-  make_option(
-    opt_str = c("-o", "--output_sce_file"),
-    type = "character",
-    default = "",
-    help = "Output path for updated SCE file. Must end in .rds"
   ),
   make_option(
     opt_str = c("-t", "--threads"),
@@ -42,11 +36,8 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 set.seed(opt$seed)
 
-# check files
-stopifnot(
-  "Input `input_sce_file` is missing." = file.exists(opt$input_sce_file),
-  "`output_sce_file` must end in .rds" = stringr::str_ends(opt$output_sce_file, ".rds")
-)
+# check SCE file
+stopifnot("`sce_file` is missing." = file.exists(opt$sce_file))
 
 # set up multiprocessing params
 if (opt$threads > 1) {
@@ -56,7 +47,7 @@ if (opt$threads > 1) {
 }
 
 # read SCE
-sce <- readr::read_rds(opt$input_sce_file)
+sce <- readr::read_rds(opt$sce_file)
 
 # run scDblFinder -----------
 doublet_result <- scDblFinder::scDblFinder(
@@ -79,4 +70,4 @@ colData(sce) <- colData(sce) |>
   DataFrame(row.names = colnames(sce))
 
 # Export updated SCE with doublet information
-readr::write_rds(sce, opt$output_sce_file, compress = "bz2")
+readr::write_rds(sce, opt$sce_file, compress = "bz2")

--- a/bin/filter_sce.R
+++ b/bin/filter_sce.R
@@ -33,6 +33,12 @@ option_list <- list(
     help = "flag to set the miQC's enforce_left_cutoff option to TRUE"
   ),
   make_option(
+    opt_str = c("--no_sce_compression"),
+    action = "store_false",
+    default = TRUE,
+    help = "flag to turn off compression of the output SCE object"
+  ),
+  make_option(
     opt_str = c("--adt_barcode_file"),
     type = "character",
     default = NULL,
@@ -192,5 +198,10 @@ if (!is.null(ambient_profile)) {
   # Add `target_type` to rowData
   rowData(altExp(filtered_sce, adt_exp))$target_type <- adt_barcode_df$target_type
 }
+
 # write filtered sce to output
-readr::write_rds(filtered_sce, opt$filtered_file, compress = "bz2")
+compress_str <- "bz2"
+if (opt$no_sce_compression) {
+  compress_str <- "none"
+}
+readr::write_rds(filtered_sce, opt$filtered_file, compress = compress_str)

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -129,6 +129,11 @@ process filter_sce {
       ${adt_present ? "--adt_barcode_file ${feature_barcode_file}":""} \
       --prob_compromised_cutoff ${params.prob_compromised_cutoff} \
       ${params.seed ? "--random_seed ${params.seed}" : ""}
+
+    detect_doublets.R \
+      --sce_file ${filtered_rds} \
+      ${params.seed ? "--random_seed ${params.seed}" : ""} \
+      --threads ${task.cpus}
     """
   stub:
     filtered_rds = "${meta.library_id}_filtered.rds"

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -124,14 +124,16 @@ process filter_sce {
     """
     filter_sce.R \
       --unfiltered_file ${unfiltered_rds} \
-      --filtered_file ${filtered_rds} \
+      --filtered_file "filtered.rds" \
       ${adt_present ? "--adt_name ${meta.feature_type}":""} \
       ${adt_present ? "--adt_barcode_file ${feature_barcode_file}":""} \
       --prob_compromised_cutoff ${params.prob_compromised_cutoff} \
-      ${params.seed ? "--random_seed ${params.seed}" : ""}
+      ${params.seed ? "--random_seed ${params.seed}" : ""} \
+      --no_sce_compression
 
     detect_doublets.R \
-      --sce_file ${filtered_rds} \
+      --input_sce_file "filtered.rds" \
+      --output_sce_file ${filtered.rds} \
       ${params.seed ? "--random_seed ${params.seed}" : ""} \
       --threads ${task.cpus}
     """


### PR DESCRIPTION
Closes #929 

In this PR, I am adding code to run the `detect_doublets.R` script into the workflow. Given that we should probably be running this on filtered instead of processed files, I decided for a first stab to take the path of absolute least resistance and just add the script to run inside our existing `filter_sce` process, which does use the `slim` container (for which `scDblFinder` inclusion is still pending in https://github.com/AlexsLemonade/scpcaTools/pull/305). This code is therefore analogous to how we add in submitter annotations in the unfiltered processes, e.g.:

https://github.com/AlexsLemonade/scpca-nf/blob/8a85702f7c3e616d1d73335d4139d3c72fabfd4e/modules/sce-processing.nf#L4-L45

It reads in an SCE, adds some colData, and exports the SCE to the same input file. As such, I updated the R script to have only a single `sce_file` argument. I also reverted a smidge and renamed the seed to `random_seed` since that better matches what's in this area of the workflow, it turns out....

I'm opening this as a draft until https://github.com/AlexsLemonade/scpcaTools/pull/305 is completed, but in the meantime people can feel free to weigh in, or let me know if a bona fide module would be better here for (as the name suggests...) workflow modularity :) 