### PR TITLE
Fix coltypes behavior

### DIFF
--- a/bin/format_unfiltered_sce.R
+++ b/bin/format_unfiltered_sce.R
@@ -75,9 +75,8 @@ sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 sample_metadata_df <- readr::read_tsv(
   opt$sample_metadata_file,
   # read all columns as character except:
-  # - is_cell_line and is_xenograft should be logical
-  # - age should be double
-  col_types = readr::cols(is_cell_line = "l", is_xenograft = "l", age = "d", .default = "c")
+  # is_cell_line and is_xenograft should be logical
+  col_types = readr::cols(is_cell_line = "l", is_xenograft = "l", .default = "c")
 ) |>
   # rename sample id column
   dplyr::rename("sample_id" = "scpca_sample_id") |>

--- a/bin/format_unfiltered_sce.R
+++ b/bin/format_unfiltered_sce.R
@@ -72,7 +72,13 @@ if (file.exists(opt$mito_file)) {
 sample_ids <- unlist(stringr::str_split(opt$sample_id, ",|;")) |> sort()
 
 # read in sample metadata
-sample_metadata_df <- readr::read_tsv(opt$sample_metadata_file, col_types = "c") |>
+sample_metadata_df <- readr::read_tsv(
+  opt$sample_metadata_file,
+  # read all columns as character except:
+  # - is_cell_line and is_xenograft should be logical
+  # - age should be double
+  col_types = readr::cols(is_cell_line = "l", is_xenograft = "l", age = "d", .default = "c")
+) |>
   # rename sample id column
   dplyr::rename("sample_id" = "scpca_sample_id") |>
   # add library ID as column in sample metadata


### PR DESCRIPTION
Closes #926

This is a short and sweet PR to fix the bug in defining column types when we read in sample metadata; it was not properly defining all columns as character, only the first column. Really though, want we want is _most_ columns to be character. Based on discussion in #926, I've updated this code (though it's now in a different script from when that issue was opened because 10xflex!) to set the default columns to character, but override the logicals (`is_*` and double (`age`) columns. 

In the final processed objects, we end now up with these specifications:

```
> metadata(sce)$sample_metadata |> tibble::as_tibble()
# A tibble: 1 × 22
  sample_id   scpca_project_id submitter_id participant_id submitter         age
  <chr>       <chr>            <chr>        <chr>          <chr>           <dbl>
1 SCPCS000001 SCPCP000001      834          834            green_mulcahy_…    14
# ℹ 16 more variables: age_timing <chr>, sex <chr>, diagnosis <chr>,
#   subdiagnosis <chr>, tissue_location <chr>, disease_timing <chr>,
#   organism <chr>, is_xenograft <lgl>, is_cell_line <lgl>,
#   development_stage_ontology_term_id <chr>, sex_ontology_term_id <chr>,
#   organism_ontology_id <chr>, self_reported_ethnicity_ontology_term_id <chr>,
#   disease_ontology_term_id <chr>, tissue_ontology_term_id <chr>,
#   library_id <chr>
```

You can see in there, `age` is `<dbl>` and we have `is_xenograft <lgl>, is_cell_line <lgl>,`.

(Note, there's also this sort-of-but-not-totally-related PR nextdoor, where I'm making sure logical columns stay logical when merging: https://github.com/AlexsLemonade/scpcaTools/pull/327, just fyi).