### PR TITLE
Filter out libraries where we do not have a UMAP

### DIFF
--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -98,7 +98,7 @@ workflow cellbrowser_build {
     // create single channel of [[project_ids], [library_dirs]]
     project_libs_ch = cellbrowser_library.out
     // only include libraries with umap
-     .filter{it.has_umap == "true" }
+     .filter{it[2] == "true" }
      // use dummy value to group everything together into tuples
      .map{meta, library_dir, _has_umap -> [1, meta.project_id, library_dir] }
      .groupTuple()

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -7,7 +7,7 @@ process cellbrowser_library {
     tuple val(meta), path(h5ad_file, arity: '1')
 
   output:
-    tuple val(meta), path("${meta.library_id}")
+    tuple val(meta), path("${meta.library_id}"), env('has_umap')
 
   script:
     """
@@ -24,6 +24,13 @@ process cellbrowser_library {
 
     # remove the h5ad from the imported files as we won't use it
     rm "${meta.library_id}"/*_processed_rna.h5ad
+
+    # Check that the umap coordinates were output
+    if [ -f "${meta.library_id}/umap_coords.tsv" ]; then
+      has_umap="true"
+    else
+      has_umap="false"
+    fi
     """
   stub:
     """
@@ -32,6 +39,7 @@ process cellbrowser_library {
     touch "${meta.library_id}/cellbrowser.conf"
     touch "${meta.library_id}/desc.conf"
     touch "${meta.library_id}/matrix.mtx.gz"
+    has_umap="true"
     """
 }
 
@@ -89,8 +97,10 @@ workflow cellbrowser_build {
 
     // create single channel of [[project_ids], [library_dirs]]
     project_libs_ch = cellbrowser_library.out
-     // use dummy value to grouping everything together into tuples
-     .map{meta, library_dir -> [1, meta.project_id, library_dir] }
+    // only include libraries with umap
+     .filter{it.has_umap == "true" }
+     // use dummy value to group everything together into tuples
+     .map{meta, library_dir, _has_umap -> [1, meta.project_id, library_dir] }
      .groupTuple()
      .map{it -> it.drop(1)}
 


### PR DESCRIPTION
Closes #981 

As a fix for the error that occurs when a UMAP is missing, I have added an output field to the library processing step and then use that to filter the output channel to remove any libraries from the Cell Browser site that do not have calculated UMAP coordinates. 

Testing this did allow a full run of the `build-cellbrowser.nf` workflow (see #980), which is available at`s3://nextflow-ccdl-results/scpca-staging/cellbrowser`. The complete workflow ran in about 6 hours (most of which was the final build process), and the full site is ~50 GB.
