### PR TITLE
Add inferCNV reference info to SCE

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -395,15 +395,13 @@ if (has_singler && has_cellassign) {
       dplyr::select(consensus_ontology, consensus_annotation) |>
       dplyr::distinct()
 
-    # count the number of reference cells in the SCE for export
-    reference_cell_count <- sum(celltype_df$consensus_ontology %in% ref_df$consensus_ontology)
-
     # Add reference cell information to SCE
     metadata(sce)$infercnv_reference_celltypes <- ref_df$consensus_annotation # vector of reference cell types
-    sce$is_infercnv_reference <-  sce$consensus_celltype_ontology %in% ref_df$consensus_ontology
-    
+    sce$is_infercnv_reference <- sce$consensus_celltype_ontology %in% ref_df$consensus_ontology # boolean
+
     # get the full count
     reference_cell_count <- sum(sce$is_infercnv_reference)
+  }
 }
 
 # export annotated object with cell type assignments


### PR DESCRIPTION
Closes #1002 

This is a small PR to update the `add_celltypes_to_sce.R` script to add some items to the SCE:
- I added a vector to the metadata with the reference cell types. Here, I used labels and not ontologies. Any disagreement?
- I added a colData column with T/F if it's a reference cell

Noting I'm also keeping track of all this for eventual docs!


Also noting! This PR was originally going to be bigger and include a function to get cell line samples, until I learned that you don't get nextflow nice things like `splitCSV` in `lib` utils which all has to be plain groovy. I then learned that working with TSVs in groovy is decidedly not groovy (unless I brought in a dependency which I didn't want to do), and making a submodule for just cell line samples felt very silly. I'd rather reuse the code 🙃 