### PR TITLE
Move clustering plots to a separate section

### DIFF
--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup Nextflow
         uses: nf-core/setup-nextflow@v2
-        with:
-          version: latest
 
       - name: Check Nextflow workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: "21"
+          distribution: "corretto"
 
       - name: Setup Nextflow
         #   uses: nf-core/setup-nextflow@v2

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -8,10 +8,15 @@ on:
 
 jobs:
   nf-stub-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
 
       - name: Setup Nextflow
         #   uses: nf-core/setup-nextflow@v2

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -14,7 +14,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Nextflow
-        uses: nf-core/setup-nextflow@v2
+        #   uses: nf-core/setup-nextflow@v2
+        # manual install as the action is currently broken
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
 
       - name: Check Nextflow workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -417,7 +417,7 @@ if (has_consensus && !has_submitter && !is_supplemental) {
 
 knitr::asis_output(glue::glue(
   '## UMAPs
-  
+
   In this section, we show UMAPs colored by cell types.
   {umap_text}
 In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -401,54 +401,10 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 ```
 
 
-```{r, eval = has_umap && has_clusters}
-knitr::asis_output(glue::glue("
-## UMAPs
-
-In this section, we show UMAPs colored by clusters.
-Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_algorithm} algorithm with  {metadata(processed_sce)$cluster_weighting} weighting.
-"))
-```
-
-
 ```{r, eval = has_umap, warning = FALSE}
 # Create dataset for plotting UMAPs with lumped and label-wrapped cell types
 umap_df <- lump_wrap_celltypes(celltype_df)
 ```
-
-
-<!-- First UMAP: clusters -->
-
-```{r, eval = has_umap && has_multiplex && has_clusters, results='asis'}
-glue::glue("
-  <div class=\"alert alert-info\">
-    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
-    Please use caution when interpreting these results.
-  </div>
-")
-```
-
-
-```{r eval = has_umap && has_clusters, message=FALSE, warning=FALSE}
-clusters_plot <- plot_umap(
-  umap_df,
-  cluster,
-  "Cluster",
-  point_size = umap_point_size
-) +
-  ggtitle("UMAP colored by cluster identity")
-
-# Determine palette based on number of levels.
-# If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
-#  Otherwise, we will use the default palette.
-if (length(levels(umap_df$cluster)) <= 8) {
-  clusters_plot +
-    scale_color_brewer(palette = "Set2")
-} else {
-  clusters_plot
-}
-```
-
 
 ```{r, eval = has_umap && has_celltypes }
 # only mention multiple annotations if we're actually showing multiple annotations
@@ -460,7 +416,9 @@ if (has_consensus && !has_submitter && !is_supplemental) {
 
 
 knitr::asis_output(glue::glue(
-  'Next, we show UMAPs colored by cell types.
+  '## UMAPs
+  
+  In this section, we show UMAPs colored by cell types.
   {umap_text}
 In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -759,14 +759,19 @@ glue::glue(
 )
 ```
 
-```{r, eval= has_submitter & has_consensus & !is_supplemental }
-# Set plot dimensions based on number of consensus cell types
-all_celltypes <- levels(celltype_df$consensus_celltype_annotation)
-plot_height <- calculate_plot_height(
-  unique(celltype_df$consensus_celltype_annotation),
-  unique(celltype_df$submitter_celltype_annotation),
-  0
-)
+```{r}
+if(has_submitter & has_consensus & !is_supplemental ){
+  # Set plot dimensions based on number of consensus cell types
+  all_celltypes <- levels(celltype_df$consensus_celltype_annotation)
+  plot_height <- calculate_plot_height(
+    unique(celltype_df$consensus_celltype_annotation),
+    unique(celltype_df$submitter_celltype_annotation),
+    0
+  ) 
+} else {
+  # set a default to avoid failure in the next chunk 
+  plot_height = 1
+}
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -82,55 +82,6 @@ lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35) {
 }
 
 
-
-
-
-#' Make UMAP  colored by given variable
-#'
-#' @param umap_df Data frame with UMAP1 and UMAP2 columns
-#' @param color_variable Column in data frame to color by, not a string.
-#' @param legend_title Title for legend.
-#' @param legend_nrow Number of rows in legend. Default is 2.
-#' @param point_size Point size. Default is 1
-#'
-#' @return UMAP plot as a ggplot2 object
-plot_umap <- function(
-    umap_df,
-    color_variable,
-    legend_title,
-    point_size = 1,
-    legend_nrow = 2) {
-  ggplot(umap_df) +
-    aes(
-      x = UMAP1,
-      y = UMAP2,
-      color = {{ color_variable }}
-    ) +
-    geom_point(
-      size = point_size,
-      alpha = 0.5
-    ) +
-    # remove axis numbers and background grid
-    scale_x_continuous(labels = NULL, breaks = NULL) +
-    scale_y_continuous(labels = NULL, breaks = NULL) +
-    guides(
-      color = guide_legend(
-        title = legend_title,
-        nrow = legend_nrow,
-        # more visible points in legend
-        override.aes = list(
-          alpha = 1,
-          size = 1.5
-        )
-      )
-    ) +
-    theme(
-      legend.position = "bottom",
-      aspect.ratio = 1
-    )
-}
-
-
 #' Create a faceted UMAP panel where each panel has only one cell type colored
 #'
 #' @param umap_df Data frame with UMAP1 and UMAP2 columns

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -760,17 +760,17 @@ glue::glue(
 ```
 
 ```{r}
-if(has_submitter & has_consensus & !is_supplemental ){
+if (has_submitter & has_consensus & !is_supplemental) {
   # Set plot dimensions based on number of consensus cell types
   all_celltypes <- levels(celltype_df$consensus_celltype_annotation)
   plot_height <- calculate_plot_height(
     unique(celltype_df$consensus_celltype_annotation),
     unique(celltype_df$submitter_celltype_annotation),
     0
-  ) 
+  )
 } else {
-  # set a default to avoid failure in the next chunk 
-  plot_height = 1
+  # set a default to avoid failure in the next chunk
+  plot_height <- 1
 }
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -341,14 +341,14 @@ jaccard_consensus_matrices |>
 knitr::asis_output(glue::glue("
 # Unsupervised clustering
 
-In this section, we look at unsupervised cluster assignments. 
-The first plot shows the cluster assignments on a UMAP and the second plot shows a heatmap comparing cluster assignments to cell type annotations. 
+In this section, we look at unsupervised cluster assignments.
+The first plot shows the cluster assignments on a UMAP and the second plot shows a heatmap comparing cluster assignments to cell type annotations.
 The heatmap is colored by the Jaccard similarity index as described in the `Cell label comparisons` section above.
 
 Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_algorithm} algorithm with  {metadata(processed_sce)$cluster_weighting} weighting.
 
-**Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters. 
-These results should be interpreted with caution. 
+**Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters.
+These results should be interpreted with caution.
 "))
 ```
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -373,23 +373,11 @@ glue::glue("
 
 
 ```{r eval = has_umap && has_clusters, message=FALSE, warning=FALSE}
-clusters_plot <- plot_umap(
-  umap_df,
-  cluster,
-  "Cluster",
-  point_size = umap_point_size
-) +
-  ggtitle("UMAP colored by cluster identity")
-
-# Determine palette based on number of levels.
-# If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
-#  Otherwise, we will use the default palette.
-if (length(levels(umap_df$cluster)) <= 8) {
-  clusters_plot +
-    scale_color_brewer(palette = "Set2")
-} else {
-  clusters_plot
-}
+# create UMAP colored by clusters
+plot_clusters_umap(
+  processed_sce,
+  umap_point_size
+)
 ```
 
 <!-- If multiplexed, show info alert instead of this heatmap --> 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -365,7 +365,7 @@ umap_df <- lump_wrap_celltypes(celltype_df)
 ```{r, eval = has_umap && has_multiplex && has_clusters, results='asis'}
 glue::glue("
   <div class=\"alert alert-info\">
-    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
+    This library contains multiple samples that have not been demultiplexed, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -346,7 +346,7 @@ In this section, we look at unsupervised cluster assignments.
 The first plot shows the cluster assignments on a UMAP and the second plot shows a heatmap comparing cluster assignments to cell type annotations.
 The heatmap is colored by the Jaccard similarity index as described in the `Cell label comparisons` section above.
 
-Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_algorithm} algorithm with  {metadata(processed_sce)$cluster_weighting} weighting.
+Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_algorithm} algorithm with  {metadata(processed_sce)$cluster_weighting} weighting and {metadata(processed_sce)$cluster_nn} nearest neighbors.
 
 **Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters.
 These results should be interpreted with caution.

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -234,7 +234,7 @@ if (!has_multiplex) {
 <!-------------------------- Submitter heatmaps ------------------------------->
 ```{r, eval = submitter_heatmaps}
 # don't compare submitter to submitter
-available_celltypes <- available_celltypes[!(available_celltypes == "Submitter")]
+automated_celltypes_available <- available_celltypes[!(available_celltypes == "Submitter")]
 
 knitr::asis_output(
   "## Submitter-provided annotations
@@ -245,7 +245,7 @@ knitr::asis_output(
 
 ```{r, eval = submitter_heatmaps}
 # calculate matrices comparing to submitter
-jaccard_submitter_matrices <- available_celltypes |>
+jaccard_submitter_matrices <- automated_celltypes_available |>
   stringr::str_to_lower() |>
   purrr::map(\(name) {
     make_jaccard_matrix(
@@ -254,7 +254,7 @@ jaccard_submitter_matrices <- available_celltypes |>
       glue::glue("{name}_celltype_annotation")
     )
   }) |>
-  purrr::set_names(available_celltypes)
+  purrr::set_names(automated_celltypes_available)
 
 # how many cell types?
 all_celltypes <- jaccard_submitter_matrices |>
@@ -336,6 +336,61 @@ jaccard_consensus_matrices |>
 ```
 
 <!--TODO: Fill out clustering section -->
+
+```{r, eval = has_umap && has_clusters}
+knitr::asis_output(glue::glue("
+# Unsupervised clustering
+
+In this section, we look at unsupervised cluster assignments. 
+The first plot shows the cluster assignments on a UMAP and the second plot shows a heatmap comparing cluster assignments to cell type annotations. 
+The heatmap is colored by the Jaccard similarity index as described in the `Cell label comparisons` section above.
+
+Clusters were calculated using the graph-based {metadata(processed_sce)$cluster_algorithm} algorithm with  {metadata(processed_sce)$cluster_weighting} weighting.
+
+**Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters. 
+These results should be interpreted with caution. 
+"))
+```
+
+
+```{r, eval = has_umap, warning = FALSE}
+# Create dataset for plotting UMAPs with lumped and label-wrapped cell types
+umap_df <- lump_wrap_celltypes(celltype_df)
+```
+
+
+<!-- First UMAP: clusters -->
+
+```{r, eval = has_umap && has_multiplex && has_clusters, results='asis'}
+glue::glue("
+  <div class=\"alert alert-info\">
+    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
+    Please use caution when interpreting these results.
+  </div>
+")
+```
+
+
+```{r eval = has_umap && has_clusters, message=FALSE, warning=FALSE}
+clusters_plot <- plot_umap(
+  umap_df,
+  cluster,
+  "Cluster",
+  point_size = umap_point_size
+) +
+  ggtitle("UMAP colored by cluster identity")
+
+# Determine palette based on number of levels.
+# If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
+#  Otherwise, we will use the default palette.
+if (length(levels(umap_df$cluster)) <= 8) {
+  clusters_plot +
+    scale_color_brewer(palette = "Set2")
+} else {
+  clusters_plot
+}
+```
+
 <!-- If multiplexed, show info alert instead of this heatmap --> 
 ```{r, eval = has_multiplex, results='asis'}
 glue::glue("
@@ -349,13 +404,6 @@ glue::glue("
 
 <!-- If not multiplexed, show the header, text, and heatmap --> 
 ```{r, eval = !has_multiplex && has_clusters, results='asis'}
-glue::glue("
-  ## Unsupervised clustering
-
-  Here we show the labels from unsupervised clustering compared to cell type annotations.
-  Cluster assignment was performed using the `{metadata(processed_sce)$cluster_algorithm}` algorithm.
-")
-
 # Calculate all jaccard matrices of interest for input to heatmap
 jaccard_cluster_matrices <- available_celltypes |>
   stringr::str_to_lower() |>

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -20,7 +20,7 @@ These results should be interpreted with caution.
 ```{r, eval = has_multiplex && has_clusters, results='asis'}
 glue::glue("
   <div class=\"alert alert-info\">
-    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
+    This library contains multiple samples that have not been demultiplexed, which may confound clustering assignments.
     Please use caution when interpreting these results.
   </div>
 ")

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -12,7 +12,7 @@ umap_facet_point_size <- umap_points_sizes[2]
 ### Unsupervised clustering
 
 The cells in the blow UMAP are colored by cluster assignment. 
-Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with  `r metadata(processed_sce)$cluster_weighting` weighting.
+Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with  `r metadata(processed_sce)$cluster_weighting` weighting and `r metadata(processed_sce)$cluster_nn` nearest neighbors.
 
 **Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters.
 These results should be interpreted with caution.

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -1,6 +1,6 @@
 ## Dimensionality Reduction
 
-The below plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
+The below plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell. 
 
 ```{r}
 # determine UMAP point sizing
@@ -8,6 +8,35 @@ umap_points_sizes <- determine_umap_point_size(ncol(processed_sce))
 umap_point_size <- umap_points_sizes[1]
 umap_facet_point_size <- umap_points_sizes[2]
 ```
+
+### Unsupervised clustering
+
+The cells in the blow UMAP are colored by cluster assignment. 
+Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with  `r metadata(processed_sce)$cluster_weighting` weighting.
+
+**Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters.
+These results should be interpreted with caution.
+
+```{r, eval = has_multiplex && has_clusters, results='asis'}
+glue::glue("
+  <div class=\"alert alert-info\">
+    This library contains multiple samples that have not been batch-corrected, which may confound clustering assignments.
+    Please use caution when interpreting these results.
+  </div>
+")
+```
+
+```{r eval = has_clusters, message=FALSE, warning=FALSE}
+# create UMAP colored by clusters
+plot_clusters_umap(
+  processed_sce,
+  umap_point_size
+)
+```
+
+### Total number of genes
+
+The cells in the below UMAP are colored by the total number of genes detected per cell. 
 
 
 ```{r message=FALSE}
@@ -25,8 +54,10 @@ scater::plotUMAP(
   guides(
     color = guide_colorbar(title = "Number of \ngenes detected")
   ) +
+  theme_bw() +
   theme(aspect.ratio = 1)
 ```
+
 
 ### Expression of highly variable genes
 

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -25,6 +25,57 @@ determine_umap_point_size <- function(n_processed_cells) {
 
   return(c(umap_point_size, umap_facet_point_size))
 }
+
+#' Make UMAP colored by clusters
+#'
+#' @param sce SingleÇellExperiment object with UMAP embeddings
+#' @param point_size Point size. Default is 1
+#'
+#' @return UMAP plot as a ggplot2 object
+#' 
+plot_clusters_umap <- function(
+    sce,
+    point_size = 1) {
+  
+  # umap colored by clusters
+  clusters_plot <- scater::plotUMAP(
+    sce,
+    point_size = umap_point_size,
+    point_alpha = 0.5,
+    colour_by = "cluster"
+  ) +
+    # remove axis numbers and background grid
+    scale_x_continuous(labels = NULL, breaks = NULL) +
+    scale_y_continuous(labels = NULL, breaks = NULL) +
+    guides(
+      color = guide_legend(
+        title = "Cluster",
+        nrow = 2,
+        # more visible points in legend
+        override.aes = list(
+          alpha = 1,
+          size = 1.5
+        )
+      )
+    ) +
+    theme_bw() +
+    theme(
+      legend.position = "bottom",
+      aspect.ratio = 1
+    )
+  
+  # Determine palette based on number of levels.
+  # If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
+  #  Otherwise, we will use the default palette.
+  if (length(levels(sce$cluster)) <= 8) {
+    clusters_plot +
+      scale_color_brewer(palette = "Set2")
+  } else {
+    clusters_plot
+  }
+  
+  return(clusters_plot)
+}
 ```
 
 ```{r}

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -32,11 +32,10 @@ determine_umap_point_size <- function(n_processed_cells) {
 #' @param point_size Point size. Default is 1
 #'
 #' @return UMAP plot as a ggplot2 object
-#' 
+#'
 plot_clusters_umap <- function(
     sce,
     point_size = 1) {
-  
   # umap colored by clusters
   clusters_plot <- scater::plotUMAP(
     sce,
@@ -63,7 +62,7 @@ plot_clusters_umap <- function(
       legend.position = "bottom",
       aspect.ratio = 1
     )
-  
+
   # Determine palette based on number of levels.
   # If we have <=8, we can use a CVD-friendly palette (they generally don't have more than 8 colors).
   #  Otherwise, we will use the default palette.
@@ -73,7 +72,7 @@ plot_clusters_umap <- function(
   } else {
     clusters_plot
   }
-  
+
   return(clusters_plot)
 }
 ```


### PR DESCRIPTION
Stacked on #950 
Closes #948 

Here I'm moving the clustering UMAP and heatmap to a separate `Unsupervised clustering` section to be shown in the supplemental report. This section appears after the cell label comparisons (see #950) and before the diagnostic plots. I included a statement warning users to interpret the clusters with caution. 

At first, I was skeptical about moving the UMAP with clusters out of the main report since people love to look at colorful UMAPs, BUT I don't think it's entirely helpful where it currently is in the main report. We include it within the cell type section as a UMAP before the faceted UMAPs. I think _if_ we include the UMAP in the main report, it should be its own section outside of the cell type section. Because we don't really trust these clusters anyways, I don't love having a whole section in the main report on it, but feel free to convince me otherwise. 

So all of that led me back to just having the one section in the supplemental report. What do we think? 

Here's a copy of both reports: 
[reports.zip](https://github.com/user-attachments/files/21634074/reports.zip)
