### PR TITLE
Adopt stricter Nextflow syntax

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "nextflow.files.exclude": [".git", ".nf-test", "work", ".pixi", ".github"],
+  "[nextflow]": {
+    "editor.tabSize": 2,
+    "editor.formatOnSave": false
+  },
+  "[tsv]": {
+    "editor.insertSpaces": false
+  }
+}

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -20,12 +20,12 @@ This section provides instructions for running the main workflow, found in [`mai
 Note that there are three other workflows:
 
 - [`build-index.nf`](build-index.nf) for building reference indices (see #adding-additional-organisms)
-- [`build-celltype-ref.nf`](build-cellltype-ref.nf) for creating cell type annotation references (see #adding-additional-cell-type-references)
+- [`build-celltype-ref.nf`](build-celltype-ref.nf) for creating cell type annotation references (see #adding-additional-cell-type-references)
 - [`merge.nf`](merge.nf) for merging processed objects produced by the main workflow (see #running-the-merge-workflow)
 
 The instructions below assume that you are a member of the Data Lab with access to AWS.
 Most of the workflow settings described are configured for the ALSF Childhood Cancer Data Lab computational infrastructure.
-To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-data-instructions.md).
+To process samples that are not part of the ScPCA project, please see the [instructions on using `scpca-nf` with external data](external-instructions.md).
 
 To process single-cell and single-nuclei samples using `scpca-nf` you will need access to at least 24 GB of RAM and 12 CPUs, so we recommend using AWS batch.
 The first step in running the workflow is ensuring that your AWS credentials are configured.
@@ -53,7 +53,7 @@ There are several flags and/or parameters which you may additionally wish to spe
 - Workflow parameters:
   - `--run_ids list,of,ids`: A custom comma-separated list of ids (run, library, or sample) for this run.
   - `--project list,of,project_ids`: A custom comma-separated list of project ids for this run
-    [The default](config/profile_ccdl.config) run ids are `"SCPCR000001,SCPCS000101"`.
+    [The default](config/ccdl_profiles.config) run ids are `"SCPCR000001,SCPCS000101"`.
   - `--repeat_mapping`: Use this flag to repeat mapping, even if results already exist.
     - By default, the workflow checks whether each library has existing `alevin-fry` or `salmon` mapping results, and skips mapping for libraries with existing results.
       Using this flag will override that default behavior and repeat mapping even if the given library's results exist.

--- a/main.nf
+++ b/main.nf
@@ -192,21 +192,21 @@ workflow {
     }
 
   // generate lists of library ids for feature libraries & RNA-only
-  def feature_libs = runs_ch.feature
+  feature_libs = runs_ch.feature
     .collect{it.library_id}
-  def rna_only_libs = runs_ch.rna
+  rna_only_libs = runs_ch.rna
     .filter{!(it.library_id in feature_libs.getVal())}
     .collect{it.library_id}
-  def multiplex_libs = runs_ch.rna
+  multiplex_libs = runs_ch.rna
     .filter{it.sample_id.contains(",")}
     .collect{it.library_id}
 
   // get list of samples with bulk RNA-seq
-  def bulk_samples = runs_ch.bulk
+  bulk_samples = runs_ch.bulk
     .collect{it.sample_id}
 
   // get genetic multiplex libs with all bulk samples present
-  def genetic_multiplex_libs = runs_ch.rna
+  genetic_multiplex_libs = runs_ch.rna
     .filter{!params.skip_genetic_demux} // empty channel if skipping genetic demux
     .filter{it.sample_id.contains(",")}
     .filter{it.sample_id.tokenize(",").every{it in bulk_samples.getVal()}}

--- a/merge.nf
+++ b/merge.nf
@@ -4,27 +4,27 @@ nextflow.enable.dsl=2
 // Workflow to merge SCE objects into a single object.
 // This workflow does NOT perform integration, i.e. batch correction.
 
-// define path to merge template
-merge_template = "${projectDir}/templates/merge-report.rmd"
+// parameter check
+def check_parameters() {
+  def param_error = false
 
-// parameter checks
-param_error = false
+  // check that at least one project has been provided
+  if(!params.project) {
+    log.error("At least one 'project' must be specified for merging.")
+    param_error = true
+  }
 
-// check that at least one project has been provided
-if(!params.project) {
-  log.error("At least one 'project' must be specified for merging.")
-  param_error = true
+  // check for provided run file
+  if (!file(params.run_metafile).exists()) {
+    log.error("The 'run_metafile' file '${params.run_metafile}' can not be found.")
+    param_error = true
+  }
+
+  if (param_error) {
+    System.exit(1)
+  }
 }
 
-// check for provided run file
-if (!file(params.run_metafile).exists()) {
-  log.error("The 'run_metafile' file '${params.run_metafile}' can not be found.")
-  param_error = true
-}
-
-if (param_error) {
-  System.exit(1)
-}
 
 // merge individual SCE objects into one SCE object
 process merge_sce {
@@ -88,175 +88,180 @@ process generate_merge_report {
 }
 
 process export_anndata {
-    container params.SCPCATOOLS_ANNDATA_CONTAINER
-    label 'mem_max'
-    label 'long_running'
-    tag "${merge_group_id}"
-    publishDir "${params.results_dir}/${merge_group_id}/merged", mode: 'copy'
-    input:
-      tuple path(merged_sce_file), val(merge_group_id), val(has_adt)
-    output:
-      tuple val(merge_group_id), path("${merge_group_id}_merged_*.h5ad")
-    script:
-      rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
-      feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
-      """
-      sce_to_anndata.R \
-        --input_sce_file ${merged_sce_file} \
-        --output_rna_h5 ${rna_h5ad_file} \
-        --output_feature_h5 ${feature_h5ad_file} \
-        --is_merged \
-        ${has_adt ? "--feature_name adt" : ''}
+  container params.SCPCATOOLS_ANNDATA_CONTAINER
+  label 'mem_max'
+  label 'long_running'
+  tag "${merge_group_id}"
+  publishDir "${params.results_dir}/${merge_group_id}/merged", mode: 'copy'
+  input:
+    tuple path(merged_sce_file), val(merge_group_id), val(has_adt)
+  output:
+    tuple val(merge_group_id), path("${merge_group_id}_merged_*.h5ad")
+  script:
+    rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
+    feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
+    """
+    sce_to_anndata.R \
+      --input_sce_file ${merged_sce_file} \
+      --output_rna_h5 ${rna_h5ad_file} \
+      --output_feature_h5 ${feature_h5ad_file} \
+      --is_merged \
+      ${has_adt ? "--feature_name adt" : ''}
 
-      # move normalized counts to X in AnnData
-      reformat_anndata.py --anndata_file ${rna_h5ad_file} --hvg_name "merged_highly_variable_genes"
-      ${has_adt ? "reformat_anndata.py --anndata_file ${feature_h5ad_file} --hvg_name 'none' " : ''}
-      """
-    stub:
-      rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
-      feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
-      """
-      touch ${rna_h5ad_file}
-      ${has_adt ? "touch ${feature_h5ad_file}" : ''}
-      """
+    # move normalized counts to X in AnnData
+    reformat_anndata.py --anndata_file ${rna_h5ad_file} --hvg_name "merged_highly_variable_genes"
+    ${has_adt ? "reformat_anndata.py --anndata_file ${feature_h5ad_file} --hvg_name 'none' " : ''}
+    """
+  stub:
+    rna_h5ad_file = "${merge_group_id}_merged_rna.h5ad"
+    feature_h5ad_file = "${merge_group_id}_merged_adt.h5ad"
+    """
+    touch ${rna_h5ad_file}
+    ${has_adt ? "touch ${feature_h5ad_file}" : ''}
+    """
 }
 
 workflow {
+  check_parameters()
 
-    // grab project ids to run
-    project_ids = params.project?.tokenize(',') ?: []
+  // define path to merge template
+  def merge_template = "${projectDir}/templates/merge-report.rmd"
 
-    // grab run ids to include
-    run_ids = params.merge_run_ids?.tokenize(',') ?: []
-    // if no run ids, run all
-    run_all = run_ids[0] == "All"
 
-    // read in run metafile and filter to projects of interest
-    libraries_ch = Channel.fromPath(params.run_metafile)
-      .splitCsv(header: true, sep: '\t')
-      // filter to only include specified project ids
-      .filter{it.scpca_project_id in project_ids}
-      // filter to run all ids or just specified ones
-      .filter{
-        run_all
-        || (it.scpca_run_id in run_ids)
-        || (it.scpca_library_id in run_ids)
-        || (it.scpca_sample_id in run_ids)
-      }
-      .map{[
-        project_id: it.scpca_project_id,
-        library_id: it.scpca_library_id,
-        sample_id: it.scpca_sample_id.split(";").sort().join(","),
-        seq_unit: it.seq_unit,
-        technology: it.technology
-      ]}
+  // grab project ids to run
+  def project_ids = params.project?.tokenize(',') ?: []
 
-    // get all projects that contain at least one library with CITEseq
-    adt_projects = libraries_ch
-      .filter{it.technology.startsWith('CITEseq')}
-      .collect{it.project_id}
-      .map{it.unique()}
+  // grab run ids to include
+  def run_ids = params.merge_run_ids?.tokenize(',') ?: []
+  // if no run ids, run all
+  def run_all = run_ids[0] == "All"
 
-    multiplex_projects = libraries_ch
-      .filter{it.technology.startsWith('cellhash')}
-      .collect{it.project_id}
-      .map{it.unique()}
+  // read in run metafile and filter to projects of interest
+  libraries_ch = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    // filter to only include specified project ids
+    .filter{it.scpca_project_id in project_ids}
+    // filter to run all ids or just specified ones
+    .filter{
+      run_all
+      || (it.scpca_run_id in run_ids)
+      || (it.scpca_library_id in run_ids)
+      || (it.scpca_sample_id in run_ids)
+    }
+    .map{[
+      project_id: it.scpca_project_id,
+      library_id: it.scpca_library_id,
+      sample_id: it.scpca_sample_id.split(";").sort().join(","),
+      seq_unit: it.seq_unit,
+      technology: it.technology
+    ]}
 
-    oversized_projects = libraries_ch
-      .filter{it.technology.startsWith("10X")} // only count single-cell or single-nuclei libraries, no cell hash, ADT, bulk or spatial
-      .map{[
-        it.project_id, // pull out project id for grouping
-        it
-      ]}
-      .groupTuple(by: 0) // group by project id
-      .filter{it[1].size() > params.max_merge_libraries} // get projects with more samples than max merge
-      .collect{it[0]} // get project id
+  // get all projects that contain at least one library with CITEseq
+  adt_projects = libraries_ch
+    .filter{it.technology.startsWith('CITEseq')}
+    .collect{it.project_id}
+    .map{it.unique()}
 
-    filtered_libraries_ch = libraries_ch
-      // only include single-cell/single-nuclei which ensures we don't try to merge libraries from spatial or bulk data
-      .filter{it.seq_unit in ['cell', 'nucleus']}
-      // remove any multiplexed projects or oversized projects
-      // future todo: only filter library ids that are multiplexed, but keep all other non-multiplexed libraries
-      .branch{
-        multiplexed: it.project_id in multiplex_projects.getVal()
-        oversized: it.project_id in oversized_projects.getVal()
-        single_sample: true
-      }
+  multiplex_projects = libraries_ch
+    .filter{it.technology.startsWith('cellhash')}
+    .collect{it.project_id}
+    .map{it.unique()}
 
-    filtered_libraries_ch.multiplexed
-      .unique{ it.project_id }
-      .subscribe{
-        log.warn("Not merging ${it.project_id} because it contains multiplexed libraries.")
-      }
+  oversized_projects = libraries_ch
+    .filter{it.technology.startsWith("10X")} // only count single-cell or single-nuclei libraries, no cell hash, ADT, bulk or spatial
+    .map{[
+      it.project_id, // pull out project id for grouping
+      it
+    ]}
+    .groupTuple(by: 0) // group by project id
+    .filter{it[1].size() > params.max_merge_libraries} // get projects with more samples than max merge
+    .collect{it[0]} // get project id
 
-    filtered_libraries_ch.oversized
-      .unique{ it.project_id }
-      .subscribe{
-        log.warn("Not merging ${it.project_id} because it contains too many libraries.")
-      }
-
-    // print out warning message for any libraries not included in merging
-    filtered_libraries_ch.single_sample
-      .map{[
-        it.library_id,
-        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds"),
-        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_metadata.json")
-      ]}
-    .subscribe{
-      if(!(it[1].exists() && it[1].size() > 0)){
-        log.warn("Processed files do not exist for ${it[0]}. This library will not be included in the merged object.")
-      }
-      else if(!(it[2].exists() && it[2].size() > 0)){
-        log.warn("Metadata file does not exist for ${it[0]}. This library will not be included in the merged object.")
-      }
-      else if (Utils.getMetaVal(it[2], "processed_cells") < 3){
-        log.warn("Library ${it[0]} has fewer than 3 cells. This library will not be included in the merged object.")
-      }
+  filtered_libraries_ch = libraries_ch
+    // only include single-cell/single-nuclei which ensures we don't try to merge libraries from spatial or bulk data
+    .filter{it.seq_unit in ['cell', 'nucleus']}
+    // remove any multiplexed projects or oversized projects
+    // future todo: only filter library ids that are multiplexed, but keep all other non-multiplexed libraries
+    .branch{
+      multiplexed: it.project_id in multiplex_projects.getVal()
+      oversized: it.project_id in oversized_projects.getVal()
+      single_sample: true
     }
 
-    grouped_libraries_ch = filtered_libraries_ch.single_sample
-      // create tuple of [project id, library_id, processed_sce_file]
-      .map{[
-        it.project_id,
-        it.library_id,
-        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds"),
-        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_metadata.json")
-      ]}
-      // only include libraries that have been processed through scpca-nf and have at least 3 cells
-      .filter{it[2].exists() && it[2].size() > 0 && Utils.getMetaVal(it[3], "processed_cells") >= 3}
-      .map{it[0..2]} // remove metadata file from tuple
-      // only one row per library ID, this removes all the duplicates that may be present due to CITE/hashing
-      .unique()
-      // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
-      .groupTuple(by: 0)
-      // add in boolean for if project contains samples with adt
-      .map{project_id, library_id_list, sce_file_list -> tuple(
-        project_id,
-        project_id in adt_projects.getVal(), // determines if altExp should be included in the merged object
-        library_id_list,
-        sce_file_list
-      )}
-      .branch{
-        has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && params.reuse_merge
-        make_merge: true
-      }
+  filtered_libraries_ch.multiplexed
+    .unique{ it.project_id }
+    .subscribe{
+      log.warn("Not merging ${it.project_id} because it contains multiplexed libraries.")
+    }
 
-    pre_merged_ch = grouped_libraries_ch.has_merge
-      .map{[ // merge file, project id, has adt
-        file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds"),
-        it[0],
-        it[1]
-      ]}
+  filtered_libraries_ch.oversized
+    .unique{ it.project_id }
+    .subscribe{
+      log.warn("Not merging ${it.project_id} because it contains too many libraries.")
+    }
 
-    // merge SCE objects
-    merge_sce(grouped_libraries_ch.make_merge)
+  // print out warning message for any libraries not included in merging
+  filtered_libraries_ch.single_sample
+    .map{[
+      it.library_id,
+      file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds"),
+      file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_metadata.json")
+    ]}
+  .subscribe{
+    if(!(it[1].exists() && it[1].size() > 0)){
+      log.warn("Processed files do not exist for ${it[0]}. This library will not be included in the merged object.")
+    }
+    else if(!(it[2].exists() && it[2].size() > 0)){
+      log.warn("Metadata file does not exist for ${it[0]}. This library will not be included in the merged object.")
+    }
+    else if (Utils.getMetaVal(it[2], "processed_cells") < 3){
+      log.warn("Library ${it[0]} has fewer than 3 cells. This library will not be included in the merged object.")
+    }
+  }
 
-    merged_ch = merge_sce.out.mix(pre_merged_ch)
+  grouped_libraries_ch = filtered_libraries_ch.single_sample
+    // create tuple of [project id, library_id, processed_sce_file]
+    .map{[
+      it.project_id,
+      it.library_id,
+      file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed.rds"),
+      file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_metadata.json")
+    ]}
+    // only include libraries that have been processed through scpca-nf and have at least 3 cells
+    .filter{it[2].exists() && it[2].size() > 0 && Utils.getMetaVal(it[3], "processed_cells") >= 3}
+    .map{it[0..2]} // remove metadata file from tuple
+    // only one row per library ID, this removes all the duplicates that may be present due to CITE/hashing
+    .unique()
+    // group tuple by project id: [project_id, [library_id1, library_id2, ...], [sce_file1, sce_file2, ...]]
+    .groupTuple(by: 0)
+    // add in boolean for if project contains samples with adt
+    .map{project_id, library_id_list, sce_file_list -> tuple(
+      project_id,
+      project_id in adt_projects.getVal(), // determines if altExp should be included in the merged object
+      library_id_list,
+      sce_file_list
+    )}
+    .branch{
+      has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && params.reuse_merge
+      make_merge: true
+    }
+
+  pre_merged_ch = grouped_libraries_ch.has_merge
+    .map{[ // merge file, project id, has adt
+      file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds"),
+      it[0],
+      it[1]
+    ]}
+
+  // merge SCE objects
+  merge_sce(grouped_libraries_ch.make_merge)
+
+  merged_ch = merge_sce.out.mix(pre_merged_ch)
 
 
-    // generate merge report
-    generate_merge_report(merged_ch, file(merge_template))
+  // generate merge report
+  generate_merge_report(merged_ch, file(merge_template))
 
-    // export merged objects to AnnData
-    export_anndata(merged_ch)
+  // export merged objects to AnnData
+  export_anndata(merged_ch)
 }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -141,12 +141,13 @@ process add_celltypes_to_sce {
     """
 }
 
-empty_file = "${projectDir}/assets/NO_FILE"
+
 
 workflow annotate_celltypes {
   take: sce_files_channel // channel of meta, unfiltered_sce, filtered_sce, processed_sce
   main:
 
+  def empty_file = "${projectDir}/assets/NO_FILE"
   // read in sample metadata and make a list of cell line samples; these won't be cell typed
   cell_line_samples = Channel.fromPath(params.sample_metafile)
     .splitCsv(header: true, sep: '\t')

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -190,7 +190,7 @@ workflow annotate_celltypes {
       .combine(celltype_ch, by: 0)
       // current contents: [project_id, meta, processed_sce, singler_model_file, cellassign_reference_file]
       // add values to meta for later use
-      .map{ project_id, meta_in, processed_sce, singler_model_file, cellassign_reference_file ->
+      .map{ _project_id, meta_in, processed_sce, singler_model_file, cellassign_reference_file ->
         def meta = meta_in.clone(); // local copy for safe modification
         meta.celltype_checkpoints_dir = "${params.checkpoints_dir}/celltype/${meta.library_id}";
         meta.singler_dir = "${meta.celltype_checkpoints_dir}/${meta.library_id}_singler";
@@ -299,7 +299,7 @@ workflow annotate_celltypes {
         by: 0, failOnMismatch: true, failOnDuplicate: true
       )
       // rearrange to be [meta, unfiltered, filtered, processed]
-      .map{library_id, meta, processed_sce, unfiltered_sce, filtered_sce ->
+      .map{_library_id, meta, processed_sce, unfiltered_sce, filtered_sce ->
         [meta, unfiltered_sce, filtered_sce, processed_sce]
       }
       // mix in cell line libraries which were not cell typed

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -71,7 +71,7 @@ workflow sce_to_anndata {
 
       // combine all anndata files by library id
       anndata_ch = export_anndata.out
-        .map{ meta, h5ad_files, file_type -> tuple(
+        .map{ meta, h5ad_files, _file_type -> tuple(
           meta.library_id, // pull out library id for grouping
           meta,
           h5ad_files // either rna.h5ad or [ rna.h5ad, feature.h5ad ]

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -229,8 +229,7 @@ process post_process_sce {
 }
 
 
-// used when a given file is not defined in the below workflows
-empty_file = "${projectDir}/assets/NO_FILE"
+
 
 workflow generate_sce {
   // generate rds files for RNA-only samples
@@ -238,6 +237,7 @@ workflow generate_sce {
     quant_channel
     sample_metafile
   main:
+    def empty_file = "${projectDir}/assets/NO_FILE"
 
     sce_ch = quant_channel
       .map{it.toList() + [file(it[0].mito_file, checkIfExists: true),
@@ -265,6 +265,7 @@ workflow generate_sce_with_feature {
     feature_quant_channel
     sample_metafile
   main:
+    def empty_file = "${projectDir}/assets/NO_FILE"
 
     feature_sce_ch = feature_quant_channel
       // RNA meta is in the third slot here


### PR DESCRIPTION
In the future, Nextflow will be requiring a [stricter syntax](https://nextflow.io/docs/latest/strict-syntax.html), which includes some elements like not allowing bare statements in scripts; all statements must be in a `workflow` or `process` block, or in a function or class definition. The new [Nextflow VSCode plugin](https://nextflow.io/docs/latest/vscode.html) provides feedback on many kinds of potential syntax errors, but the majority of the errors that show up in scpca-nf at the moment are related to the strict syntax, so I wanted to get them out of the way. 

The result is a PR that looks big (especially as regards `main.nf` and `merge.nf`, but is mostly just about moving some code, not actually changing logic. 

I also added a `.vscode/settings.json` file to the repository, mostly to add a few common settings for the Nextflow plugin config that I though we would want to share. In particular we probably don't want to reformat on save at this stage, because the format we have been using does not match the "standard" format (we indent under `input:` & `script:`, for example), and there does not seem to be an easy way to customize this. If we want to we can turn that to `true` at some point, but there are enough changes here already, I thought. 

Other more minor changes include adding `def` to most variable definitions (though not for channels, as that seemed to cause problems), and adding `_` prefixes in `map{}` statements when an input tuple element is not used in the block. Seemed a reasonable thing to do to quiet some warnings. 

I have a separate PR that I will file to the flex support branch soon to keep that in sync for its eventual merge.

  