### PR TITLE
Update UMAPs to include consensus cell type annotations

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -448,16 +448,25 @@ if (length(levels(umap_df$cluster)) <= 8) {
 }
 ```
 
+
 ```{r, eval = has_umap && has_celltypes }
-knitr::asis_output(
+# only mention multiple annotations if we're actually showing multiple annotations
+if (has_consensus && !has_submitter && !is_supplemental) {
+  umap_text <- ""
+} else {
+  umap_text <- "For each cell typing method, we show a separate faceted UMAP."
+}
+
+
+knitr::asis_output(glue::glue(
   'Next, we show UMAPs colored by cell types.
-For each cell typing method, we show a separate faceted UMAP.
+  {umap_text}
 In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.
 
 For legibility, only the seven most common cell types are shown.
 All other cell types are grouped together and labeled "All remaining cell types" (not to be confused with "Unknown cell type" which represents cells that could not be classified).
   '
-)
+))
 ```
 
 <!-- Now, UMAPs of cell types, where present -->
@@ -485,6 +494,28 @@ faceted_umap(
 
 
 ```{r}
+if (has_consensus & has_umap) {
+  consensus_n_celltypes <- length(levels(umap_df$consensus_celltype_annotation_lumped))
+  consensus_dims <- determine_umap_dimensions(consensus_n_celltypes)
+} else {
+  # set fake dims for evaluating next chunk
+  consensus_dims <- c(1, 1)
+}
+```
+
+
+```{r, eval=has_consensus && has_umap, message=FALSE, warning=FALSE, fig.width = consensus_dims[1], fig.height = consensus_dims[2], fig.align = "center"}
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  consensus_n_celltypes,
+  consensus_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
+) +
+  ggtitle("UMAP colored by Consensus cell type annotations")
+```
+
+```{r}
 if (has_singler & has_umap) {
   singler_n_celltypes <- length(levels(umap_df$singler_celltype_annotation_lumped))
   singler_dims <- determine_umap_dimensions(singler_n_celltypes)
@@ -495,7 +526,7 @@ if (has_singler & has_umap) {
 ```
 
 
-```{r, eval=has_singler && has_umap, message=FALSE, warning=FALSE, fig.width = singler_dims[1], fig.height = singler_dims[2], fig.align = "center"}
+```{r, eval=has_singler && has_umap && (is_supplemental || !has_consensus), message=FALSE, warning=FALSE, fig.width = singler_dims[1], fig.height = singler_dims[2], fig.align = "center"}
 # umap for cell assign annotations
 faceted_umap(
   umap_df,
@@ -517,7 +548,7 @@ if (has_cellassign & has_umap) {
 }
 ```
 
-```{r, eval = has_cellassign && has_umap, message=FALSE, warning=FALSE, fig.width = cellassign_dims[1], fig.height = cellassign_dims[2], fig.align = "center"}
+```{r, eval = has_cellassign && has_umap && (is_supplemental || !has_consensus), message=FALSE, warning=FALSE, fig.width = cellassign_dims[1], fig.height = cellassign_dims[2], fig.align = "center"}
 # umap for cell assign annotations
 faceted_umap(
   umap_df,

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -512,7 +512,7 @@ faceted_umap(
   consensus_celltype_annotation_lumped,
   point_size = umap_facet_point_size
 ) +
-  ggtitle("UMAP colored by Consensus cell type annotations")
+  ggtitle("UMAP colored by consensus cell type annotations")
 ```
 
 ```{r}

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -178,6 +178,7 @@ faceted_umap <- function(umap_df,
     guides(
       color = guide_legend(
         title = "Cell types",
+        byrow = TRUE,
         # more visible points in legend
         override.aes = list(
           alpha = 1,

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -119,6 +119,7 @@ if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
   has_clusters <- "cluster" %in% names(colData(processed_sce))
   has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
+  has_consensus <- FALSE
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -119,7 +119,6 @@ if (has_processed) {
   has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
   has_clusters <- "cluster" %in% names(colData(processed_sce))
   has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
-  has_consensus <- FALSE
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&


### PR DESCRIPTION
Closes #933 

I added the UMAP for the consensus cell types to the main report and the supplemental report. Just like with the tables, I show the SingleR/CellAssign UMAPs in the main report if there are no consensus cell types. 

The only tricky thing here was that I didn't love the text we show if we are only showing consensus cell types in the main report (if we don't have submitter). I made a small change to just remove one of the lines describing multiple UMAPs if we are only showing consensus.

Here's the example reports again: 
[celltype_reports.zip](https://github.com/user-attachments/files/21517177/celltype_reports.zip)
