### PR TITLE
Add infercnv plots to QC

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -36,13 +36,15 @@ create_celltype_n_table <- function(df, celltype_column) {
 #' @param n_celltypes The number of cell types (facets) displayed in the plot
 #' @param annotation_column Column containing cell type annotations
 #' @param point_size Point size. Default is 1
+#' @param palette Optionally, a named vector to use as a palette. If not provided, "Dark2" will be used
 #'
 #' @return ggplot object containing a faceted UMAP where each cell type is a facet.
 #'   In each panel, the cell type of interest is colored and all other cells are grey.
 faceted_umap <- function(umap_df,
                          n_celltypes,
                          annotation_column,
-                         point_size = 1) {
+                         point_size = 1, 
+                         palette = NULL) {
   # Determine legend y-coordinate based on n_celltypes
   if (n_celltypes %in% 7:8) {
     legend_y <- 0.33
@@ -70,7 +72,6 @@ faceted_umap <- function(umap_df,
       vars({{ annotation_column }}),
       ncol = 3
     ) +
-    scale_color_brewer(palette = "Dark2") +
     # remove axis numbers and background grid
     scale_x_continuous(labels = NULL, breaks = NULL) +
     scale_y_continuous(labels = NULL, breaks = NULL) +
@@ -85,7 +86,16 @@ faceted_umap <- function(umap_df,
         )
       )
     )
-
+  
+  # Add colors from palette if provided
+  if (!is.null(palette)) {
+   faceted_umap <- faceted_umap +
+     scale_color_manual(values = palette)
+  } else {
+   faceted_umap <- faceted_umap +
+     scale_color_brewer(palette = "Dark2")
+  }
+  
   # Determine legend placement based on total_celltypes
   if (n_celltypes == 1) {
     # If n=1, we do not need to a show a legend, and title should be smaller
@@ -119,8 +129,6 @@ faceted_umap <- function(umap_df,
         aspect.ratio = 1
       )
   }
-
-
 
   return(faceted_umap)
 }
@@ -416,11 +424,16 @@ if (has_consensus & has_umap) {
 
 ```{r, eval=has_consensus && has_umap, message=FALSE, warning=FALSE, fig.width = consensus_dims[1], fig.height = consensus_dims[2], fig.align = "center"}
 # umap for cell assign annotations
+# we define a palette so we can use it (if applicable) in the inferCNV report
+consensus_hex <- RColorBrewer::brewer.pal(name = "Dark2", n = consensus_n_celltypes)
+names(consensus_hex) <- levels(umap_df$consensus_celltype_annotation_lumped)
+
 faceted_umap(
   umap_df,
   consensus_n_celltypes,
   consensus_celltype_annotation_lumped,
-  point_size = umap_facet_point_size
+  point_size = umap_facet_point_size, 
+  palette = consensus_hex
 )
 ```
 
@@ -504,7 +517,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
-celltype_colors <- celltype_colors_df |>
+celltype_colors <- validation_palette_df |>
   tibble::deframe()
 ```
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -29,42 +29,6 @@ create_celltype_n_table <- function(df, celltype_column) {
     )
 }
 
-#' Function to lump celltype columns in an existing data frame for all of the
-#'  following columns, if they exist: `<singler/cellassign/submitter>_celltype_annotation`.
-#' The cell types will also be renamed via wrapping at the given `wrap` level.
-#'  The resulting lumped column will be named:
-#'  `<singler/cellassign/submitter>_celltype_annotation_lumped`.
-#'
-#'
-#' @param df Data frame to manipulate
-#' @param n_celltypes Number of groups to lump into, with rest put into "Other" group. Default is 7.
-#'
-#' @return Updated df with new column of lumped celltypes for each present method
-lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35) {
-  df <- df |>
-    # First, wrap labels
-    dplyr::mutate(
-      across(
-        ends_with("_celltype_annotation"),
-        \(x) stringr::str_wrap(x, wrap)
-      )
-    ) |>
-    # Next, apply factor lumping, but ensure final order is via frequency with the "others" at the end
-    dplyr::mutate(
-      across(
-        ends_with("_celltype_annotation"),
-        \(x) {
-          x |>
-            forcats::fct_lump_n(n_celltypes, other_level = "All remaining cell types", ties.method = "first") |>
-            forcats::fct_infreq() |>
-            forcats::fct_relevel("Unknown cell type", "All remaining cell types", after = Inf)
-        },
-        .names = "{.col}_lumped"
-      )
-    )
-  return(df)
-}
-
 
 #' Create a faceted UMAP panel where each panel has only one cell type colored
 #'

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -43,7 +43,7 @@ create_celltype_n_table <- function(df, celltype_column) {
 faceted_umap <- function(umap_df,
                          n_celltypes,
                          annotation_column,
-                         point_size = 1, 
+                         point_size = 1,
                          palette = NULL) {
   # Determine legend y-coordinate based on n_celltypes
   if (n_celltypes %in% 7:8) {
@@ -86,16 +86,16 @@ faceted_umap <- function(umap_df,
         )
       )
     )
-  
+
   # Add colors from palette if provided
   if (!is.null(palette)) {
-   faceted_umap <- faceted_umap +
-     scale_color_manual(values = palette)
+    faceted_umap <- faceted_umap +
+      scale_color_manual(values = palette)
   } else {
-   faceted_umap <- faceted_umap +
-     scale_color_brewer(palette = "Dark2")
+    faceted_umap <- faceted_umap +
+      scale_color_brewer(palette = "Dark2")
   }
-  
+
   # Determine legend placement based on total_celltypes
   if (n_celltypes == 1) {
     # If n=1, we do not need to a show a legend, and title should be smaller
@@ -432,7 +432,7 @@ faceted_umap(
   umap_df,
   consensus_n_celltypes,
   consensus_celltype_annotation_lumped,
-  point_size = umap_facet_point_size, 
+  point_size = umap_facet_point_size,
   palette = consensus_hex
 )
 ```

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -114,12 +114,12 @@ This section displays the library UMAP colored by the total per-cell CNV as esti
 This total CNV value was calculated by summing across all CNV events inferred within each cell.
 ")
 
-# create UMAP colored by total_cnv
+# create UMAP colored by infercnv_total_cnv
 scater::plotUMAP(
   processed_sce,
   point_size = umap_point_size, # defined in UMAP child report
   point_alpha = 0.5,
-  color_by = "total_cnv"
+  color_by = "infercnv_total_cnv"
 ) +
   scale_color_viridis_c(name = "cividis") +
   # remove axis numbers and background grid
@@ -146,7 +146,7 @@ The second ridge plot shows the CNV distributions across consensus cell types, s
 # Prepare data frames for plotting
 total_cnv_df <- scuttle::makePerCellDF(
   processed_sce,
-  use.coldata = c("is_infercnv_reference", "consensus_celltype_annotation", "total_cnv"),
+  use.coldata = c("is_infercnv_reference", "consensus_celltype_annotation", "infercnv_total_cnv"),
   use.dimred = FALSE
 ) |>
   tibble::rownames_to_column("barcodes") |>
@@ -167,7 +167,7 @@ total_cnv_filtered_df$celltype_lumped <- factor(total_cnv_filtered_df$celltype_l
 total_cnv_filtered_df$celltype_lumped <- forcats::fct_rev(total_cnv_filtered_df$celltype_lumped) # reverse for display in ridge plot
 
 cell_group_plot <- ggplot(total_cnv_df) +
-  aes(x = total_cnv, y = is_infercnv_reference, fill = is_infercnv_reference) +
+  aes(x = infercnv_total_cnv, y = is_infercnv_reference, fill = is_infercnv_reference) +
   ggridges::geom_density_ridges2(scale = 0.9) +
   labs(
     x = "Total CNV events per cell",
@@ -177,7 +177,7 @@ cell_group_plot <- ggplot(total_cnv_df) +
   theme(legend.position = "none")
 
 cell_type_plot <- ggplot(total_cnv_filtered_df) +
-  aes(x = total_cnv, y = celltype_lumped, fill = celltype_lumped) +
+  aes(x = infercnv_total_cnv, y = celltype_lumped, fill = celltype_lumped) +
   ggridges::geom_density_ridges2(scale = 0.9) +
   scale_fill_brewer(palette = "Dark2", direction = -1) +
   labs(

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -101,7 +101,7 @@ knitr::include_graphics(params$infercnv_heatmap_file)
 This section displays the library UMAP colored by the total per-cell CNV as estimated by `inferCNV`.
 This total CNV value was calculated by summing across all CNV events inferred within each cell.
 
-```{r message=FALSE, warning=FALSE}
+```{r eval = has_umap, message=FALSE, warning=FALSE}
 # create UMAP colored by infercnv_total_cnv
 scater::plotUMAP(
   processed_sce,

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -70,3 +70,28 @@ For more information on interpreting this heatmap, please refer to the [`inferCN
 ```{r}
 knitr::include_graphics(params$infercnv_heatmap_file)
 ```
+
+## UMAP colored by total CNV
+
+This section displays the library UMAP colored by the total per-cell CNV as estimated by `inferCNV`.
+This total CNV value was calculated by summing across all CNV events inferred within each cell.
+
+```{r message=FALSE, warning=FALSE}
+# create UMAP colored by total_cnv
+scater::plotUMAP(
+  processed_sce,
+  point_size = umap_point_size, # defined in UMAP child report
+  point_alpha = 0.5,
+  color_by = "total_cnv"
+) +
+  scale_color_viridis_c(name = "cividis") +
+  # remove axis numbers and background grid
+  scale_x_continuous(labels = NULL, breaks = NULL) +
+  scale_y_continuous(labels = NULL, breaks = NULL) +
+  guides(
+    color = guide_colorbar(title = "Total CNV events")
+  ) +
+  theme_bw() +
+  theme(aspect.ratio = 1)
+```
+

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -106,12 +106,14 @@ For more information on interpreting this heatmap, please refer to the [`inferCN
 knitr::include_graphics(params$infercnv_heatmap_file)
 ```
 
-## UMAP colored by total CNV
+
+```{r eval = has_infercnv_results, message=FALSE, warning=FALSE}
+knitr::asis_output("## UMAP colored by total CNV
 
 This section displays the library UMAP colored by the total per-cell CNV as estimated by `inferCNV`.
 This total CNV value was calculated by summing across all CNV events inferred within each cell.
+")
 
-```{r message=FALSE, warning=FALSE}
 # create UMAP colored by total_cnv
 scater::plotUMAP(
   processed_sce,
@@ -130,14 +132,17 @@ scater::plotUMAP(
   theme(aspect.ratio = 1)
 ```
 
-## Total CNV distributions
+```{r eval = has_infercnv_results, message=FALSE, warning=FALSE}
+knitr::asis_output("## Total CNV distributions
 
 This section displays the distributions of total CNVs across cell types.
 The first ridge plot shows the CNV distributions between cell type groups: Those included in the `inferCNV` normal reference, versus all other query cells.
-The second ridge plot shows the CNV distributions across consensus cell types, considering only cell types with at least 3 cells.
+The second ridge plot shows the CNV distributions across consensus cell types, showing only the top seven most common cell types.
+")
+```
 
 
-```{r}
+```{r eval = has_infercnv_results, fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
 # Prepare data frames for plotting
 total_cnv_df <- scuttle::makePerCellDF(
   processed_sce,
@@ -160,10 +165,7 @@ new_labels_df <- forcats::fct_count(total_cnv_filtered_df$celltype_lumped)
 new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
 total_cnv_filtered_df$celltype_lumped <- factor(total_cnv_filtered_df$celltype_lumped, labels = new_labels)
 total_cnv_filtered_df$celltype_lumped <- forcats::fct_rev(total_cnv_filtered_df$celltype_lumped) # reverse for display in ridge plot
-```
 
-
-```{r, fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
 cell_group_plot <- ggplot(total_cnv_df) +
   aes(x = total_cnv, y = is_infercnv_reference, fill = is_infercnv_reference) +
   ggridges::geom_density_ridges2(scale = 0.9) +

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -96,14 +96,12 @@ For more information on interpreting this heatmap, please refer to the [`inferCN
 knitr::include_graphics(params$infercnv_heatmap_file)
 ```
 
-
-```{r eval = has_infercnv_results, message=FALSE, warning=FALSE}
-knitr::asis_output("## UMAP colored by total CNV
+## UMAP colored by total CNV
 
 This section displays the library UMAP colored by the total per-cell CNV as estimated by `inferCNV`.
 This total CNV value was calculated by summing across all CNV events inferred within each cell.
-")
 
+```{r message=FALSE, warning=FALSE}
 # create UMAP colored by infercnv_total_cnv
 scater::plotUMAP(
   processed_sce,
@@ -122,17 +120,13 @@ scater::plotUMAP(
   theme(aspect.ratio = 1)
 ```
 
-```{r eval = has_infercnv_results, message=FALSE, warning=FALSE}
-knitr::asis_output("## Total CNV distributions
+## Total CNV distributions
 
 This section displays the distributions of total CNVs across cell types.
 The first ridge plot shows the CNV distributions between cell type groups: Those included in the `inferCNV` normal reference, versus all other query cells.
 The second ridge plot shows the CNV distributions across consensus cell types, showing only the top seven most common cell types.
-")
-```
 
-
-```{r eval = has_infercnv_results, fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
+```{r fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
 # Prepare data frames for plotting
 total_cnv_df <- scuttle::makePerCellDF(
   processed_sce,
@@ -143,7 +137,7 @@ total_cnv_df <- scuttle::makePerCellDF(
   dplyr::add_count(is_infercnv_reference) |>
   dplyr::mutate(
     is_infercnv_reference = ifelse(is_infercnv_reference, "Reference cells", "Query cells"),
-    is_infercnv_reference = glue::glue("{is_infercnv_reference} (N={n}")
+    is_infercnv_reference = glue::glue("{is_infercnv_reference} (N={n})")
   )
 
 total_cnv_filtered_df <- total_cnv_df |>
@@ -156,6 +150,7 @@ new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
 total_cnv_filtered_df$celltype_lumped <- factor(total_cnv_filtered_df$celltype_lumped, labels = new_labels)
 total_cnv_filtered_df$celltype_lumped <- forcats::fct_rev(total_cnv_filtered_df$celltype_lumped) # reverse for display in ridge plot
 
+# first plot: across cell type groups
 cell_group_plot <- ggplot(total_cnv_df) +
   aes(x = infercnv_total_cnv, y = is_infercnv_reference, fill = is_infercnv_reference) +
   ggridges::geom_density_ridges2(scale = 0.9) +
@@ -166,6 +161,7 @@ cell_group_plot <- ggplot(total_cnv_df) +
   ) +
   theme(legend.position = "none")
 
+# second plot: across cell types
 cell_type_plot <- ggplot(total_cnv_filtered_df) +
   aes(x = infercnv_total_cnv, y = celltype_lumped, fill = celltype_lumped) +
   ggridges::geom_density_ridges2(scale = 0.9) +

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -127,7 +127,7 @@ This section displays the distributions of total CNVs across cell types.
 The first ridge plot shows the CNV distributions between cell type groups: Those included in the `inferCNV` normal reference, versus all other query cells.
 
 The second ridge plot shows the CNV distributions across consensus cell types, showing only the top seven most common cell types.
-Note that any cell types with fewer than 3 cells are not shown in this plot; if one of the most common cell types had fewer than 3 cells, the colors in this plot may differ from those shown in the cell type annotation QC report section.
+Note that any cell types with fewer than 3 cells are not shown in this plot.
 
 ```{r fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
 # Prepare data frames for plotting

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -141,7 +141,15 @@ total_cnv_df <- scuttle::makePerCellDF(
   )
 
 total_cnv_filtered_df <- total_cnv_df |>
-  lump_wrap_celltypes(unknown_string = "Unknown") |>
+  # rename for consistency with cell type report section
+  dplyr::mutate(
+    consensus_celltype_annotation = ifelse(
+      consensus_celltype_annotation == "Unknown", 
+      "Unknown cell type", 
+      consensus_celltype_annotation
+    )
+  ) |>
+  lump_wrap_celltypes() |>
   # rename for convenience
   dplyr::rename(celltype_lumped = consensus_celltype_annotation_lumped)
 

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -95,3 +95,63 @@ scater::plotUMAP(
   theme(aspect.ratio = 1)
 ```
 
+## Total CNV distributions
+
+This section displays the distributions of total CNVs across cell types.
+The first ridge plot shows the CNV distributions between cell type groups: Those included in the `inferCNV` normal reference, versus all other query cells.
+The second ridge plot shows the CNV distributions across consensus cell types, considering only cell types with at least 3 cells.
+
+
+```{r}
+# Prepare data frames for plotting
+total_cnv_df <- scuttle::makePerCellDF(
+  processed_sce, 
+  use.coldata = c("is_infercnv_reference", "consensus_celltype_annotation", "total_cnv"), 
+  use.dimred = FALSE
+) |>
+  tibble::rownames_to_column("barcodes") |>
+  dplyr::add_count(is_infercnv_reference) |>
+  dplyr::mutate(
+    is_infercnv_reference = ifelse(is_infercnv_reference, "Reference cells", "Query cells"), 
+    is_infercnv_reference = glue::glue("{is_infercnv_reference} (N={n}")
+  )
+  
+total_cnv_filtered_df <- total_cnv_df |> 
+  lump_wrap_celltypes(unknown_string = "Unknown") |>
+  # rename for convenience
+  dplyr::rename(celltype_lumped = consensus_celltype_annotation_lumped) 
+  
+new_labels_df <- forcats::fct_count(total_cnv_filtered_df$celltype_lumped)
+new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})") 
+total_cnv_filtered_df$celltype_lumped <- factor(total_cnv_filtered_df$celltype_lumped, labels = new_labels)
+total_cnv_filtered_df$celltype_lumped <- forcats::fct_rev(total_cnv_filtered_df$celltype_lumped) # reverse for display in ridge plot
+```
+
+
+```{r, fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
+cell_group_plot <- ggplot(total_cnv_df) +
+  aes(x = total_cnv, y = is_infercnv_reference, fill = is_infercnv_reference) +
+  ggridges::geom_density_ridges2(scale = 0.9) +
+  labs(
+    x = "Total CNV events per cell",
+    y = "Cell type group", 
+    title = "CNV between reference and query cell groups"
+  ) +
+    theme(legend.position = "none") 
+
+cell_type_plot <- ggplot(total_cnv_filtered_df) +
+  aes(x = total_cnv, y = celltype_lumped, fill = celltype_lumped) +
+  ggridges::geom_density_ridges2(scale = 0.9) +
+  scale_fill_brewer(palette = "Dark2", direction = -1) +
+  labs(
+    x = "Total CNV events per cell",
+    y = "Consensus cell type",
+    title = "CNV across consensus cell types"
+  ) +
+    theme(legend.position = "none") 
+ 
+ 
+cell_group_plot / cell_type_plot + plot_layout(heights = c(1, 3))
+```
+
+

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -158,11 +158,11 @@ new_labels_df <- forcats::fct_count(total_cnv_df$celltype_lumped)
 new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
 
 # set ordering for labels in total cnv dataframe for plotting
-total_cnv_df <- total_cnv_df |> 
+total_cnv_df <- total_cnv_df |>
   dplyr::mutate(
     celltype_lumped = factor(total_cnv_df$celltype_lumped, labels = new_labels) |>
-    forcats::fct_rev() # reverse for display in ridge plot
-)
+      forcats::fct_rev() # reverse for display in ridge plot
+  )
 
 # first plot: across cell type groups
 cell_group_plot <- ggplot(total_cnv_df) +

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -144,8 +144,8 @@ total_cnv_filtered_df <- total_cnv_df |>
   # rename for consistency with cell type report section
   dplyr::mutate(
     consensus_celltype_annotation = ifelse(
-      consensus_celltype_annotation == "Unknown", 
-      "Unknown cell type", 
+      consensus_celltype_annotation == "Unknown",
+      "Unknown cell type",
       consensus_celltype_annotation
     )
   ) |>

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -153,10 +153,16 @@ total_cnv_filtered_df <- total_cnv_df |>
   # rename for convenience
   dplyr::rename(celltype_lumped = consensus_celltype_annotation_lumped)
 
-new_labels_df <- forcats::fct_count(total_cnv_filtered_df$celltype_lumped)
+# get a vector of labels with cell counts in order of total cells
+new_labels_df <- forcats::fct_count(total_cnv_df$celltype_lumped)
 new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
-total_cnv_filtered_df$celltype_lumped <- factor(total_cnv_filtered_df$celltype_lumped, labels = new_labels)
-total_cnv_filtered_df$celltype_lumped <- forcats::fct_rev(total_cnv_filtered_df$celltype_lumped) # reverse for display in ridge plot
+
+# set ordering for labels in total cnv dataframe for plotting
+total_cnv_df <- total_cnv_df |> 
+  dplyr::mutate(
+    celltype_lumped = factor(total_cnv_df$celltype_lumped, labels = new_labels) |>
+    forcats::fct_rev() # reverse for display in ridge plot
+)
 
 # first plot: across cell type groups
 cell_group_plot <- ggplot(total_cnv_df) +

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -123,8 +123,11 @@ scater::plotUMAP(
 ## Total CNV distributions
 
 This section displays the distributions of total CNVs across cell types.
+
 The first ridge plot shows the CNV distributions between cell type groups: Those included in the `inferCNV` normal reference, versus all other query cells.
+
 The second ridge plot shows the CNV distributions across consensus cell types, showing only the top seven most common cell types.
+Note that any cell types with fewer than 3 cells are not shown in this plot; if one of the most common cell types had fewer than 3 cells, the colors in this plot may differ from those shown in the cell type annotation QC report section.
 
 ```{r fig.width = 7, fig.height = 10, warning = FALSE, message = FALSE}
 # Prepare data frames for plotting
@@ -138,9 +141,8 @@ total_cnv_df <- scuttle::makePerCellDF(
   dplyr::mutate(
     is_infercnv_reference = ifelse(is_infercnv_reference, "Reference cells", "Query cells"),
     is_infercnv_reference = glue::glue("{is_infercnv_reference} (N={n})")
-  )
-
-total_cnv_filtered_df <- total_cnv_df |>
+  ) |>
+  dplyr::select(-n) |>
   # rename for consistency with cell type report section
   dplyr::mutate(
     consensus_celltype_annotation = ifelse(
@@ -148,19 +150,34 @@ total_cnv_filtered_df <- total_cnv_df |>
       "Unknown cell type",
       consensus_celltype_annotation
     )
-  ) |>
+  ) 
+
+# this data frame version is used for the plot across celltypes
+total_cnv_lumped_df <- total_cnv_df |>
+  # keep only cell types with at least 3 cells
+  dplyr::add_count(consensus_celltype_annotation) |>
+  dplyr::filter(n >= 3) |>
+  dplyr::select(-n) |>
   lump_wrap_celltypes() |>
   # rename for convenience
   dplyr::rename(celltype_lumped = consensus_celltype_annotation_lumped)
 
-# get a vector of labels with cell counts in order of total cells
-new_labels_df <- forcats::fct_count(total_cnv_df$celltype_lumped)
-new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
+# join in consensus colors which were defined in the celltypes_qc.rmd child report, 
+# but do separately to preserve factor order out of lump_wrap_celltypes()
+hex_df <- data.frame(consensus_hex) |>
+  tibble::rownames_to_column("celltype_lumped") |>
+  dplyr::filter(celltype_lumped %in% unique(total_cnv_lumped_df$celltype_lumped))
+hex_df$celltype_lumped <- factor(hex_df$celltype_lumped, levels = levels(total_cnv_lumped_df$celltype_lumped))
 
-# set ordering for labels in total cnv dataframe for plotting
-total_cnv_df <- total_cnv_df |>
+total_cnv_lumped_df <- total_cnv_lumped_df |>
+  dplyr::inner_join(hex_df, by = "celltype_lumped")
+
+# set total_cnv_lumped_df$celltype_lumped levels for plotting
+new_labels_df <- forcats::fct_count(total_cnv_lumped_df$celltype_lumped)
+new_labels <- glue::glue("{new_labels_df$f} (N={new_labels_df$n})")
+total_cnv_lumped_df <- total_cnv_lumped_df |>
   dplyr::mutate(
-    celltype_lumped = factor(total_cnv_df$celltype_lumped, labels = new_labels) |>
+    celltype_lumped = factor(celltype_lumped, labels = new_labels) |>
       forcats::fct_rev() # reverse for display in ridge plot
   )
 
@@ -175,11 +192,13 @@ cell_group_plot <- ggplot(total_cnv_df) +
   ) +
   theme(legend.position = "none")
 
+
+
 # second plot: across cell types
-cell_type_plot <- ggplot(total_cnv_filtered_df) +
-  aes(x = infercnv_total_cnv, y = celltype_lumped, fill = celltype_lumped) +
+cell_type_plot <- ggplot(total_cnv_lumped_df) +
+  aes(x = infercnv_total_cnv, y = celltype_lumped, fill = consensus_hex) +
   ggridges::geom_density_ridges2(scale = 0.9) +
-  scale_fill_brewer(palette = "Dark2", direction = -1) +
+  scale_fill_identity() +
   labs(
     x = "Total CNV events per cell",
     y = "Consensus cell type",

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -150,7 +150,7 @@ total_cnv_df <- scuttle::makePerCellDF(
       "Unknown cell type",
       consensus_celltype_annotation
     )
-  ) 
+  )
 
 # this data frame version is used for the plot across celltypes
 total_cnv_lumped_df <- total_cnv_df |>
@@ -162,7 +162,7 @@ total_cnv_lumped_df <- total_cnv_df |>
   # rename for convenience
   dplyr::rename(celltype_lumped = consensus_celltype_annotation_lumped)
 
-# join in consensus colors which were defined in the celltypes_qc.rmd child report, 
+# join in consensus colors which were defined in the celltypes_qc.rmd child report,
 # but do separately to preserve factor order out of lump_wrap_celltypes()
 hex_df <- data.frame(consensus_hex) |>
   tibble::rownames_to_column("celltype_lumped") |>

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -202,10 +202,9 @@ format_datatable <- function(df) {
 #' @param df Data frame to manipulate
 #' @param n_celltypes Number of groups to lump into, with rest put into "Other" group. Default is 7.
 #' @param wrap Characters to wrap the cell type label
-#' @param unknown_string String used to represent unknown cell types
 #'
 #' @return Updated df with new column of lumped celltypes for each present method
-lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35, unknown_string = "Unknown cell type") {
+lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35) {
   df <- df |>
     # First, wrap labels
     dplyr::mutate(
@@ -222,7 +221,7 @@ lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35, unknown_string =
           x |>
             forcats::fct_lump_n(n_celltypes, other_level = "All remaining cell types", ties.method = "first") |>
             forcats::fct_infreq() |>
-            forcats::fct_relevel(unknown_string, "All remaining cell types", after = Inf)
+            forcats::fct_relevel("Unknown cell type", "All remaining cell types", after = Inf)
         },
         .names = "{.col}_lumped"
       )

--- a/templates/qc_report/utils/report_functions.rmd
+++ b/templates/qc_report/utils/report_functions.rmd
@@ -189,3 +189,44 @@ format_datatable <- function(df) {
     )
 }
 ```
+
+
+```{r}
+#' Function to lump celltype columns in an existing data frame for all of the
+#'  following columns, if they exist: `{type}_celltype_annotation`.
+#' The cell types will also be renamed via wrapping at the given `wrap` level.
+#'  The resulting lumped column will be named:
+#'  `{type}>_celltype_annotation_lumped`.
+#'
+#'
+#' @param df Data frame to manipulate
+#' @param n_celltypes Number of groups to lump into, with rest put into "Other" group. Default is 7.
+#' @param wrap Characters to wrap the cell type label
+#' @param unknown_string String used to represent unknown cell types
+#'
+#' @return Updated df with new column of lumped celltypes for each present method
+lump_wrap_celltypes <- function(df, n_celltypes = 7, wrap = 35, unknown_string = "Unknown cell type") {
+  df <- df |>
+    # First, wrap labels
+    dplyr::mutate(
+      across(
+        ends_with("_celltype_annotation"),
+        \(x) stringr::str_wrap(x, wrap)
+      )
+    ) |>
+    # Next, apply factor lumping, but ensure final order is via frequency with the "others" at the end
+    dplyr::mutate(
+      across(
+        ends_with("_celltype_annotation"),
+        \(x) {
+          x |>
+            forcats::fct_lump_n(n_celltypes, other_level = "All remaining cell types", ties.method = "first") |>
+            forcats::fct_infreq() |>
+            forcats::fct_relevel(unknown_string, "All remaining cell types", after = Inf)
+        },
+        .names = "{.col}_lumped"
+      )
+    )
+  return(df)
+}
+```


### PR DESCRIPTION
Closes #999
Closes #1000 

This PR adds the next two sections to the inferCNV report; each was fairly small so I went ahead and did them together.
The first new section is UMAP colored by total CNV, and the second new section is ridge plots of total CNV. For the ridge plot across cell types, I decided to mirror the cell type report section and show the same lumped cell types there. Let me know if you agree with that decision! In order to do this, I had to move the `lump_wrap_celltypes()` into the report functions file instead of the celltype functions file so it was available to the ifnerCNV chld report.

Here is an attached rendered report (again no cell type sections for faster local development). Note that these plots are _not compelling_ biologically since the processed SCE I used to generate them was produced from an SCE I ran through while testing and used that exciting new inferCNV argument to limit the number of cells per group for runtime, so the CNV estimates are bad (note this is _not_ related to NA situation I'm looking into; indeed I need to do a full rerun of infercnv over there to track things down...).
[infercnv-main_qc_report.html.zip](https://github.com/user-attachments/files/22392084/infercnv-main_qc_report.html.zip)

 
