### PR TITLE
Add tabs and DT to the main report

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -47,7 +47,6 @@ miQC
 Nextflow
 Nextflow's
 nf
-Oligos
 oligos
 PanglaoDB
 parallelizing

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -48,6 +48,7 @@ Nextflow
 Nextflow's
 nf
 Oligos
+oligos
 PanglaoDB
 parallelizing
 pixi

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -1,4 +1,4 @@
-# Cell type Annotation Summary
+# Cell type annotation summary
 
 <!--
 This file is meant to be run as a child report within either `main_qc_report.rmd` or `celltypes_supplemental_report.rmd`. 
@@ -244,8 +244,14 @@ glue::glue("
 ")
 ```
 
+```{r}
+if(has_consensus & !has_submitter & !is_supplemental){
+  knitr::asis_output('## Statistics')
+} else {
+  knitr::asis_output('## Statistics {.tabset}')
+}
+```
 
-## Statistics
 
 ```{r, warning = FALSE}
 # Create data frame of cell types
@@ -357,18 +363,21 @@ create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
 umap_df <- lump_wrap_celltypes(celltype_df)
 ```
 
+
 ```{r, eval = has_umap && has_celltypes }
 # only mention multiple annotations if we're actually showing multiple annotations
 if (has_consensus && !has_submitter && !is_supplemental) {
+  header_text <- "## UMAPs"
   umap_text <- ""
 } else {
+  header_text <- '## UMAPs {.tabset}'
   umap_text <- "For each cell typing method, we show a separate faceted UMAP."
 }
 
 
 knitr::asis_output(glue::glue(
-  '## UMAPs
-
+  '{header_text}
+  
   In this section, we show UMAPs colored by cell types.
   {umap_text}
 In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.
@@ -385,6 +394,7 @@ All other cell types are grouped together and labeled "All remaining cell types"
 if (has_submitter & has_umap) {
   submitter_n_celltypes <- length(levels(umap_df$submitter_celltype_annotation_lumped))
   submitter_dims <- determine_umap_dimensions(submitter_n_celltypes)
+  knitr::asis_output('### Submitter-provided annotations')
 } else {
   # set fake dims for evaluating next chunk
   submitter_dims <- c(1, 1)
@@ -398,8 +408,7 @@ faceted_umap(
   submitter_n_celltypes,
   submitter_celltype_annotation_lumped,
   point_size = umap_facet_point_size
-) +
-  ggtitle("UMAP colored by submitter-provided annotations")
+)
 ```
 
 
@@ -407,6 +416,7 @@ faceted_umap(
 if (has_consensus & has_umap) {
   consensus_n_celltypes <- length(levels(umap_df$consensus_celltype_annotation_lumped))
   consensus_dims <- determine_umap_dimensions(consensus_n_celltypes)
+  knitr::asis_output('### Consensus cell type annotations')
 } else {
   # set fake dims for evaluating next chunk
   consensus_dims <- c(1, 1)
@@ -421,14 +431,14 @@ faceted_umap(
   consensus_n_celltypes,
   consensus_celltype_annotation_lumped,
   point_size = umap_facet_point_size
-) +
-  ggtitle("UMAP colored by consensus cell type annotations")
+) 
 ```
 
 ```{r}
-if (has_singler & has_umap) {
+if (has_singler & has_umap && (is_supplemental || !has_consensus)) {
   singler_n_celltypes <- length(levels(umap_df$singler_celltype_annotation_lumped))
   singler_dims <- determine_umap_dimensions(singler_n_celltypes)
+  knitr::asis_output('### SingleR annotations')
 } else {
   # set fake dims for evaluating next chunk
   singler_dims <- c(1, 1)
@@ -443,15 +453,15 @@ faceted_umap(
   singler_n_celltypes,
   singler_celltype_annotation_lumped,
   point_size = umap_facet_point_size
-) +
-  ggtitle("UMAP colored by SingleR annotations")
+)
 ```
 
 
 ```{r}
-if (has_cellassign & has_umap) {
+if (has_cellassign & has_umap && (is_supplemental || !has_consensus)) {
   cellassign_n_celltypes <- length(levels(umap_df$cellassign_celltype_annotation_lumped))
   cellassign_dims <- determine_umap_dimensions(cellassign_n_celltypes)
+  knitr::asis_output('### CellAssign annotations')
 } else {
   # set fake dims for evaluating next chunk
   cellassign_dims <- c(1, 1)
@@ -465,8 +475,7 @@ faceted_umap(
   cellassign_n_celltypes,
   cellassign_celltype_annotation_lumped,
   point_size = umap_facet_point_size
-) +
-  ggtitle("UMAP colored by CellAssign annotations")
+)
 ```
 
 
@@ -683,7 +692,7 @@ combined_plot
 submitter_heatmaps <- (has_submitter & (has_consensus | has_cellassign | has_singler))
 ```
 
-```{r, eval=submitter_heatmaps | has_consensus, results = 'asis'}
+```{r, eval=submitter_heatmaps | (has_consensus & is_supplemental), results = 'asis'}
 # update text depending on if this is the main or supplemental report
 if (has_submitter & has_consensus & !is_supplemental) {
   heatmap_text <- "This section displays heatmaps comparing consensus cell type labels to submitter annotations."

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -494,6 +494,8 @@ All marker genes shown are specific to a single cell type, with the exception of
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
 Note that dots are only shown if the gene has mean expression greater than 0 and is expressed in at least 10% of the cells in the given cell type.
+
+If all consensus cell types are labeled as `Unknown cell type`, then no dot plot will be shown. 
   ")
 ```
 
@@ -641,49 +643,53 @@ dotplot_df <- group_stats_df |>
 
 
 ```{r, eval = has_consensus, fig.height=7, fig.width=15}
-# make dotplot with marker gene exp
-dotplot <- ggplot(dotplot_df, aes(y = y_label, x = gene_symbol, color = mean_exp, size = percent_exp)) +
-  geom_point() +
-  scale_color_viridis_c(option = "magma") +
-  facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
-  theme_classic() +
-  theme(
-    strip.background = element_rect(fill = "transparent", color = NA),
-    strip.placement = "outside",
-    strip.text.x = element_blank(),
-    axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
-    axis.ticks.x = element_blank(),
-    text = element_text(size = 14),
-    panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
-  ) +
-  labs(
-    x = "",
-    y = "Broad cell type annotation",
-    color = "Mean gene expression",
-    size = "Percent cells expressed"
-  )
-
-
-# add annotation bar aligning marker genes with validation group
-color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
-  geom_tile() +
-  facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
-  scale_fill_manual(values = celltype_colors, breaks = levels(dotplot_df$validation_group_annotation)) +
-  ggmap::theme_nothing() +
-  theme(
-    strip.background = element_rect(fill = "transparent", color = NA),
-    strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
-    strip.placement = "outside",
-    legend.position = "none",
-    panel.spacing = unit(0.5, "lines"),
-    strip.clip = "off"
-  ) +
-  labs(fill = "")
-
-combined_plot <- color_bar / dotplot +
-  patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
-
-combined_plot
+# only make a dot plot if we have at least one validation group annotation present 
+if(length(unique(dotplot_df$validation_group_annotation)) > 0) {
+  
+  # make dotplot with marker gene exp
+  dotplot <- ggplot(dotplot_df, aes(y = y_label, x = gene_symbol, color = mean_exp, size = percent_exp)) +
+    geom_point() +
+    scale_color_viridis_c(option = "magma") +
+    facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
+    theme_classic() +
+    theme(
+      strip.background = element_rect(fill = "transparent", color = NA),
+      strip.placement = "outside",
+      strip.text.x = element_blank(),
+      axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
+      axis.ticks.x = element_blank(),
+      text = element_text(size = 14),
+      panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
+    ) +
+    labs(
+      x = "",
+      y = "Broad cell type annotation",
+      color = "Mean gene expression",
+      size = "Percent cells expressed"
+    )
+  
+  
+  # add annotation bar aligning marker genes with validation group
+  color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
+    geom_tile() +
+    facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
+    scale_fill_manual(values = celltype_colors, breaks = levels(dotplot_df$validation_group_annotation)) +
+    ggmap::theme_nothing() +
+    theme(
+      strip.background = element_rect(fill = "transparent", color = NA),
+      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
+      strip.placement = "outside",
+      legend.position = "none",
+      panel.spacing = unit(0.5, "lines"),
+      strip.clip = "off"
+    ) +
+    labs(fill = "")
+  
+  combined_plot <- color_bar / dotplot +
+    patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
+  
+  combined_plot
+}
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -494,8 +494,6 @@ All marker genes shown are specific to a single cell type, with the exception of
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
 Note that dots are only shown if the gene has mean expression greater than 0 and is expressed in at least 10% of the cells in the given cell type.
-
-If all consensus cell types are labeled as `Unknown cell type`, then no dot plot will be shown.
   ")
 ```
 
@@ -643,52 +641,49 @@ dotplot_df <- group_stats_df |>
 
 
 ```{r, eval = has_consensus, fig.height=7, fig.width=15}
-# only make a dot plot if we have at least one validation group annotation present
-if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
-  # make dotplot with marker gene exp
-  dotplot <- ggplot(dotplot_df, aes(y = y_label, x = gene_symbol, color = mean_exp, size = percent_exp)) +
-    geom_point() +
-    scale_color_viridis_c(option = "magma") +
-    facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
-    theme_classic() +
-    theme(
-      strip.background = element_rect(fill = "transparent", color = NA),
-      strip.placement = "outside",
-      strip.text.x = element_blank(),
-      axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
-      axis.ticks.x = element_blank(),
-      text = element_text(size = 14),
-      panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
-    ) +
-    labs(
-      x = "",
-      y = "Broad cell type annotation",
-      color = "Mean gene expression",
-      size = "Percent cells expressed"
-    )
+# make dotplot with marker gene exp
+dotplot <- ggplot(dotplot_df, aes(y = y_label, x = gene_symbol, color = mean_exp, size = percent_exp)) +
+  geom_point() +
+  scale_color_viridis_c(option = "magma") +
+  facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
+  theme_classic() +
+  theme(
+    strip.background = element_rect(fill = "transparent", color = NA),
+    strip.placement = "outside",
+    strip.text.x = element_blank(),
+    axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
+    axis.ticks.x = element_blank(),
+    text = element_text(size = 14),
+    panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
+  ) +
+  labs(
+    x = "",
+    y = "Broad cell type annotation",
+    color = "Mean gene expression",
+    size = "Percent cells expressed"
+  )
 
 
-  # add annotation bar aligning marker genes with validation group
-  color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
-    geom_tile() +
-    facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
-    scale_fill_manual(values = celltype_colors, breaks = levels(dotplot_df$validation_group_annotation)) +
-    ggmap::theme_nothing() +
-    theme(
-      strip.background = element_rect(fill = "transparent", color = NA),
-      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
-      strip.placement = "outside",
-      legend.position = "none",
-      panel.spacing = unit(0.5, "lines"),
-      strip.clip = "off"
-    ) +
-    labs(fill = "")
+# add annotation bar aligning marker genes with validation group
+color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
+  geom_tile() +
+  facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
+  scale_fill_manual(values = celltype_colors, breaks = levels(dotplot_df$validation_group_annotation)) +
+  ggmap::theme_nothing() +
+  theme(
+    strip.background = element_rect(fill = "transparent", color = NA),
+    strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
+    strip.placement = "outside",
+    legend.position = "none",
+    panel.spacing = unit(0.5, "lines"),
+    strip.clip = "off"
+  ) +
+  labs(fill = "")
 
-  combined_plot <- color_bar / dotplot +
-    patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
+combined_plot <- color_bar / dotplot +
+  patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
 
-  combined_plot
-}
+combined_plot
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -1,4 +1,4 @@
-# Cell type annotation summary
+# Cell type Annotation Summary
 
 <!--
 This file is meant to be run as a child report within either `main_qc_report.rmd` or `celltypes_supplemental_report.rmd`. 
@@ -324,7 +324,7 @@ knitr::asis_output('
 In this table, cells labeled "Submitter-excluded" are those for which submitters did not provide an annotation.
 ')
 create_celltype_n_table(celltype_df, submitter_celltype_annotation) |>
-  format_celltype_n_table()
+  DT::datatable(rownames = FALSE)
 ```
 
 ```{r, eval = has_consensus}
@@ -334,7 +334,7 @@ In this table, cells labeled "Unknown cell type" are those whose `SingleR` and `
 In the processed result files, these cells are labeled `Unknown`.
 ')
 create_celltype_n_table(celltype_df, consensus_celltype_annotation) |>
-  format_celltype_n_table()
+  DT::datatable(rownames = FALSE)
 ```
 
 ```{r, eval = has_singler && (!has_consensus || is_supplemental)}
@@ -344,7 +344,7 @@ In this table, cells labeled "Unknown cell type" are those which `SingleR` prune
 In the processed result files, these cells are labeled `NA`.
 ')
 create_celltype_n_table(celltype_df, singler_celltype_annotation) |>
-  format_celltype_n_table()
+  DT::datatable(rownames = FALSE)
 ```
 
 ```{r, eval = has_cellassign && (!has_consensus || is_supplemental)}
@@ -354,7 +354,7 @@ In this table, cells labeled "Unknown cell type" are those which `CellAssign` co
 In the processed result files, these cells are labeled `"other"`.
 ')
 create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
-  format_celltype_n_table()
+  DT::datatable(rownames = FALSE)
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -245,10 +245,10 @@ glue::glue("
 ```
 
 ```{r}
-if(has_consensus & !has_submitter & !is_supplemental){
-  knitr::asis_output('## Statistics')
+if (has_consensus & !has_submitter & !is_supplemental) {
+  knitr::asis_output("## Statistics")
 } else {
-  knitr::asis_output('## Statistics {.tabset}')
+  knitr::asis_output("## Statistics {.tabset}")
 }
 ```
 
@@ -370,14 +370,14 @@ if (has_consensus && !has_submitter && !is_supplemental) {
   header_text <- "## UMAPs"
   umap_text <- ""
 } else {
-  header_text <- '## UMAPs {.tabset}'
+  header_text <- "## UMAPs {.tabset}"
   umap_text <- "For each cell typing method, we show a separate faceted UMAP."
 }
 
 
 knitr::asis_output(glue::glue(
   '{header_text}
-  
+
   In this section, we show UMAPs colored by cell types.
   {umap_text}
 In each panel, cells that were assigned the given cell type label are colored, while all other cells are in grey.
@@ -394,7 +394,7 @@ All other cell types are grouped together and labeled "All remaining cell types"
 if (has_submitter & has_umap) {
   submitter_n_celltypes <- length(levels(umap_df$submitter_celltype_annotation_lumped))
   submitter_dims <- determine_umap_dimensions(submitter_n_celltypes)
-  knitr::asis_output('### Submitter-provided annotations')
+  knitr::asis_output("### Submitter-provided annotations")
 } else {
   # set fake dims for evaluating next chunk
   submitter_dims <- c(1, 1)
@@ -416,7 +416,7 @@ faceted_umap(
 if (has_consensus & has_umap) {
   consensus_n_celltypes <- length(levels(umap_df$consensus_celltype_annotation_lumped))
   consensus_dims <- determine_umap_dimensions(consensus_n_celltypes)
-  knitr::asis_output('### Consensus cell type annotations')
+  knitr::asis_output("### Consensus cell type annotations")
 } else {
   # set fake dims for evaluating next chunk
   consensus_dims <- c(1, 1)
@@ -431,14 +431,14 @@ faceted_umap(
   consensus_n_celltypes,
   consensus_celltype_annotation_lumped,
   point_size = umap_facet_point_size
-) 
+)
 ```
 
 ```{r}
 if (has_singler & has_umap && (is_supplemental || !has_consensus)) {
   singler_n_celltypes <- length(levels(umap_df$singler_celltype_annotation_lumped))
   singler_dims <- determine_umap_dimensions(singler_n_celltypes)
-  knitr::asis_output('### SingleR annotations')
+  knitr::asis_output("### SingleR annotations")
 } else {
   # set fake dims for evaluating next chunk
   singler_dims <- c(1, 1)
@@ -461,7 +461,7 @@ faceted_umap(
 if (has_cellassign & has_umap && (is_supplemental || !has_consensus)) {
   cellassign_n_celltypes <- length(levels(umap_df$cellassign_celltype_annotation_lumped))
   cellassign_dims <- determine_umap_dimensions(cellassign_n_celltypes)
-  knitr::asis_output('### CellAssign annotations')
+  knitr::asis_output("### CellAssign annotations")
 } else {
   # set fake dims for evaluating next chunk
   cellassign_dims <- c(1, 1)

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -495,7 +495,7 @@ We expect that each cell type group should show high expression of marker genes 
 
 Note that dots are only shown if the gene has mean expression greater than 0 and is expressed in at least 10% of the cells in the given cell type.
 
-If all consensus cell types are labeled as `Unknown cell type`, then no dot plot will be shown. 
+If all consensus cell types are labeled as `Unknown cell type`, then no dot plot will be shown.
   ")
 ```
 
@@ -643,9 +643,8 @@ dotplot_df <- group_stats_df |>
 
 
 ```{r, eval = has_consensus, fig.height=7, fig.width=15}
-# only make a dot plot if we have at least one validation group annotation present 
-if(length(unique(dotplot_df$validation_group_annotation)) > 0) {
-  
+# only make a dot plot if we have at least one validation group annotation present
+if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp
   dotplot <- ggplot(dotplot_df, aes(y = y_label, x = gene_symbol, color = mean_exp, size = percent_exp)) +
     geom_point() +
@@ -667,8 +666,8 @@ if(length(unique(dotplot_df$validation_group_annotation)) > 0) {
       color = "Mean gene expression",
       size = "Percent cells expressed"
     )
-  
-  
+
+
   # add annotation bar aligning marker genes with validation group
   color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
     geom_tile() +
@@ -684,10 +683,10 @@ if(length(unique(dotplot_df$validation_group_annotation)) > 0) {
       strip.clip = "off"
     ) +
     labs(fill = "")
-  
+
   combined_plot <- color_bar / dotplot +
     patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
-  
+
   combined_plot
 }
 ```

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -29,22 +29,6 @@ create_celltype_n_table <- function(df, celltype_column) {
     )
 }
 
-#' Format tables of cell type counts as kable
-#'
-#' @param df Data frame to format
-#'
-#' @return kable table of cell type counts
-format_celltype_n_table <- function(df) {
-  df |>
-    knitr::kable(align = "r") |>
-    kableExtra::kable_styling(
-      bootstrap_options = "striped",
-      full_width = FALSE,
-      position = "left"
-    ) |>
-    kableExtra::column_spec(2, monospace = TRUE)
-}
-
 #' Function to lump celltype columns in an existing data frame for all of the
 #'  following columns, if they exist: `<singler/cellassign/submitter>_celltype_annotation`.
 #' The cell types will also be renamed via wrapping at the given `wrap` level.
@@ -324,7 +308,7 @@ knitr::asis_output('
 In this table, cells labeled "Submitter-excluded" are those for which submitters did not provide an annotation.
 ')
 create_celltype_n_table(celltype_df, submitter_celltype_annotation) |>
-  DT::datatable(rownames = FALSE)
+  format_datatable()
 ```
 
 ```{r, eval = has_consensus}
@@ -334,7 +318,7 @@ In this table, cells labeled "Unknown cell type" are those whose `SingleR` and `
 In the processed result files, these cells are labeled `Unknown`.
 ')
 create_celltype_n_table(celltype_df, consensus_celltype_annotation) |>
-  DT::datatable(rownames = FALSE)
+  format_datatable()
 ```
 
 ```{r, eval = has_singler && (!has_consensus || is_supplemental)}
@@ -344,7 +328,7 @@ In this table, cells labeled "Unknown cell type" are those which `SingleR` prune
 In the processed result files, these cells are labeled `NA`.
 ')
 create_celltype_n_table(celltype_df, singler_celltype_annotation) |>
-  DT::datatable(rownames = FALSE)
+  format_datatable()
 ```
 
 ```{r, eval = has_cellassign && (!has_consensus || is_supplemental)}
@@ -354,7 +338,7 @@ In this table, cells labeled "Unknown cell type" are those which `CellAssign` co
 In the processed result files, these cells are labeled `"other"`.
 ')
 create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
-  DT::datatable(rownames = FALSE)
+  format_datatable()
 ```
 
 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -53,9 +53,7 @@ antibody_tags <- as.data.frame(rowData(adt_exp)) |>
     "ADT target type" = target_type
   )
 
-DT::datatable(antibody_tags,
-  rownames = FALSE
-) |>
+format_datatable(antibody_tags) |>
   DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -1,8 +1,8 @@
-# CITE-seq experiment summary
+# CITE-seq Experiment Summary
 
 This section details quality control statistics from the ADT (antibody-derived tag) component of CITE-seq experiments.
 
-## CITE-seq summary tables {.tabset}
+## Summary tables {.tabset}
 
 ### Experiment statistics
 
@@ -53,12 +53,9 @@ antibody_tags <- as.data.frame(rowData(adt_exp)) |>
     "ADT target type" = target_type
   )
 
-knitr::kable(antibody_tags, digits = 2) |>
-  kableExtra::kable_styling(
-    bootstrap_options = c("striped", "condensed"),
-    full_width = FALSE,
-    position = "left",
-  )
+DT::datatable(antibody_tags, 
+              rownames = FALSE) |> 
+  DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 
 ### ADT post-processing statistics

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -1,8 +1,10 @@
-# CITE-seq Experiment Summary
+# CITE-seq experiment summary
 
 This section details quality control statistics from the ADT (antibody-derived tag) component of CITE-seq experiments.
 
-## CITE-seq Experiment Statistics
+## CITE-seq summary tables {.tabset}
+
+### Experiment statistics
 
 ```{r}
 # add rowData if missing
@@ -37,7 +39,7 @@ knitr::kable(adt_information, align = "r") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-## ADT Statistics
+### ADT statistics
 ```{r}
 antibody_tags <- as.data.frame(rowData(adt_exp)) |>
   tibble::rownames_to_column("Antibody") |>
@@ -59,7 +61,7 @@ knitr::kable(antibody_tags, digits = 2) |>
   )
 ```
 
-## ADT Post-processing Statistics
+### ADT post-processing statistics
 
 ```{r}
 if (has_processed) {
@@ -174,7 +176,7 @@ if (has_processed && !(processed_meta$adt_scpca_filter_method == "No filter")) {
 
 
 
-## Expression of highly variable ADTs
+## Expression of highly variable ADTs {.tabset}
 
 The plots in this section visualize the top four most variable ADTs in the library.
 
@@ -205,6 +207,7 @@ if (has_processed) {
 ```
 
 
+### Density plots
 
 
 ```{r fig.alt="Density plot showing normalized expression of highly variable ADTs", warning = FALSE, results='asis'}
@@ -237,7 +240,7 @@ if (has_processed) {
 }
 ```
 
-
+### UMAPs
 
 ```{r fig.alt="UMAP calculated from RNA expression but colored by normalized expression of highly variable ADTs", fig.height = 6, results='asis'}
 if (has_processed) {

--- a/templates/qc_report/cite_qc.rmd
+++ b/templates/qc_report/cite_qc.rmd
@@ -53,8 +53,9 @@ antibody_tags <- as.data.frame(rowData(adt_exp)) |>
     "ADT target type" = target_type
   )
 
-DT::datatable(antibody_tags, 
-              rownames = FALSE) |> 
+DT::datatable(antibody_tags,
+  rownames = FALSE
+) |>
   DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -223,7 +223,7 @@ if ("cell line" %in% sample_types) {
 }
 ```
 
-# Metadata and processing information for `r library_id` {.tabset}
+# Metadata and Processing Information for `r library_id` {.tabset}
 
 ```{r, eval = has_multiplex, results='asis'}
 # convert sample id to bullet separated list
@@ -364,7 +364,7 @@ knitr::kable(processing_info, align = "r") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-# RNA-seq experiment summary
+# RNA-seq Experiment Summary
 
 ## Cell statistics
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -223,7 +223,7 @@ if ("cell line" %in% sample_types) {
 }
 ```
 
-# Metadata and Processing Information for `r library_id`
+# Metadata and processing information for `r library_id` {.tabset}
 
 ```{r, eval = has_multiplex, results='asis'}
 # convert sample id to bullet separated list
@@ -240,7 +240,7 @@ glue::glue("
 ")
 ```
 
-## Sample Metadata
+## Sample metadata
 
 The below table summarizes clinical metadata for the sample associated with this library. 
 Blue hyperlinks are present for any terms with an ontology term identifier associated with the displayed human readable value. 
@@ -267,7 +267,7 @@ if (!has_multiplex) {
 }
 ```
 
-## Raw Library Metrics
+## Raw library metrics
 
 ```{r }
 # extract sce metadata containing processing information as table
@@ -332,7 +332,7 @@ knitr::kable(library_information, align = "r") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-## Pre-Processing Information
+## Pre-processing information
 
 ```{r }
 # define transcript type
@@ -364,9 +364,9 @@ knitr::kable(processing_info, align = "r") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-# RNA-seq Experiment Summary
+# RNA-seq experiment summary
 
-## Cell Statistics
+## Cell statistics
 
 ```{r}
 basic_statistics <- tibble::tibble(
@@ -459,7 +459,14 @@ if (has_processed) {
 }
 ```
 
-## Knee Plot
+## Quality control plots {.tabset}
+
+### Knee plot
+
+The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets.
+The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDropsCellRanger()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html), unless otherwise specified in the `Cell Statistics` table, which uses both the total UMI counts and expressed gene content (adapted from [Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
+As the boundary between droplets passing and failing this filter is not solely dependent on total UMI count, some regions contain droplets in both categories.
+The color in this plot indicates the percentage of droplets in a region passing the filter.
 
 ```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) |>
@@ -512,12 +519,12 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
   )
 ```
 
-The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets.
-The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDropsCellRanger()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html), unless otherwise specified in the `Cell Statistics` table, which uses both the total UMI counts and expressed gene content (adapted from [Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
-As the boundary between droplets passing and failing this filter is not solely dependent on total UMI count, some regions contain droplets in both categories.
-The color in this plot indicates the percentage of droplets in a region passing the filter.
 
-## Cell Read Metrics
+### Cell read metrics
+
+The below plot of cell metrics includes only droplets which have passed the `emptyDropsCellRanger()` filter.
+The plot will usually display a strong (but curved) relationship between the total UMI count and the number of genes detected.
+Cells with low UMI counts and high mitochondrial percentages may require further filtering.
 
 ```{r, fig.alt="Total UMI x genes expressed"}
 filtered_celldata <- data.frame(colData(filtered_sce))
@@ -547,11 +554,18 @@ ggplot(
   )
 ```
 
-The above plot of cell metrics includes only droplets which have passed the `emptyDropsCellRanger()` filter.
-The plot will usually display a strong (but curved) relationship between the total UMI count and the number of genes detected.
-Cells with low UMI counts and high mitochondrial percentages may require further filtering.
 
-## miQC Model Diagnostics
+### miQC model diagnostics
+
+We calculate the probability that a cell is compromised due to degradation or rupture using [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) ([Hippen _et al._ 2021](https://doi.org/10.1371/journal.pcbi.1009290)).
+This relies on fitting a mixture model using the number of genes expressed by a cell and the percentage of mitochondrial reads.
+The expected plot will show a characteristic triangular shape and two model fit lines.
+Cells with low numbers of genes expressed may have both low and high mitochondrial percentage, but cells with many genes tend to have a low mitochondrial percentage.
+Compromised cells are likely to have a fewer genes detected and higher percentage of mitochondrial reads.
+
+If the model has failed to fit properly, the pattern of cells may differ, and there may not be model fit lines.
+This can be the result of a low-quality library or may occur if there is no mitochondrial content, as in the case of a high-quality single-nucleus sample.
+In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
 
 ```{r, fig.alt="miQC model diagnostics plot", results='asis', warning=FALSE}
 if (skip_miQC) {
@@ -588,17 +602,8 @@ if (skip_miQC) {
 }
 ```
 
-We calculate the probability that a cell is compromised due to degradation or rupture using [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) ([Hippen _et al._ 2021](https://doi.org/10.1371/journal.pcbi.1009290)).
-This relies on fitting a mixture model using the number of genes expressed by a cell and the percentage of mitochondrial reads.
-The expected plot will show a characteristic triangular shape and two model fit lines.
-Cells with low numbers of genes expressed may have both low and high mitochondrial percentage, but cells with many genes tend to have a low mitochondrial percentage.
-Compromised cells are likely to have a fewer genes detected and higher percentage of mitochondrial reads.
 
-If the model has failed to fit properly, the pattern of cells may differ, and there may not be model fit lines.
-This can be the result of a low-quality library or may occur if there is no mitochondrial content, as in the case of a high-quality single-nucleus sample.
-In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
-
-## Removing low quality cells
+### Removing low quality cells
 
 The below plot highlights cells that were removed prior to normalization and dimensionality reduction.
 Cells that should be removed based on RNA counts are those that are identified to be low quality cells, such as cells with high probability of being compromised.

--- a/templates/qc_report/multiplex_qc.rmd
+++ b/templates/qc_report/multiplex_qc.rmd
@@ -49,8 +49,9 @@ hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
   )
 
 
-DT::datatable(hto_tags, 
-              rownames = FALSE) |>
+DT::datatable(hto_tags,
+  rownames = FALSE
+) |>
   DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 

--- a/templates/qc_report/multiplex_qc.rmd
+++ b/templates/qc_report/multiplex_qc.rmd
@@ -1,6 +1,8 @@
 # Multiplexing Experiment Summary
 
-## Multiplexing Statistics
+## Summary tables {.tabset}
+
+### Multiplexing statistics
 
 ```{r}
 # add rowData if missing
@@ -35,7 +37,7 @@ knitr::kable(hto_information, align = "r") |>
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-## Hashtag Oligos (HTOs) Statistics
+### Hashtag oligos (HTOs) statistics
 
 ```{r}
 hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
@@ -46,16 +48,13 @@ hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
     "Percent of cells detected" = detected
   )
 
-knitr::kable(hto_tags, digits = 2) |>
-  kableExtra::kable_styling(
-    bootstrap_options = c("striped", "condensed"),
-    full_width = FALSE,
-    position = "left",
-  ) |>
-  kableExtra::column_spec(2:3, monospace = TRUE)
+
+DT::datatable(hto_tags, 
+              rownames = FALSE) |>
+  DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 
-## Demultiplexing Sample Calls
+## Demultiplexing sample calls
 
 Demultiplexing was performed using both [`DropletUtils::hashedDrops()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [`Seurat::HTOdemux()`](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
 
@@ -86,7 +85,6 @@ if (any(demux_columns)) {
       names_from = demux_method,
       values_from = n
     )
-
 
   knitr::kable(demux_calls, digits = 2) |>
     kableExtra::kable_styling(

--- a/templates/qc_report/multiplex_qc.rmd
+++ b/templates/qc_report/multiplex_qc.rmd
@@ -49,9 +49,7 @@ hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
   )
 
 
-DT::datatable(hto_tags,
-  rownames = FALSE
-) |>
+format_datatable(hto_tags) |>
   DT::formatRound(c("Mean UMI count per cell", "Percent of cells detected"), 2)
 ```
 

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -1,6 +1,6 @@
-## Dimensionality Reduction
+## Dimensionality reduction {.tabset}
 
-The below plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell. 
+The plots in this section show the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell. 
 
 ```{r}
 # determine UMAP point sizing
@@ -11,7 +11,7 @@ umap_facet_point_size <- umap_points_sizes[2]
 
 ### Unsupervised clustering
 
-The cells in the blow UMAP are colored by cluster assignment. 
+The cells in the below UMAP are colored by cluster assignment. 
 Clusters were calculated using the graph-based `r metadata(processed_sce)$cluster_algorithm` algorithm with  `r metadata(processed_sce)$cluster_weighting` weighting and `r metadata(processed_sce)$cluster_nn` nearest neighbors.
 
 **Caution**: Clusters are computed without performing any evaluation or optimization of clustering parameters.
@@ -61,7 +61,7 @@ scater::plotUMAP(
 
 ### Expression of highly variable genes
 
-The plots below show the same UMAP embeddings, coloring each cell by the expression level of the labeled gene.
+The cells in the below UMAP are colored by the expression level of the labeled gene.
 The genes chosen for plotting are the 12 most variable genes identified in the library.
 Gene symbols are used when available to label the UMAP plots.
 If gene symbols are not available, the Ensembl id will be shown.

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -28,7 +28,7 @@ determine_umap_point_size <- function(n_processed_cells) {
 
 #' Make UMAP colored by clusters
 #'
-#' @param sce SingleÇellExperiment object with UMAP embeddings
+#' @param sce Single<U+00C7>ellExperiment object with UMAP embeddings
 #' @param point_size Point size. Default is 1
 #'
 #' @return UMAP plot as a ggplot2 object
@@ -155,5 +155,36 @@ print_sample_metadata <- function(meta_list) {
   ")
     )
   }
+}
+```
+
+```{r}
+#' Format DT datatables
+#'
+#' @param df Data frame to format
+#'
+#' @return DT datatable
+format_datatable <- function(df) {
+  df |>
+    DT::datatable(
+      rownames = FALSE,
+      extensions = "Scroller",
+      options = list(
+        scroller = TRUE,
+        deferRender = TRUE,
+        scrollX = TRUE,
+        scrollY = 400,
+        scrollCollapse = TRUE,
+        columnDefs = list(list(
+          # render missing values as "NA" rather than blanks in the table
+          targets = "_all",
+          render = DT::JS(
+            "function(data, type, row, meta) {",
+            "return data === null ? 'NA' : data;",
+            "}"
+          )
+        ))
+      )
+    )
 }
 ```

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -175,7 +175,7 @@ format_datatable <- function(df) {
         scrollX = TRUE,
         scrollY = 400,
         scrollCollapse = TRUE,
-        language = list(search = "Filter:"), 
+        language = list(search = "Filter:"),
         columnDefs = list(list(
           # render missing values as "NA" rather than blanks in the table
           targets = "_all",

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -28,7 +28,7 @@ determine_umap_point_size <- function(n_processed_cells) {
 
 #' Make UMAP colored by clusters
 #'
-#' @param sce Single<U+00C7>ellExperiment object with UMAP embeddings
+#' @param sce SingleCellExperiment object with UMAP embeddings
 #' @param point_size Point size. Default is 1
 #'
 #' @return UMAP plot as a ggplot2 object
@@ -175,6 +175,7 @@ format_datatable <- function(df) {
         scrollX = TRUE,
         scrollY = 400,
         scrollCollapse = TRUE,
+        language = list(search = "Filter:"), 
         columnDefs = list(list(
           # render missing values as "NA" rather than blanks in the table
           targets = "_all",


### PR DESCRIPTION
Part 1 of #371 

Here I'm making a number of small changes to the main report to make things prettier. Mostly, I added tabs where I thought they helped de-clutter things without hiding too much and converted some tables to use `DT::datatable()`. 

Here's a zip file with three different versions of the main report - a regular single cell library with submitter annotations, a library with CITE-seq, and a multiplexed library: 
[reports.zip](https://github.com/user-attachments/files/21761997/reports.zip)

Here's an overview of the changes that I made: 

- I added tabs in places where we had related tables or plots. I find this really helpful for viewing the cell type tables and UMAPs!
  - This includes a tab with the QC plots (knee plot, miQC etc) and I was a little unsure if we wanted to do this but in general I think I like the tabs here? Did I add too many tabs? 
- To add all the tabs I did have to update some headers. While I was here I noticed we were all over the place with our capitalization. So I updated anything that was part of a tab or wasn't header 1 to now be sentence case instead. 
- I also moved the text so that it's consistently above plots rather than below. 
- I replaced the cell type annotation tables with `DT::datatable()` so these tables are now interactive. I also did this for the ADT and HTO statistics, where we show all the ADTs/HTOs and their mean percentage. 
  - I did not update any of the basic summary tables since I think DT would be too much for those tables? If the contrasting styles are too much between the tables I can make a simplified DT option that we can use for those tables, but generally I don't think we need to do that? 

I started with just making these changes in the main report and once we have this updated I'll go through the supplemental report. Those changes should be pretty minor since I included the tables and UMAPs for cell types that appear in the main report here. 