### PR TITLE
Update tables to include consensus cell types in report

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -288,7 +288,7 @@ As these annotations are based on the output from `SingleR` and `CellAssign`, on
 }
 
 glue::glue("
-  \n\nFor additional information about cell typing, including a description of all methods used, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
+  \n\nFor additional information about cell typing, including the results from all methods used, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
 ")
 ```
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -280,9 +280,9 @@ if (cellassign_not_run) {
 
 if (has_consensus) {
   glue::glue(
-    "\n\nConsensus cell types are obtained based on agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
+    "\n\nConsensus cell types are obtained by looking for agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
 If no common label is identified, no consensus cell type is assigned.
-See the [ScPCA documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned.
+See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned.
 As these annotations are based on the output from `SingleR` and `CellAssign`, only the consensus cell type assignments will be displayed in the below tables and plots."
   )
 }

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -254,6 +254,7 @@ cellassign_not_run <- check_cellassign_not_run(
 # define bullets glue string
 methods_bullets <- c(
   ifelse(has_submitter, "Submitter-provided", NA),
+  ifelse(has_consensus, "Consensus cell types", NA),
   ifelse(has_singler, "`SingleR`", NA),
   ifelse(has_cellassign, "`CellAssign`", NA)
 ) |>
@@ -277,8 +278,17 @@ if (cellassign_not_run) {
   )
 }
 
+if (has_consensus) {
+  glue::glue(
+    "\n\nConsensus cell types are obtained based on agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
+If no common label is identified, no consensus cell type is assigned.
+See the [ScPCA documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned.
+As these annotations are based on the output from `SingleR` and `CellAssign`, only the consensus cell type assignments will be displayed in the below tables and plots."
+  )
+}
+
 glue::glue("
-  \n\nFor additional information about cell typing, including methods used for cell typing, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
+  \n\nFor additional information about cell typing, including a description of all methods used, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
 ")
 ```
 
@@ -296,7 +306,7 @@ umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 
-```{r, eval = (has_cellassign || has_singler), results='asis'}
+```{r, eval = (has_cellassign || has_singler) && is_supplemental, results='asis'}
 unclassified_methods <- c()
 
 # check for unclassified SingleR cells
@@ -359,7 +369,17 @@ create_celltype_n_table(celltype_df, submitter_celltype_annotation) |>
   format_celltype_n_table()
 ```
 
-```{r, eval = has_singler}
+```{r, eval = has_consensus}
+knitr::asis_output('### Consensus cell type annotations\n
+
+In this table, cells labeled "Unknown cell type" are those which did not have agreement between the annotation from `SingleR` and `CellAssign`.
+In the processed result files, these cells are labeled `Unknown`.
+')
+create_celltype_n_table(celltype_df, consensus_celltype_annotation) |>
+  format_celltype_n_table()
+```
+
+```{r, eval = has_singler && is_supplemental}
 knitr::asis_output('### `SingleR` cell type annotations\n
 
 In this table, cells labeled "Unknown cell type" are those which `SingleR` pruned due to low-quality assignments.
@@ -369,7 +389,7 @@ create_celltype_n_table(celltype_df, singler_celltype_annotation) |>
   format_celltype_n_table()
 ```
 
-```{r, eval = has_cellassign}
+```{r, eval = has_cellassign && is_supplemental}
 knitr::asis_output('### `CellAssign` cell type annotations\n
 
 In this table, cells labeled "Unknown cell type" are those which `CellAssign` could not confidently assign to a label in the reference list.
@@ -428,8 +448,7 @@ if (length(levels(umap_df$cluster)) <= 8) {
 }
 ```
 
-
-```{r, eval = has_umap && has_celltypes}
+```{r, eval = has_umap && has_celltypes }
 knitr::asis_output(
   'Next, we show UMAPs colored by cell types.
 For each cell typing method, we show a separate faceted UMAP.

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -379,7 +379,7 @@ create_celltype_n_table(celltype_df, consensus_celltype_annotation) |>
   format_celltype_n_table()
 ```
 
-```{r, eval = has_singler && is_supplemental}
+```{r, eval = has_singler && (!has_consensus || is_supplemental)}
 knitr::asis_output('### `SingleR` cell type annotations\n
 
 In this table, cells labeled "Unknown cell type" are those which `SingleR` pruned due to low-quality assignments.
@@ -389,7 +389,7 @@ create_celltype_n_table(celltype_df, singler_celltype_annotation) |>
   format_celltype_n_table()
 ```
 
-```{r, eval = has_cellassign && is_supplemental}
+```{r, eval = has_cellassign && (!has_consensus || is_supplemental)}
 knitr::asis_output('### `CellAssign` cell type annotations\n
 
 In this table, cells labeled "Unknown cell type" are those which `CellAssign` could not confidently assign to a label in the reference list.

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -369,6 +369,15 @@ if (has_cellassign) {
   )
 }
 
+if (has_consensus) {
+  methods_text <- glue::glue(
+    "{methods_text}
+    * Consensus cell types obtained by looking for agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
+If no common label is identified, no consensus cell type is assigned.
+See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned."
+  )
+}
+
 glue::glue("{methods_text}")
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -373,8 +373,8 @@ if (has_consensus) {
   methods_text <- glue::glue(
     "{methods_text}
     * Consensus cell types obtained by looking for agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
-If no common label is identified, no consensus cell type is assigned.
-See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned."
+    If no common label is identified, no consensus cell type is assigned.
+    See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned.\n"
   )
 }
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -118,18 +118,20 @@ if (has_cellhash) {
 if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
   has_clusters <- "cluster" %in% names(colData(processed_sce))
+  has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
     !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
   # If at least 1 is present, we have cell type annotations.
-  has_celltypes <- any(has_singler, has_cellassign, has_submitter)
+  has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter)
 
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
   has_umap <- FALSE
   has_clusters <- FALSE
+  has_consensus <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
   has_submitter <- FALSE
@@ -137,7 +139,7 @@ if (has_processed) {
 }
 
 # check for celltypes_report if celltypes are present
-if ((has_singler | has_cellassign) & is.null(params$celltype_report)) {
+if ((has_consensus | has_singler | has_cellassign) & is.null(params$celltype_report)) {
   stop("Cell type annotations were provided but the parameter specifying the cell type report file is missing.")
 }
 

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -34,6 +34,7 @@ create_celltype_df <- function(processed_sce) {
       # account for potentially missing columns
       contains("cluster"),
       contains("UMAP"),
+      contains("consensus"),
       contains("singler"),
       contains("cellassign"),
       contains("submitter")
@@ -42,7 +43,12 @@ create_celltype_df <- function(processed_sce) {
   if ("submitter_celltype_annotation" %in% names(celltype_df)) {
     celltype_df <- prepare_submitter_annotation_values(celltype_df)
   }
-
+  if ("consensus_celltype_annotation" %in% names(celltype_df)) {
+    celltype_df <- prepare_automated_annotation_values(
+      celltype_df,
+      consensus_celltype_annotation
+    )
+  }
   if ("singler_celltype_annotation" %in% names(celltype_df)) {
     celltype_df <- prepare_automated_annotation_values(
       celltype_df,
@@ -81,6 +87,8 @@ prepare_automated_annotation_values <- function(
         is.na({{ annotation_column }}) ~ unknown_string,
         # cellassign condition
         {{ annotation_column }} == "other" ~ unknown_string,
+        # consensus condition
+        {{ annotation_column }} == "Unknown" ~ unknown_string,
         # otherwise, keep it
         .default = {{ annotation_column }}
       ) |>


### PR DESCRIPTION
Closes #932 

Here I'm getting started on adding consensus cell types to the main and supplemental report. 

- I added a boolean for `has_consensus` to use throughout the report. 
- I updated some of the prep functions to account for having consensus cell types. 
- I added some text in the main report describing the consensus cell types and noting that we will only show the consensus cell types and will not show SingleR/CellAssign. Instead they need to go to the supplemental report for that. 
- I also updated the text in the supplemental report to have a bullet describing consensus cell types. 
- For the tables, I added a consensus cell type table below the submitters (if present). If it's the main report, the SingleR and CellAssign tables aren't shown _unless_ there are no consensus cell types for whatever reason. There may be cases where CellAssign failed and we don't have consensus, so we should account for that here. 
- I also moved the warning message about reusing SingleR/CellAssign results to the supplemental report as long as consensus exists. 

I was struggling a little with the text updates and how to best organize it so if you have other ideas about that please let me know! 

Here's a zip file with three reports - a main report with consensus, a main report without consensus, and a supplemental report. 
[celltype_reports.zip](https://github.com/user-attachments/files/21496548/celltype_reports.zip)
