### PR TITLE
Include SCimilarity in cell type report part 1

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -165,12 +165,25 @@ methods_bullets <- c(
   ifelse(has_openscpca, "OpenScPCA", NA),
   ifelse(has_consensus, "Consensus cell types", NA),
   ifelse(has_singler, "`SingleR`", NA),
-  ifelse(has_cellassign, "`CellAssign`", NA)
+  ifelse(has_cellassign, "`CellAssign`", NA),
+  ifelse(has_scimilarity, "`SCimilarity`", NA)
 ) |>
   na.omit() |>
   # make it bullets
   stringr::str_replace_all("^", "* ") |>
   stringr::str_flatten(collapse = "\n")
+
+# define map of automated methods to their proper names for use when printing text and plot labels
+automated_celltype_names <- c(
+  singler = "SingleR",
+  cellassign = "CellAssign",
+  scimilarity = "SCimilarity"
+)
+
+# get a vector of the automated methods that are present and were used to generate consensus
+automated_celltypes_available <- unname(automated_celltype_names[metadata(processed_sce)$consensus_celltype_methods])
+# make a pretty string for use in text
+automated_celltypes_string <- stringr::str_flatten_comma(automated_celltypes_available, last = ", and ")
 
 # print the bullets and other info messages
 glue::glue("
@@ -187,10 +200,10 @@ if (cellassign_not_run) {
 
 if (has_consensus) {
   glue::glue(
-    "\n\nConsensus cell types are obtained based on agreement between `SingleR` and `CellAssign` using an ontology-aware approach.
+    "\n\nConsensus cell types are obtained based on agreement between all available automated methods ({automated_celltypes_string}) using an ontology-aware approach.
 If no common label is identified, no consensus cell type is assigned.
 See the [ScPCA Portal documentation](https://scpca.readthedocs.io/en/stable/processing_information.html#cell-type-annotation) for a full description on how these cell type annotations are assigned.
-`SingleR` and `CellAssign` annotation results are provided in the [supplementary cell type QC report](`r params$celltype_report`)."
+Annotation results from {automated_celltypes_string} are provided in the [supplementary cell type QC report](`r params$celltype_report`)."
   )
 }
 
@@ -232,7 +245,7 @@ umap_facet_point_size <- umap_points_sizes[2]
 ```
 
 
-```{r, eval = (has_cellassign || has_singler) && (is_supplemental || !has_consensus), results='asis'}
+```{r, eval = (has_cellassign || has_singler || has_scimilarity) && (is_supplemental || !has_consensus), results='asis'}
 unclassified_methods <- c()
 
 # check for unclassified SingleR cells
@@ -264,6 +277,23 @@ if (has_cellassign && any(celltype_df$cellassign_celltype_annotation == "Unclass
     dplyr::mutate(
       cellassign_celltype_annotation = forcats::fct_drop(
         cellassign_celltype_annotation,
+        only = "Unclassified cell"
+      )
+    )
+}
+
+# check for unclassified scimilarity cells
+if (has_scimilarity && any(celltype_df$scimilarity_celltype_annotation == "Unclassified cell")) {
+  unclassified_methods <- c(unclassified_methods, "SCimilarity")
+
+  # remove unclassified cells
+  celltype_df <- celltype_df |>
+    dplyr::filter(
+      scimilarity_celltype_annotation != "Unclassified cell"
+    ) |>
+    dplyr::mutate(
+      scimilarity_celltype_annotation = forcats::fct_drop(
+        scimilarity_celltype_annotation,
         only = "Unclassified cell"
       )
     )
@@ -306,7 +336,7 @@ create_celltype_n_table(celltype_df, submitter_celltype_annotation) |>
 ```{r, eval = has_consensus}
 knitr::asis_output('### Consensus cell type annotations
 
-In this table, cells labeled "Unknown cell type" are those whose `SingleR` and `CellAssign` annotations did not agree.
+In this table, cells labeled "Unknown cell type" are those whose annotations across automated cell type methods did not agree.
 In the processed result files, these cells are labeled `Unknown`.
 ')
 
@@ -331,6 +361,14 @@ In this table, cells labeled "Unknown cell type" are those which `CellAssign` co
 In the processed result files, these cells are labeled `"other"`.
 ')
 create_celltype_n_table(celltype_df, cellassign_celltype_annotation) |>
+  format_datatable()
+```
+
+```{r, eval = has_scimilarity && (!has_consensus || is_supplemental)}
+knitr::asis_output("### `SCimilarity` annotations
+
+")
+create_celltype_n_table(celltype_df, scimilarity_celltype_annotation) |>
   format_datatable()
 ```
 
@@ -481,6 +519,27 @@ faceted_umap(
 )
 ```
 
+```{r}
+if (has_scimilarity & has_umap && (is_supplemental || !has_consensus)) {
+  scimilarity_n_celltypes <- length(levels(umap_df$scimilarity_celltype_annotation_lumped))
+  scimilarity_dims <- determine_umap_dimensions(scimilarity_n_celltypes)
+  knitr::asis_output("### `SCimilarity` annotations")
+} else {
+  # set fake dims for evaluating next chunk
+  scimilarity_dims <- c(1, 1)
+}
+```
+
+```{r, eval = has_scimilarity && has_umap && (is_supplemental || !has_consensus), message=FALSE, warning=FALSE, fig.width = scimilarity_dims[1], fig.height = scimilarity_dims[2], fig.align = "center"}
+# umap for cell assign annotations
+faceted_umap(
+  umap_df,
+  scimilarity_n_celltypes,
+  scimilarity_celltype_annotation_lumped,
+  point_size = umap_facet_point_size
+)
+```
+
 
 ```{r, eval=has_consensus}
 knitr::asis_output('
@@ -517,7 +576,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
-celltype_colors <- validation_palette_df |>
+celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
 
@@ -697,8 +756,8 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
 
 ```{r}
 # boolean for whether or not to include heatmaps comparing submitter or openscpca
-submitter_heatmaps <- (has_submitter & (has_consensus | has_cellassign | has_singler))
-openscpca_heatmaps <- (has_openscpca & (has_consensus | has_cellassign | has_singler))
+submitter_heatmaps <- (has_submitter & (has_consensus | has_cellassign | has_singler | has_scimilarity))
+openscpca_heatmaps <- (has_openscpca & (has_consensus | has_cellassign | has_singler | has_scimilarity))
 ```
 
 ```{r, eval= (submitter_heatmaps | openscpca_heatmaps) | (has_consensus & is_supplemental), results = 'asis'}
@@ -708,7 +767,7 @@ glue::glue(
 
   This section displays heatmaps comparing cell labels from various methods.
 
-  We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between         pairs of labels assigned by different annotation methods.
+  We use the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) to display the agreement between between pairs of labels assigned by different annotation methods.
 
   The Jaccard index reflects the degree of overlap between the two labels and ranges from 0 to 1.
 

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -70,13 +70,14 @@ processed_sce <- params$processed_sce
 # check for annotation methods
 has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
 has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
+has_scimilarity <- "scimilarity" %in% metadata(processed_sce)$celltype_methods
 has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
 has_openscpca <- "openscpca" %in% metadata(processed_sce)$celltype_methods
 has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
   !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
 # If at least 1 is present, we have cell type annotations.
-has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter, has_openscpca)
+has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
 # check for umap and clusters
 has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
@@ -88,6 +89,7 @@ available_celltypes <- c(
   ifelse(has_openscpca, "OpenScPCA", NA),
   ifelse(has_singler, "SingleR", NA),
   ifelse(has_cellassign, "CellAssign", NA),
+  ifelse(has_scimilarity, "SCimilarity", NA),
   ifelse(has_consensus, "Consensus", NA)
 ) |>
   na.omit() |>
@@ -99,6 +101,8 @@ cellassign_not_run <- check_cellassign_not_run(
   colData(processed_sce)
 )
 
+# vector of automated celltypes to include in comparison, including consensus
+automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
 
 # check for validation group info if consensus cell types are present
 if (has_consensus) {
@@ -206,6 +210,13 @@ if (has_cellassign) {
   )
 }
 
+if (has_scimilarity) {
+  methods_text <- glue::glue(
+    "{methods_text}
+    * Annotations from [`SCimilarity`](https://genentech.github.io/scimilarity/index.html), which uses a foundational model to assign cell types ([Heimberg _et al._ 2024](https://doi.org/10.1038/s41586-024-08411-y)).\n"
+  )
+}
+
 if (has_consensus) {
   methods_text <- glue::glue(
     "{methods_text}
@@ -261,9 +272,6 @@ if (!has_multiplex) {
 
 <!-------------------------- OpenScPCA heatmaps ------------------------------->
 ```{r, eval = openscpca_heatmaps}
-# don't compare to openscpca or submitter
-automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
-
 knitr::asis_output(
   "## OpenScPCA annotations
 
@@ -311,9 +319,6 @@ jaccard_openscpca_matrices |>
 
 <!-------------------------- Submitter heatmaps ------------------------------->
 ```{r, eval = submitter_heatmaps}
-# don't compare submitter to submitter
-automated_celltypes_available <- available_celltypes[!(available_celltypes %in% c("Submitter", "OpenScPCA"))]
-
 knitr::asis_output(
   "## Submitter-provided annotations
 
@@ -361,7 +366,6 @@ jaccard_submitter_matrices |>
 
 
 <!---------------------- consensus cell type heatmap  -------------------------->
-<!--TODO: Update with SCimilarity as additional panel --> 
 ```{r, eval = has_consensus, fig.height=7, fig.width=8}
 knitr::asis_output("
 ## Automated annotations
@@ -372,12 +376,11 @@ Note that due to different annotations references, these methods may use differe
 ```
 
 ```{r, eval = has_consensus}
-# having consensus celltypes implies that both SingleR and CellAssign exist
-# TODO: Update to handle adding in SCimilarity
-automated_celltypes <- c("SingleR", "CellAssign")
+# celltypes used to generate consensus, all automated - consensus
+consensus_input_celltypes <- automated_celltypes_available[!(automated_celltypes_available == "Consensus")]
 
 # calculate matrices comparing to consensus
-jaccard_consensus_matrices <- automated_celltypes |>
+jaccard_consensus_matrices <- consensus_input_celltypes |>
   stringr::str_to_lower() |>
   purrr::map(\(name) {
     make_jaccard_matrix(
@@ -386,7 +389,7 @@ jaccard_consensus_matrices <- automated_celltypes |>
       glue::glue("{name}_celltype_annotation")
     )
   }) |>
-  purrr::set_names(automated_celltypes)
+  purrr::set_names(consensus_input_celltypes)
 
 # how many cell types?
 all_celltypes <- jaccard_consensus_matrices |>

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -139,12 +139,13 @@ if (has_processed) {
   has_consensus <- "consensus_celltype_annotation" %in% names(colData(processed_sce))
   has_singler <- "singler" %in% metadata(processed_sce)$celltype_methods
   has_cellassign <- "cellassign" %in% metadata(processed_sce)$celltype_methods
+  has_scimilarity <- "scimilarity" %in% metadata(processed_sce)$celltype_methods
   has_openscpca <- "openscpca" %in% metadata(processed_sce)$celltype_methods
   has_submitter <- "submitter" %in% metadata(processed_sce)$celltype_methods &&
     !all(is.na(processed_sce$submitter_celltype_annotation)) # make sure they aren't all NA
 
   # If at least 1 is present, we have cell type annotations.
-  has_celltypes <- any(has_singler, has_cellassign, has_consensus, has_submitter, has_openscpca)
+  has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
   # Determine inferCNV condition and include one check while we're in this if
   # define these with FALSE baseline, to be overridden if present
@@ -172,6 +173,7 @@ if (has_processed) {
   has_consensus <- FALSE
   has_singler <- FALSE
   has_cellassign <- FALSE
+  has_scimilarity <- FALSE
   has_openscpca <- FALSE
   has_submitter <- FALSE
   has_celltypes <- FALSE
@@ -181,7 +183,7 @@ if (has_processed) {
 
 
 # check for celltypes_report if celltypes are present
-if ((has_consensus | has_singler | has_cellassign) & is.null(params$celltype_report)) {
+if ((has_consensus | has_singler | has_cellassign | has_scimilarity) & is.null(params$celltype_report)) {
   stop("Cell type annotations were provided but the parameter specifying the cell type report file is missing.")
 }
 

--- a/templates/qc_report/utils/celltype_functions.rmd
+++ b/templates/qc_report/utils/celltype_functions.rmd
@@ -37,6 +37,7 @@ create_celltype_df <- function(processed_sce) {
       contains("consensus"),
       contains("singler"),
       contains("cellassign"),
+      contains("scimilarity"),
       contains("openscpca", ),
       contains("submitter")
     )
@@ -60,6 +61,12 @@ create_celltype_df <- function(processed_sce) {
     celltype_df <- prepare_automated_annotation_values(
       celltype_df,
       cellassign_celltype_annotation
+    )
+  }
+  if ("scimilarity_celltype_annotation" %in% names(celltype_df)) {
+    celltype_df <- prepare_automated_annotation_values(
+      celltype_df,
+      scimilarity_celltype_annotation
     )
   }
 


### PR DESCRIPTION
Stacked on #1048 
Towards #1031 

This PR adds in SCimilarity annotations to the existing plots in the main and supplemental cell type report. This includes the tables and UMAPs and ensures that SCimilarity is included when comparing automated annotations to consensus and to openscpca/submitter annotations. 

Part of this also accounts for the fact that consensus cell types can be assigned if not all three methods are present. So I had to do a little bit of wrangling with text formatting to account for that in the descriptions of the plots. 

Outside of that, this was pretty straightforward. I still want to add a section that looks at the metrics (min_dist) for these annotations, but I'm going to work on that as a separate PR. 

Here's a version of the main and supplemental report with SCimilarity added in: 
[celltypes_supplemental_report.html.zip](https://github.com/user-attachments/files/22754063/celltypes_supplemental_report.html.zip)
[main_qc_report.html.zip](https://github.com/user-attachments/files/22754064/main_qc_report.html.zip)
