### PR TITLE
Docker push fix: specify tags

### DIFF
--- a/.github/workflows/docker_cellbrowser.yaml
+++ b/.github/workflows/docker_cellbrowser.yaml
@@ -82,5 +82,7 @@ jobs:
         with:
           context: "{{defaultContext}}:docker/cellbrowser"
           push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
I managed to forget to actually specify the tags for the push, so that failed. Trying again!