### PR TITLE
Retain the doublet columns in merged SCEs

### DIFF
--- a/bin/merge_sces.R
+++ b/bin/merge_sces.R
@@ -212,6 +212,8 @@ possible_columns <- c(
   "prob_compromised",
   "scpca_filter",
   "additional_modalities",
+  "scDblFinder_class",
+  "scDblFinder_score",
   # cell type names
   "submitter_celltype_annotation",
   "singler_celltype_annotation",


### PR DESCRIPTION
Closes #930 
This PR updates our list of columns to keep in merged SCEs with the 2 new columns we added with doublet info:

https://github.com/AlexsLemonade/scpca-nf/blob/8b10cadafbf387a6457d7d498758e7790c09c11e/bin/detect_doublets.R#L74