### PR TITLE
Fix some tabs in the supplemental cell type report

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -302,8 +302,7 @@ if (length(unclassified_methods) > 0) {
 
 
 ```{r, eval = has_submitter}
-knitr::asis_output('
-### Submitter-provided cell type annotations\n
+knitr::asis_output('### Submitter-provided annotations
 
 In this table, cells labeled "Submitter-excluded" are those for which submitters did not provide an annotation.
 ')
@@ -312,17 +311,18 @@ create_celltype_n_table(celltype_df, submitter_celltype_annotation) |>
 ```
 
 ```{r, eval = has_consensus}
-knitr::asis_output('### Consensus cell type annotations\n
+knitr::asis_output('### Consensus cell type annotations
 
 In this table, cells labeled "Unknown cell type" are those whose `SingleR` and `CellAssign` annotations did not agree.
 In the processed result files, these cells are labeled `Unknown`.
 ')
+
 create_celltype_n_table(celltype_df, consensus_celltype_annotation) |>
   format_datatable()
 ```
 
 ```{r, eval = has_singler && (!has_consensus || is_supplemental)}
-knitr::asis_output('### `SingleR` cell type annotations\n
+knitr::asis_output('### `SingleR` annotations
 
 In this table, cells labeled "Unknown cell type" are those which `SingleR` pruned due to low-quality assignments.
 In the processed result files, these cells are labeled `NA`.
@@ -332,7 +332,7 @@ create_celltype_n_table(celltype_df, singler_celltype_annotation) |>
 ```
 
 ```{r, eval = has_cellassign && (!has_consensus || is_supplemental)}
-knitr::asis_output('### `CellAssign` cell type annotations\n
+knitr::asis_output('### `CellAssign` annotations
 
 In this table, cells labeled "Unknown cell type" are those which `CellAssign` could not confidently assign to a label in the reference list.
 In the processed result files, these cells are labeled `"other"`.

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -18,6 +18,20 @@ output:
     number_sections: false
     code_download: true
 ---
+ <!--Make sure tabs always fit on one line--> 
+<style>
+.nav-tabs {
+  display: flex !important;
+  flex-wrap: nowrap !important;
+}
+.nav-tabs > li {
+  flex: 1 1 auto !important;
+  text-align: center;
+}
+.nav-tabs > li > a {
+  white-space: normal !important;
+}
+</style>
 
 ```{r setup, message = FALSE, echo = FALSE}
 # knitr options

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -23,6 +23,21 @@ output:
     number_sections: false
     code_download: true
 ---
+ <!--Make sure tabs always fit on one line--> 
+<style>
+.nav-tabs {
+  display: flex !important;
+  flex-wrap: nowrap !important;
+}
+.nav-tabs > li {
+  flex: 1 1 auto !important;
+  text-align: center;
+}
+.nav-tabs > li > a {
+  white-space: normal !important;
+}
+</style>
+
 
 ```{r setup, message = FALSE, echo = FALSE}
 # knitr options


### PR DESCRIPTION
Closes #371 

I went to add tabs and such to the supplemental cell type report, but there really aren't any places where I would do that outside of the tables and the UMAPs which already have tabs. I did notice though that if you have all 4 annotations (submitter, consensus, cellassign, and singleR) that the tabs don't fit on one line and it looks bad. So I added some css to make sure that the tabs are always on one line and I think it looks much better. This should only be a problem when you have all the annotations in the tables section which only appears in the supplemental report, but just in case we ever expand on tabs (such as adding more annotations) I added the code to the main report too. 

I also shortened the tab headers in the tables section to match the headers in the UMAP section. 

Here's a zip file with lots of different versions of the reports for reference: 
[reports.zip](https://github.com/user-attachments/files/21799194/reports.zip)
