### PR TITLE
Add script to run inferCNV

### DIFF
--- a/bin/run_infercnv.R
+++ b/bin/run_infercnv.R
@@ -1,9 +1,10 @@
 #!/usr/bin/env Rscript
 
-# This script runs inferCNV on a SingleCellExperiment object and saves results to the SCE object:
-# metadata field `infercnv_table`: (data frame) The full table output from the inferCNV HMM
-# metadata field `infercnv_options`: (list) The options used when calling inferCNV, from the @options slot of the output object
-# colData column `total_cnv`: The sum of CNV per cell, calculated from the HMM output
+# This script runs inferCNV on a SingleCellExperiment object and export result files:
+# - inferCNV heatmap png
+# - an RDS file with a list of information to save to the SCE file later:
+#  - wide metadata table with CNVs
+#  - list of inferCNV options
 
 suppressPackageStartupMessages({
   library(SingleCellExperiment)
@@ -18,15 +19,15 @@ option_list <- list(
     help = "Path to the SCE file to run inferCNV on"
   ),
   make_option(
-    opt_str = "--output_rds",
-    type = "character",
-    help = "Path to the output SCE file inferCNV output"
-  ),
-  make_option(
     opt_str = c("--output_dir"),
     type = "character",
     default = "",
     help = "Folder to save final infercnv results"
+  ),
+  make_option(
+    opt_str = "--output_rds",
+    type = "character",
+    help = "Path to the output RDS file to hold inferCNV results of interest"
   ),
   make_option(
     opt_str = c("--gene_order_file"),
@@ -54,9 +55,9 @@ opts <- parse_args(OptionParser(option_list = option_list))
 
 stopifnot(
   "input_sce_file does not exist" = file.exists(opts$input_sce_file),
-  "gene_order_file does not exist" = file.exists(opts$gene_order_file),
   "output_dir does not exist" = dir.exists(opts$output_dir),
-  "output_rds was not provided" = !is.null(opts$output_rds)
+  "output_rds was not provided" = !is.null(opts$output_rds),
+  "gene_order_file does not exist" = file.exists(opts$gene_order_file)
 )
 
 # set up files and paths -----------------
@@ -86,7 +87,6 @@ annotations_df <- data.frame(
   row.names = sce$barcodes
 )
 
-
 # run infercnv in a tryCatch in case of errors
 # this will automatically create the heatmap file in the output directory
 infercnv_result <- tryCatch(
@@ -112,6 +112,7 @@ infercnv_result <- tryCatch(
       )
   },
   error = function(e) {
+    message("failed")
     # If inferCNV failed, create an empty heatmap file
     system(glue::glue("touch {png_file}"))
 
@@ -119,10 +120,10 @@ infercnv_result <- tryCatch(
     NULL
   }
 )
-# confirm png file exists
+# confirm png file was created
 stopifnot("PNG file not created" = file.exists(png_file))
 
-# save results SCE if inferCNV ran successfully ------------------------------
+# save relevant results to RDS if inferCNV ran successfully -------------------
 if (!is.null(infercnv_result)) {
   # confirm final infercnv object exists; the metadata table is created from this file
   stopifnot(
@@ -136,39 +137,17 @@ if (!is.null(infercnv_result)) {
     infercnv_output_path = opts$output_dir
   )
 
-  # save table to SCE metadata
+  # create list of results to export
+
   # note we have to read in with base R, since there are row names
   infercnv_table <- read.table(metadata_file, header = TRUE, sep = "\t") |>
     tibble::rownames_to_column(var = "barcodes")
-  metadata(sce)$infercnv_table <- infercnv_table
 
-  # save inferCNV runtime options used to SCE metadata
-  metadata(sce)$infercnv_options <- infercnv_result@options
+  output_results <- list(
+    infercnv_table = infercnv_table,
+    infercnv_options = infercnv_result@options
+  )
 
-  # add a total_cnv column to colData
-  total_cnv_df <- infercnv_table |>
-    tidyr::pivot_longer(
-      starts_with("has_cnv_"),
-      names_to = "chr",
-      values_to = "cnv"
-    ) |>
-    dplyr::group_by(barcodes) |>
-    dplyr::summarize(total_cnv = sum(cnv))
-  colData(sce) <- colData(sce) |>
-    as.data.frame() |>
-    dplyr::left_join(total_cnv_df, by = "barcodes") |>
-    DataFrame(row.names = colnames(sce))
+  # export results
+  readr::write_rds(output_results, opts$output_rds, compress = "bz2")
 }
-
-# export SCE -------------------
-readr::write_rds(
-  sce,
-  opts$output_rds,
-  compress = "bz2"
-)
-
-
-# clean up: remove all non-heatmap files from the output directory ------
-remove_files <- list.files(opts$output_dir, full.names = TRUE)
-remove_files <- remove_files[remove_files != png_file]
-fs::file_delete(remove_files)

--- a/bin/run_infercnv.R
+++ b/bin/run_infercnv.R
@@ -1,0 +1,174 @@
+#!/usr/bin/env Rscript
+
+# This script runs inferCNV on a SingleCellExperiment object and saves results to the SCE object:
+# metadata field `infercnv_table`: (data frame) The full table output from the inferCNV HMM
+# metadata field `infercnv_options`: (list) The options used when calling inferCNV, from the @options slot of the output object
+# colData column `total_cnv`: The sum of CNV per cell, calculated from the HMM output
+
+suppressPackageStartupMessages({
+  library(SingleCellExperiment)
+  library(optparse)
+})
+
+option_list <- list(
+  make_option(
+    opt_str = "--input_sce_file",
+    type = "character",
+    default = "",
+    help = "Path to the SCE file to run inferCNV on"
+  ),
+  make_option(
+    opt_str = "--output_rds",
+    type = "character",
+    help = "Path to the output SCE file inferCNV output"
+  ),
+  make_option(
+    opt_str = c("--output_dir"),
+    type = "character",
+    default = "",
+    help = "Folder to save final infercnv results"
+  ),
+  make_option(
+    opt_str = c("--gene_order_file"),
+    type = "character",
+    default = "",
+    help = "Path to gene order file as tab delimited .txt file with no column headers.
+      Columns are: Ensembl gene id, chr, start, stop."
+  ),
+  make_option(
+    opt_str = c("-t", "--threads"),
+    type = "integer",
+    default = 4,
+    help = "Number of multiprocessing threads to use."
+  ),
+  make_option(
+    opt_str = c("--random_seed"),
+    type = "integer",
+    default = 2025,
+    help = "Random seed to set for reproducibility. Note that inferCNV is only reproducible on a given operating system."
+  )
+)
+
+# parse and check input options ----------------
+opts <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot(
+  "input_sce_file does not exist" = file.exists(opts$input_sce_file),
+  "gene_order_file does not exist" = file.exists(opts$gene_order_file),
+  "output_dir does not exist" = dir.exists(opts$output_dir),
+  "output_rds was not provided" = !is.null(opts$output_rds)
+)
+
+# set up files and paths -----------------
+set.seed(opts$seed)
+
+# read SCE file and check for column
+sce <- readRDS(opts$input_sce_file)
+stopifnot(
+  "SCE colData is missing `is_infercnv_reference` column" =
+    "is_infercnv_reference" %in% colnames(colData(sce))
+)
+
+# define relevant infercnv output files for later use/checks
+# infercnv will automatically create these files at these hardcoded paths
+png_file <- file.path(opts$output_dir, "infercnv.png")
+infercnv_final_file <- file.path(opts$output_dir, "run.final.infercnv_obj")
+metadata_file <- file.path(opts$output_dir, "map_metadata_from_infercnv.txt")
+
+# run infercnv ------------------------
+
+# create annotations_df table which requires:
+# - rownames as cell barcodes
+# - a single column with annotation labels; we use reference and query
+# see `data("infercnv_annots_example")` for context
+annotations_df <- data.frame(
+  annotation = ifelse(sce$is_infercnv_reference, "reference", "query"),
+  row.names = sce$barcodes
+)
+
+
+# run infercnv in a tryCatch in case of errors
+# this will automatically create the heatmap file in the output directory
+infercnv_result <- tryCatch(
+  {
+    # create the inferCNV object and pipe into run
+    # so errors from either step are caught
+    infercnv::CreateInfercnvObject(
+      raw_counts_matrix = counts(sce),
+      annotations_file = annotations_df,
+      gene_order_file = opts$gene_order_file,
+      ref_group_name = "reference",
+      # use our chr names with arms; chrM was already removed
+      chr_exclude = c("chrXp", "chrXq", "chrYp", "chrYq")
+    ) |>
+      infercnv::run(
+        cutoff = 0.1, # use 1 for smart-seq, 0.1 for 10x-genomics
+        out_dir = opts$output_dir, # save all intermediate files here
+        denoise = TRUE, # this option is generally used in inferCNV HMM examples
+        HMM = TRUE, # use the i6 HMM
+        HMM_type = "i6",
+        save_rds = FALSE, # don't save intermediate RDS files
+        num_threads = opts$threads
+      )
+  },
+  error = function(e) {
+    # If inferCNV failed, create an empty heatmap file
+    system(glue::glue("touch {png_file}"))
+
+    # return NULL
+    NULL
+  }
+)
+# confirm png file exists
+stopifnot("PNG file not created" = file.exists(png_file))
+
+# save results SCE if inferCNV ran successfully ------------------------------
+if (!is.null(infercnv_result)) {
+  # confirm final infercnv object exists; the metadata table is created from this file
+  stopifnot(
+    "inferCNV did not write output to disc" = file.exists(infercnv_final_file)
+  )
+
+  # create wide table with barcodes and inferred CNV events
+  # this will automatically create `metadata_file`
+  infercnv::add_to_seurat(
+    seurat_obj = NULL,
+    infercnv_output_path = opts$output_dir
+  )
+
+  # save table to SCE metadata
+  # note we have to read in with base R, since there are row names
+  infercnv_table <- read.table(metadata_file, header = TRUE, sep = "\t") |>
+    tibble::rownames_to_column(var = "barcodes")
+  metadata(sce)$infercnv_table <- infercnv_table
+
+  # save inferCNV runtime options used to SCE metadata
+  metadata(sce)$infercnv_options <- infercnv_result@options
+
+  # add a total_cnv column to colData
+  total_cnv_df <- infercnv_table |>
+    tidyr::pivot_longer(
+      starts_with("has_cnv_"),
+      names_to = "chr",
+      values_to = "cnv"
+    ) |>
+    dplyr::group_by(barcodes) |>
+    dplyr::summarize(total_cnv = sum(cnv))
+  colData(sce) <- colData(sce) |>
+    as.data.frame() |>
+    dplyr::left_join(total_cnv_df, by = "barcodes") |>
+    DataFrame(row.names = colnames(sce))
+}
+
+# export SCE -------------------
+readr::write_rds(
+  sce,
+  opts$output_rds,
+  compress = "bz2"
+)
+
+
+# clean up: remove all non-heatmap files from the output directory ------
+remove_files <- list.files(opts$output_dir, full.names = TRUE)
+remove_files <- remove_files[remove_files != png_file]
+fs::file_delete(remove_files)

--- a/config/reference_paths.config
+++ b/config/reference_paths.config
@@ -46,8 +46,8 @@ params {
   // TODO: These files will be added to the `${projectDir}/references` dir once we have tagged versions. For now we use URLs.
   // Reference files for determining normal cell types to use as reference for inferCNV
   // Originally created in the `infercnv-consensus-cell-type` module of `OpenScPCA-analysis`
-  diagnosis_groups_file = "" // "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv"
-  diagnosis_celltypes_file = "" // "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/infercnv-consensus-cell-type/references/diagnosis-celltype-groups.tsv"
+  diagnosis_groups_file = "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv"
+  diagnosis_celltypes_file = "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/infercnv-consensus-cell-type/references/diagnosis-celltype-groups.tsv"
 
   // cell type metadata for building references in `build-celltype-ref.nf`; not used by main workflow
   celltype_ref_metadata = "${projectDir}/references/celltype-reference-metadata.tsv"


### PR DESCRIPTION
Closes #1001 

This PR adds a script to run inferCNV, which I have locally tested with much success. The only code changes here are this R script. Here's a rundown:

- One thing I learned is that we don't actually need to _write out_the `annotations_file` as an intermediate step but it can be a data frame, so that's a nice upgrade from previous scripts that run inferCNV!
- I have wrapped running inferCNV in a tryCatch, and if it fails I touch a PNG file with the same name that inferCNV creates it has. I don't attempt any renaming but just take what inferCNV wants to call it
- I add three items to the SCE if infercnv runs successfully:
  - the wide table goes into metadata
  - a total_cnv column goes into coldata
  - I also added another metadata field `infercnv_options` with a list of info that comes out of infercnv that seemed useful to communicate, what do you think? Here's what's in it, for example:
  
```
> infercnv_result@options
$cutoff
[1] 0.1

$out_dir
[1] "infercnv-test"

$HMM
[1] TRUE

$HMM_type
[1] "i6"

$denoise
[1] TRUE

$num_threads
[1] 8

$save_rds
[1] FALSE

$smooth_method
[1] "pyramidinal"

$HMM_report_by
[1] "subcluster"

$analysis_mode
[1] "subclusters"

$tumor_subcluster_partition_method
[1] "leiden"

$hclust_method
[1] "ward.D2"

$leiden_function
[1] "CPM"

$z_score_filter
[1] 0.8

$tumor_subcluster_pval
[1] 0.1

$k_nn
[1] 20

$leiden_method
[1] "PCA"

$per_chr_hmm_subclusters
[1] FALSE

$cluster_by_groups
[1] TRUE

$max_centered_threshold
[1] 3

$remove_genes_at_chr_ends
[1] FALSE

$prune_outliers
[1] FALSE

$BayesMaxPNormal
[1] 0.5

$mask_nonDE_genes
[1] FALSE

$noise_filter
[1] NA

$sd_amplifier
[1] 1.5

$noise_logistic
[1] FALSE

$chr_exclude
[1] "chrXp" "chrXq" "chrYp" "chrYq"

$max_cells_per_group
NULL

$min_max_counts_per_cell
[1] 100 Inf

$counts_md5
[1] "d6b907c1b37e8a078cc023e5acca5f71"
```

- In the end, I went ahead and removed all the inferCNV outputs except the PNG file, let me know if you think this is overkill! There's just so many files 🫠 

The other change is here is uncommenting some params that should have been uncommented previously! But during testing in an earlier PR the commenting-out snuck through.

----

Note that in the nextflow process coming up, I'll plan to create the output directory before running the script similar to what we do for cell typing, e.g.: https://github.com/AlexsLemonade/scpca-nf/blob/731fd68b9d7c8526d0c76dda577a8163d867844e/modules/classify-celltypes.nf#L21-L29

And in the subworkflow, I will add this directory & file name to meta for later use to stage it for the report, similar to e.g.: https://github.com/AlexsLemonade/scpca-nf/blob/731fd68b9d7c8526d0c76dda577a8163d867844e/modules/classify-celltypes.nf#L206-L217