### PR TITLE
update cell browser config file with cell type annotations

### DIFF
--- a/bin/cellbrowser_config.py
+++ b/bin/cellbrowser_config.py
@@ -4,7 +4,10 @@ import argparse
 import csv
 import itertools
 import pathlib
+import sys
 import textwrap
+
+import anndata
 
 
 def write_project_configs(
@@ -25,7 +28,11 @@ def write_project_configs(
 
 
 def write_library_configs(
-    library_id: str, sample_id: str, library_dir: pathlib.Path, label_field: str
+    library_id: str,
+    sample_id: str,
+    library_dir: pathlib.Path,
+    default_label: str,
+    label_fields: list[str],
 ) -> None:
     library_dir.mkdir(parents=True, exist_ok=True)
     # cellbrowser.conf
@@ -36,9 +43,9 @@ def write_library_configs(
         exprMatrix='matrix.mtx.gz'
         meta='meta.tsv'
         geneIdType='auto'
-        defColorField='{label_field}'
-        labelField='{label_field}'
-        enumFields=['{label_field}']
+        defColorField='{default_label}'
+        labelField='{default_label}'
+        enumFields={label_fields}
         coords=[{{"file": "umap_coords.tsv", "shortLabel": "UMAP" }}]
         markers = [{{"file": "markers.tsv", "shortLabel":"Cluster Markers" }}]
         quickGenesFile="quickGenes.tsv"
@@ -80,6 +87,11 @@ def main():
         help="Name of the display label (grouping) field.",
         default="cluster",
     )
+    parser.add_argument(
+        "--h5ad-file",
+        type=pathlib.Path,
+        help="Path to the input H5AD file, optional for library configs.",
+    )
     args = parser.parse_args()
 
     # Arg consistency checks
@@ -105,17 +117,47 @@ def main():
             if project in project_info:
                 project_metadata = project_info[project]
             else:
-                Warning(f"Warning: Project {project} not found in metadata.")
+                print(
+                    f"Warning: Project {project} not found in metadata.",
+                    file=sys.stderr,
+                )
                 project_metadata = {}
             project_dir = args.outdir / project
             write_project_configs(project, project_dir, project_metadata)
 
     elif args.conf_type == "library":
+        default_label = args.label_field
+        label_fields = [default_label]
+        # always include cluster as a label field
+        if default_label != "cluster":
+            label_fields.append("cluster")
+        if args.h5ad_file:
+            ad = anndata.read_h5ad(args.h5ad_file, backed="r")
+            if default_label not in ad.obs.columns:
+                default_label = "cluster"  # fall back to cluster
+                print(
+                    f"Warning: Label field {default_label} not found in H5AD metadata.",
+                    file=sys.stderr,
+                )
+
+            # get all cell type annotations
+            label_fields += [
+                x
+                for x in ad.obs.columns
+                if x.endswith("_celltype_annotation") and x != default_label
+            ]
+
         # create directories and config files for each library
         for library, sample in itertools.zip_longest(ids, sample_ids):
             library_dir = args.outdir / library
             sample = sample if sample else ""
-            write_library_configs(library, sample, library_dir, args.label_field)
+            write_library_configs(
+                library,
+                sample,
+                library_dir,
+                default_label,
+                label_fields,
+            )
 
 
 if __name__ == "__main__":

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -15,11 +15,12 @@ process cellbrowser_library {
     cellbrowser_config.py \
       --conf_type library \
       --ids "${meta.library_id}" \
-      --label-field cluster \
-      --sample-ids "${meta.sample_id}"
+      --label-field ${params.cellbrowser_default_label} \
+      --sample-ids "${meta.sample_id}" \
+      --h5ad-file "${h5ad_file}"
 
     # import data to library directory
-    cbImportScanpy -i "${h5ad_file}" -o "${meta.library_id}" --clusterField="cluster"
+    cbImportScanpy -i "${h5ad_file}" -o "${meta.library_id}" --clusterField="${params.cellbrowser_default_label}"
 
     # remove the h5ad from the imported files as we won't use it
     rm "${meta.library_id}"/*_processed_rna.h5ad

--- a/nextflow.config
+++ b/nextflow.config
@@ -118,7 +118,7 @@ params {
   // Cell Browser workflow-specific options //
   // output directory for UCSC Cell Browser
   cellbrowser_dirname = "cellbrowser"
-  cellbrowser_label_field = "cluster"
+  cellbrowser_default_label = "consensus_celltype_annotation"
   cellbrowser_template_dir = "${projectDir}/templates/cellbrowser"
   // fully rebuild cellbrowser site; default is false and only updates metadata
   cellbrowser_rebuild = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -396,11 +396,11 @@
           "description": "SingleR label name",
           "help_text": "Label name for `SingleR` references, used in `build-celltype-ref.nf`."
         },
-        "cellbrowser_label_field": {
+        "cellbrowser_default_label": {
           "type": "string",
           "default": "cluster",
-          "description": "Field used to label cells in UCSC Cell Browser.",
-          "help_text": "Label field for cells in the UCSC Cell Browser, used in `build-cellbrowser.nf`."
+          "description": "Default label field for cells in UCSC Cell Browser.",
+          "help_text": "Default label field for cells in the UCSC Cell Browser, used in `build-cellbrowser.nf`."
         }
       },
       "fa_icon": "fas fa-tasks"


### PR DESCRIPTION
closes #974

Here I updated the cell browser config file to include all of the cell type annotations, and made the default the consensus cell types. 

It seems like some of the code updates to find all of the celltype fields may not actually be required, as Cell Browser itself seems to auto-discover many of the fields, which I did not see before because the original files I was working with only had the clusters. But I don't mind having those annotations in the config files so I am leaving it as is. 

To see the new example browser, download the full set and display with some version of:

```bash
aws s3 sync s3://nextflow-ccdl-results/scpca/processed/cellbrowser cellbrowser
uvx --from cellbrowser cbUpgrade -o cellbrowser
```

You should see default labels by consensus cell types with the ability to change to any of the enumerable labels (including `scDblFinder` results) for the labels and any column at all for the colors. Kind of annoying that you have to change both if you want color and label by a different cell type, but that is not something we are going to be able to fix!