### PR TITLE
add regex to filter fastq file lists

### DIFF
--- a/modules/af-rna.nf
+++ b/modules/af-rna.nf
@@ -159,8 +159,11 @@ workflow map_quant_rna {
       .map{meta -> tuple(
         meta,
         // fail if the fastq files do not exist
-        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true),
+        // add R1 and R2 regex to ensure correct file names if R1 or R2 are in sample identifier
+        files("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true)
+          .findAll{it.name =~ /_R1(_\d+)?.fastq.gz$/},
+        files("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: true)
+          .findAll{it.name =~ /_R2(_\d+)?.fastq.gz$/},
         file(meta.salmon_splici_index, type: 'dir')
       )}
 

--- a/modules/bulk-salmon.nf
+++ b/modules/bulk-salmon.nf
@@ -160,11 +160,14 @@ workflow bulk_quant_rna {
       )}
 
     // If we need to run salmon, create tuple of (metadata map, [Read 1 files], [Read 2 files])
+    // regex to ensure correct file names if R1 or R2 are in sample identifier
     bulk_reads_ch = bulk_channel.make_quants
       .map{meta -> tuple(
         meta,
-        file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-        file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
+        files("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true)
+          .findAll{it.name =~ /_R1(_\d+)?.fastq.gz$/},
+        files("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
+          .findAll{it.name =~ /_R2(_\d+)?.fastq.gz$/}
       )}
 
     // run fastp and salmon for libraries that are not skipping salmon

--- a/modules/bulk-star.nf
+++ b/modules/bulk-star.nf
@@ -35,11 +35,14 @@ workflow star_bulk {
 
   main:
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
+    // regex to ensure correct file names if R1 or R2 are in sample identifier
     bulk_reads_ch = bulk_channel
         .map{meta -> tuple(
           meta,
-          file("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true),
-          file("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end'),
+          files("${meta.files_directory}/*_{R1,R1_*}.fastq.gz", checkIfExists: true)
+            .findAll{it.name =~ /_R1(_\d+)?.fastq.gz$/},
+          files("${meta.files_directory}/*_{R2,R2_*}.fastq.gz", checkIfExists: meta.technology == 'paired_end')
+            .findAll{it.name =~ /_R2(_\d+)?.fastq.gz$/},
           file(meta.star_index, type: 'dir', checkIfExists: true)
         )}
     // map and index


### PR DESCRIPTION
Closes #1014

Here I am modifying everywhere that we get fastq.gz files to better correctly find R1 and R2 _only_ at the end of the filename (with the possibility for a set of digits after them, for teh `*_R1_001.gz` case. I left the original glob, but then filter the resulting list using `findAll`. Note also that I changed `file()` to `files()`  to ensure we always get an array as the result.

Depending on needs, I might backport this to `main`, but I will wait to hear from the person who ran into this. (For now I hope that renaming files isn't too big a deal for them).
