### PR TITLE
Add openscpca annotations to the report

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -385,7 +385,7 @@ if (has_singler && has_cellassign) {
     # get the cell type groups to consider for this diagnosis
     reference_validation_groups <- diagnosis_celltype_df |>
       dplyr::filter(diagnosis_group == broad_diagnosis) |>
-      tidyr::separate_delim_longer(celltype_groups, sep = ",") |>
+      tidyr::separate_longer_delim(celltype_groups, delim = ",") |>
       dplyr::pull(celltype_groups) |>
       stringr::str_trim() # remove any leading or trailing spaces
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -190,6 +190,7 @@ cellassign_not_run <- check_cellassign_not_run(
 # define bullets glue string
 methods_bullets <- c(
   ifelse(has_submitter, "Submitter-provided", NA),
+  ifelse(has_openscpca, "OpenScPCA", NA),
   ifelse(has_consensus, "Consensus cell types", NA),
   ifelse(has_singler, "`SingleR`", NA),
   ifelse(has_cellassign, "`CellAssign`", NA)
@@ -198,8 +199,6 @@ methods_bullets <- c(
   # make it bullets
   stringr::str_replace_all("^", "* ") |>
   stringr::str_flatten(collapse = "\n")
-
-
 
 # print the bullets and other info messages
 glue::glue("
@@ -223,13 +222,26 @@ See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/proc
   )
 }
 
+if (has_openscpca) {
+  openscpca_annotation_info <- metadata(processed_sce)$openscpca_annotations_info
+  module_name <- openscpca_annotation_info$module_name
+  module_link <- glue::glue("https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/{module_name}")
+  openscpca_link <- glue::glue("https://github.com/AlexsLemonade/OpenScPCA-nf/tree/{openscpca_annotation_info$openscpca_nf_version}")
+
+  glue::glue(
+    "\n\nOpenScPCA annotations are assigned as part of the [`OpenScPCA` project](https://openscpca.readthedocs.io/en/latest/).
+    The annotations shown here were validated as part of the [{openscpca_annotation_info$module_name} analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
+    "
+  )
+}
+
 glue::glue("
   \n\nFor additional information about cell typing, including the results from all methods used, information about reference sources, comparisons among cell type annotation methods, and diagnostic plots, please refer to the [supplementary cell type QC report](`r params$celltype_report`).
 ")
 ```
 
 ```{r}
-if (has_consensus & !has_submitter & !is_supplemental) {
+if (has_consensus & !(has_submitter | has_openscpca) & !is_supplemental) {
   knitr::asis_output("## Statistics")
 } else {
   knitr::asis_output("## Statistics {.tabset}")
@@ -300,6 +312,14 @@ if (length(unclassified_methods) > 0) {
 }
 ```
 
+```{r, eval = has_openscpca}
+knitr::asis_output('### OpenScPCA annotations
+
+In this table, cells labeled "openscpca-excluded" are those for which the `OpenScPCA` module did not provide an annotation.
+')
+create_celltype_n_table(celltype_df, openscpca_celltype_annotation) |>
+  format_datatable()
+```
 
 ```{r, eval = has_submitter}
 knitr::asis_output('### Submitter-provided annotations
@@ -350,7 +370,7 @@ umap_df <- lump_wrap_celltypes(celltype_df)
 
 ```{r, eval = has_umap && has_celltypes }
 # only mention multiple annotations if we're actually showing multiple annotations
-if (has_consensus && !has_submitter && !is_supplemental) {
+if (has_consensus && !(has_submitter | has_openscpca) && !is_supplemental) {
   header_text <- "## UMAPs"
   umap_text <- ""
 } else {
@@ -373,6 +393,27 @@ All other cell types are grouped together and labeled "All remaining cell types"
 ```
 
 <!-- Now, UMAPs of cell types, where present -->
+
+```{r}
+if (has_openscpca & has_umap) {
+  openscpca_n_celltypes <- length(levels(umap_df$openscpca_celltype_annotation_lumped))
+  openscpca_dims <- determine_umap_dimensions(openscpca_n_celltypes)
+  knitr::asis_output("### OpenScPCA provided annotations")
+} else {
+  # set fake dims for evaluating next chunk
+  openscpca_dims <- c(1, 1)
+}
+```
+
+```{r, eval = has_openscpca && has_umap, message=FALSE, warning=FALSE, fig.width = openscpca_dims[1], fig.height = openscpca_dims[2], fig.align = "center"}
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  openscpca_n_celltypes,
+  openscpca_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
+)
+```
 
 ```{r}
 if (has_submitter & has_umap) {
@@ -677,23 +718,17 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
 
 
 ```{r}
-# boolean for whether or not to include submitter heatmaps
+# boolean for whether or not to include heatmaps comparing submitter or openscpca
 submitter_heatmaps <- (has_submitter & (has_consensus | has_cellassign | has_singler))
+openscpca_heatmaps <- (has_openscpca & (has_consensus | has_cellassign | has_singler))
 ```
 
-```{r, eval=submitter_heatmaps | (has_consensus & is_supplemental), results = 'asis'}
-# update text depending on if this is the main or supplemental report
-if (has_submitter & has_consensus & !is_supplemental) {
-  heatmap_text <- "This section displays heatmaps comparing consensus cell type labels to submitter annotations."
-} else {
-  heatmap_text <- "This section displays heatmaps comparing cell labels from various methods."
-}
-
+```{r, eval= (submitter_heatmaps | openscpca_heatmaps) | (has_consensus & is_supplemental), results = 'asis'}
 glue::glue(
   "
   # Cell label comparisons
 
-  {heatmap_text}
+  This section displays heatmaps comparing cell labels from various methods.
 
   We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between         pairs of labels assigned by different annotation methods.
 
@@ -708,8 +743,51 @@ glue::glue(
 )
 ```
 
+<!--OpenScPCA vs. consensus-->
+
 ```{r}
-if (has_submitter & has_consensus & !is_supplemental) {
+if (openscpca_heatmaps & has_consensus & !is_supplemental) {
+  # Set plot dimensions based on number of consensus cell types
+  all_celltypes <- levels(celltype_df$consensus_celltype_annotation)
+  plot_height <- calculate_plot_height(
+    unique(celltype_df$consensus_celltype_annotation),
+    unique(celltype_df$openscpca_celltype_annotation),
+    0
+  )
+} else {
+  # set a default to avoid failure in the next chunk
+  plot_height <- 1
+}
+```
+
+
+```{r, eval = openscpca_heatmaps & has_consensus & !is_supplemental, fig.height = plot_height, fig.width = 8.5}
+# Calculate jaccard matrix
+consensus_openscpca_matrix <- make_jaccard_matrix(
+  celltype_df,
+  "openscpca_celltype_annotation",
+  "consensus_celltype_annotation"
+)
+
+create_single_heatmap(
+  consensus_openscpca_matrix,
+  row_title = "Consensus cell types",
+  column_title = "OpenScPCA annotations",
+  labels_font_size = find_label_size(all_celltypes),
+  keep_legend_name = "Consensus cell types",
+  col_fun = heatmap_col_fun,
+  # additional arguments
+  column_names_rot = 90
+) |>
+  ComplexHeatmap::draw(
+    heatmap_legend_side = "bottom"
+  )
+```
+
+<!--Submitter vs. consensus-->
+
+```{r}
+if (submitter_heatmaps & has_consensus & !is_supplemental) {
   # Set plot dimensions based on number of consensus cell types
   all_celltypes <- levels(celltype_df$consensus_celltype_annotation)
   plot_height <- calculate_plot_height(
@@ -724,7 +802,7 @@ if (has_submitter & has_consensus & !is_supplemental) {
 ```
 
 
-```{r, eval = has_submitter & has_consensus & !is_supplemental, fig.height = plot_height, fig.width = 8.5}
+```{r, eval = submitter_heatmaps & has_consensus & !is_supplemental, fig.height = plot_height, fig.width = 8.5}
 # Calculate jaccard matrix
 consensus_submitter_matrix <- make_jaccard_matrix(
   celltype_df,

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -230,7 +230,7 @@ if (has_openscpca) {
 
   glue::glue(
     "\n\nOpenScPCA annotations are assigned as part of the [`OpenScPCA` project](https://openscpca.readthedocs.io/en/latest/).
-    The annotations shown here were validated as part of the [{openscpca_annotation_info$module_name} analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
+    The annotations shown here were validated as part of the [`{openscpca_annotation_info$module_name}` analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
     "
   )
 }

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -176,7 +176,7 @@ if (has_openscpca) {
   glue::glue(
     "{methods_text}
     * OpenScPCA annotations are assigned as part of the [`OpenScPCA` project](https://openscpca.readthedocs.io/en/latest/).
-    The annotations shown here were validated as part of the [{openscpca_annotation_info$module_name} analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
+    The annotations shown here were validated as part of the [`{openscpca_annotation_info$module_name}` analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
     "
   )
 }
@@ -265,7 +265,7 @@ if (!has_multiplex) {
 automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
 
 knitr::asis_output(
-  "## OpenScPCA provided annotations
+  "## OpenScPCA annotations
 
   This section displays heatmaps comparing OpenScPCA cell type annotations to those obtained from automated cell type annotation methods, including consensus cell types, if present."
 )

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -71,11 +71,12 @@ processed_sce <- params$processed_sce
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
 has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
 has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
+has_openscpca <- "openscpca" %in% metadata(processed_sce)$celltype_methods
 has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
   !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
 # If at least 1 is present, we have cell type annotations.
-has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter)
+has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter, has_openscpca)
 
 # check for umap and clusters
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
@@ -84,6 +85,7 @@ has_clusters <- "cluster" %in% names(colData(processed_sce))
 # what celltypes are available?
 available_celltypes <- c(
   ifelse(has_submitter, "Submitter", NA),
+  ifelse(has_openscpca, "OpenScPCA", NA),
   ifelse(has_singler, "SingleR", NA),
   ifelse(has_cellassign, "CellAssign", NA),
   ifelse(has_consensus, "Consensus", NA)
@@ -165,6 +167,20 @@ if (has_submitter) {
   )
 }
 
+if (has_openscpca) {
+  openscpca_annotation_info <- metadata(processed_sce)$openscpca_annotations_info
+  module_name <- openscpca_annotation_info$module_name
+  module_link <- glue::glue("https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/{module_name}")
+  openscpca_link <- glue::glue("https://github.com/AlexsLemonade/OpenScPCA-nf/tree/{openscpca_annotation_info$openscpca_nf_version}")
+
+  glue::glue(
+    "{methods_text}
+    * OpenScPCA annotations are assigned as part of the [`OpenScPCA` project](https://openscpca.readthedocs.io/en/latest/).
+    The annotations shown here were validated as part of the [{openscpca_annotation_info$module_name} analysis module in `OpenScPCA-analysis`]({module_link}) and output from the corresponding module in [`OpenScPCA-nf`]({openscpca_link}).
+    "
+  )
+}
+
 if (has_singler) {
   methods_text <- glue::glue(
     "{methods_text}
@@ -243,10 +259,60 @@ if (!has_multiplex) {
 ```{r, child='celltypes_qc.rmd'}
 ```
 
+<!-------------------------- OpenScPCA heatmaps ------------------------------->
+```{r, eval = openscpca_heatmaps}
+# don't compare to openscpca or submitter
+automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
+
+knitr::asis_output(
+  "## OpenScPCA provided annotations
+
+  This section displays heatmaps comparing OpenScPCA cell type annotations to those obtained from automated cell type annotation methods, including consensus cell types, if present."
+)
+```
+
+```{r, eval = openscpca_heatmaps}
+# calculate matrices comparing to submitter
+jaccard_openscpca_matrices <- automated_celltypes_available |>
+  stringr::str_to_lower() |>
+  purrr::map(\(name) {
+    make_jaccard_matrix(
+      celltype_df,
+      "openscpca_celltype_annotation",
+      glue::glue("{name}_celltype_annotation")
+    )
+  }) |>
+  purrr::set_names(automated_celltypes_available)
+
+# how many cell types?
+all_celltypes <- jaccard_openscpca_matrices |>
+  purrr::map(colnames) |>
+  unlist()
+
+plot_height <- calculate_plot_height(
+  all_celltypes,
+  unique(celltype_df$openscpca_celltype_annotation),
+  length(jaccard_openscpca_matrices) - 1
+)
+```
+
+```{r, eval = openscpca_heatmaps, fig.height = plot_height, fig.width = 8.5, warning = FALSE}
+jaccard_openscpca_matrices |>
+  create_heatmap_list(
+    column_title = "OpenScPCA annotations",
+    labels_font_size = find_label_size(all_celltypes),
+    # additional arguments
+    column_names_rot = 90
+  ) |>
+  ComplexHeatmap::draw(
+    heatmap_legend_side = "bottom"
+  )
+```
+
 <!-------------------------- Submitter heatmaps ------------------------------->
 ```{r, eval = submitter_heatmaps}
 # don't compare submitter to submitter
-automated_celltypes_available <- available_celltypes[!(available_celltypes == "Submitter")]
+automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
 
 knitr::asis_output(
   "## Submitter-provided annotations
@@ -347,7 +413,6 @@ jaccard_consensus_matrices |>
   )
 ```
 
-<!--TODO: Fill out clustering section -->
 
 ```{r, eval = has_umap && has_clusters}
 knitr::asis_output(glue::glue("

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -137,11 +137,12 @@ if (has_processed) {
   has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
+  has_openscpca <- "openscpca" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
     !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
   # If at least 1 is present, we have cell type annotations.
-  has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter)
+  has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter, has_openscpca)
 
   is_supplemental <- FALSE # this is not the celltype supp report
 } else {
@@ -150,6 +151,7 @@ if (has_processed) {
   has_consensus <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
+  has_openscpca <- FALSE
   has_submitter <- FALSE
   has_celltypes <- FALSE
 }

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -37,6 +37,7 @@ create_celltype_df <- function(processed_sce) {
       contains("consensus"),
       contains("singler"),
       contains("cellassign"),
+      contains("openscpca", ),
       contains("submitter")
     )
 
@@ -59,6 +60,15 @@ create_celltype_df <- function(processed_sce) {
     celltype_df <- prepare_automated_annotation_values(
       celltype_df,
       cellassign_celltype_annotation
+    )
+  }
+
+  # if openscpca annotations exist we just need to sort by frequency and recode unknown
+  # we already label openscpca-exluded for any missing cells when we add to the object
+  if ("openscpca_celltype_annotation" %in% names(celltype_df)) {
+    celltype_df <- prepare_automated_annotation_values(
+      celltype_df,
+      openscpca_celltype_annotation
     )
   }
 


### PR DESCRIPTION
Closes #971 

Here I'm adding the OpenScPCA annotations to the cell type sections of the report. I treated these very similarly to submitter annotations so they are shown both in the main report section and the supplemental report if present. 

- Just like submitter annotations, these appear first in the tabs for tables and UMAPs. I think this is the right choice, but someone tell me if they would prefer to have consensus first in the order. 
- If present, we show a heatmap comparing OpenScPCA to consensus in the main report and then in the supplement OpenScPCA annotations are compared to all other annotations (just like we do for submitter). 
- The way this is setup, we theoretically could have both openscpca and submitter annotations and would just have two heatmaps, one comparing to submitter and one comparing to openscpca. I don't think this will actually happen, but I thought it made the most sense to future proof against that. 

Here's a zip with reports for libraries with and without openscpca annotations: 
[reports.zip](https://github.com/user-attachments/files/22365313/reports.zip)

I also fixed a minor bug I saw in the infercnv changes, but I noticed it was also committed to https://github.com/AlexsLemonade/scpca-nf/pull/1010 this morning. 