### PR TITLE
Use edge for scpcaTools with new basilisk setup

### DIFF
--- a/config/containers.config
+++ b/config/containers.config
@@ -1,9 +1,9 @@
 // Docker container images
-SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:v0.4.3'
-SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.3'
+SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools:edge'
+SCPCATOOLS_SLIM_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-slim:edge'
 SCPCATOOLS_ANNDATA_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-anndata:edge'
-SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.3'
-SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.3'
+SCPCATOOLS_REPORTS_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-reports:edge'
+SCPCATOOLS_SEURAT_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-seurat:edge'
 SCPCATOOLS_SCVI_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scvi:edge'
 
 ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'


### PR DESCRIPTION
Hopefully solves #789 

Since we updated how we handle setting up `basilisk` in `scpcaTools`, I'm now switching to using the latest images. I tested pulling the `scvi` image with Singularity and running the script to convert SCE to AnnData and was able to convert things successfully, where previously I was hitting the error noted in #789. 