### PR TITLE
Add inferCNV meta json and update checkpointing

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -109,14 +109,14 @@ option_list <- list(
     type = "character",
     help = "Path to write number of calculated inferCNV reference cells to.
       This calculation is only performed if `diagnosis_celltype_ref`, `diagnosis_groups_ref`, and `consensus_validation_ref` are provided.
-      If not calculated, this file will be created with the value NA instead of a count",
+      If not calculated, this file will be empty",
     default = "reference_cell_count.txt"
   ),
   make_option(
     opt_str = c("--reference_cell_hash_file"),
     type = "character",
     help = "Path to write out unique hash for all concatenated barcodes in reference cell set; used for checkpointing.
-      If not calculated, this file will be created with the value NA instead of a hash",
+      If not calculated, this file will be empty",
     default = "reference_cell_hash.txt"
   )
 )
@@ -167,8 +167,8 @@ stopifnot(
 sce <- readr::read_rds(opt$input_sce_file)
 
 # We'll count inferCNV reference cells when assigning consensus cell types
-reference_cell_count <- NA_integer_
-reference_cell_hash <- NA_character_
+reference_cell_count <- ""
+reference_cell_hash <- ""
 
 # set automated methods list
 # we'll use this to assign consensus and add cell type methods to the metadata
@@ -533,7 +533,7 @@ if (assign_consensus) {
       sort(sce$barcodes[sce$is_infercnv_reference]),
       collapse = ""
     )
-    reference_cell_hash <- digest::digest(concat_barcodes, algo = "sha256")
+    reference_cell_hash <- digest::digest(concat_barcodes)
   }
 }
 
@@ -541,5 +541,5 @@ if (assign_consensus) {
 readr::write_rds(sce, opt$output_sce_file, compress = "bz2")
 
 # export normal cell count and hash
-readr::write_lines(reference_cell_count, opt$reference_cell_count_file)
-readr::write_lines(reference_cell_hash, opt$reference_cell_hash_file)
+readr::write_file(reference_cell_count, opt$reference_cell_count_file)
+readr::write_file(reference_cell_hash, opt$reference_cell_hash_file)

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -528,9 +528,9 @@ if (assign_consensus) {
     # get the full count
     reference_cell_count <- sum(sce$is_infercnv_reference)
 
-    # get hash for concatenated barcodes
+    # get hash for sorted concatenated barcodes
     concat_barcodes <- paste(
-      sce$barcodes[sce$is_infercnv_reference],
+      sort(sce$barcodes[sce$is_infercnv_reference]),
       collapse = ""
     )
     reference_cell_hash <- digest::digest(concat_barcodes, algo = "sha256")

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -525,8 +525,8 @@ if (assign_consensus) {
     metadata(sce)$infercnv_reference_celltypes <- ref_df$consensus_annotation # vector of reference cell types
     sce$is_infercnv_reference <- sce$consensus_celltype_ontology %in% ref_df$consensus_ontology # boolean
 
-    # get the full count
-    reference_cell_count <- sum(sce$is_infercnv_reference)
+    # get the full count; store as character for writing to file
+    reference_cell_count <- as.character(sum(sce$is_infercnv_reference))
 
     # get hash for sorted concatenated barcodes
     concat_barcodes <- paste(

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -13,7 +13,10 @@ process run_infercnv {
   input:
     tuple val(meta), path(processed_rds), path(infercnv_gene_order)
   output:
-    tuple val(meta), path(processed_rds), path(results_file), path(table_file), path(heatmap_file), path(meta_json_file)
+    tuple val(meta),
+    path(processed_rds),
+    path(results_file), path(table_file), path(heatmap_file),
+    path(meta_json_file)
   script:
     results_file="${meta.unique_id}_infercnv-results.rds"
     table_file="${meta.unique_id}_infercnv-table.txt"

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -3,9 +3,9 @@
 process run_infercnv {
   container params.SCPCATOOLS_INFERCNV_CONTAINER
   publishDir (
-    path: "${meta.infercnv_dir}",
+    path: "${meta.infercnv_checkpoints_dir}",
     mode: 'copy',
-    pattern: "${meta.unique_id}_infercnv-*"
+    pattern: "{${meta.unique_id}_infercnv-*,scpca-meta.json}"
   )
   label 'mem_96'
   label 'cpus_8'
@@ -13,17 +13,20 @@ process run_infercnv {
   input:
     tuple val(meta), path(processed_rds), path(infercnv_gene_order)
   output:
-    tuple val(meta), path(processed_rds), path(results_file), path(table_file), path(heatmap_file)
+    tuple val(meta), path(processed_rds), path(results_file), path(table_file), path(heatmap_file), path(meta_json_file)
   script:
     results_file="${meta.unique_id}_infercnv-results.rds"
     table_file="${meta.unique_id}_infercnv-table.txt"
     heatmap_file="${meta.unique_id}_infercnv-heatmap.png"
+    meta_json_file="scpca-meta.json"
 
-    meta += Utils.getVersions(workflow, nextflow) // why?
     meta_json = Utils.makeJson(meta)
     """
-    # note that inferCNV fails, the script will output empty results/heatmap files
-    mkdir infercnv_tmp
+
+    # Create directories
+    mkdir -p ${meta.infercnv_checkpoints_dir} # infercnv checkpoints dir exists
+    mkdir infercnv_tmp # temporary directory for infercnv intermediate files
+
     run_infercnv.R \
       --input_sce_file ${processed_rds} \
       --output_rds ${results_file} \
@@ -35,7 +38,7 @@ process run_infercnv {
       ${params.seed ? "--random_seed ${params.seed}" : ""}
 
     # write out meta file
-    echo '${meta_json}' > "${meta.infercnv_dir}/scpca-meta.json"
+    echo '${meta_json}' > "${meta_json_file}"
     """
   stub:
     results_file="${meta.unique_id}_infercnv-results.rds"
@@ -46,7 +49,7 @@ process run_infercnv {
     touch "${results_file}"
     touch "${table_file}"
     touch "${heatmap_file}"
-    echo '${meta_json}' > "${singler_dir}/scpca-meta.json"
+    echo '${meta_json}' > "${meta_json_file}"
     """
 }
 
@@ -99,10 +102,10 @@ workflow call_cnvs {
       .map{ meta_in, _unfiltered_sce, _filtered_sce, processed_sce ->
         def meta = meta_in.clone(); // local copy for safe modification
         // define infercnv checkpoint files
-        meta.infercnv_dir = "${params.checkpoints_dir}/infercnv/${meta.unique_id}";
-        meta.infercnv_heatmap_file = "${meta.infercnv_dir}/${meta.unique_id}_infercnv-heatmap.png";
-        meta.infercnv_results_file = "${meta.infercnv_dir}/${meta.unique_id}_infercnv-results.rds";
-        meta.infercnv_table_file = "${meta.infercnv_dir}/${meta.unique_id}_infercnv-table.txt";
+        meta.infercnv_checkpoints_dir = "${params.checkpoints_dir}/infercnv/${meta.unique_id}";
+        meta.infercnv_heatmap_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-heatmap.png";
+        meta.infercnv_results_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-results.rds";
+        meta.infercnv_table_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-table.txt";
         // if meta.infercnv_reference_cell_count doesn't exist, set it to null
         // this happens when perform_celltyping is on but a library has no cell type references
         meta.infercnv_reference_cell_count = meta.infercnv_reference_cell_count ?: null;
@@ -122,12 +125,11 @@ workflow call_cnvs {
           && file(it[0].infercnv_heatmap_file).exists()
           && file(it[0].infercnv_results_file).exists()
           && file(it[0].infercnv_table_file).exists()
-          && Utils.getMetaVal(file("${it[0].infercnv_dir}/scpca-meta.json"), "infercnv_reference_cell_hash") == "${it[0].infercnv_reference_cell_hash}"
+          && Utils.getMetaVal(file("${it[0].infercnv_checkpoints_dir}/scpca-meta.json"), "infercnv_reference_cell_hash") == "${it[0].infercnv_reference_cell_hash}"
         ) || it[0]["infercnv_reference_cell_count"] < params.infercnv_min_reference_cells
         )
         run_infercnv: true
       }
-
 
     // run inferCNV
     // outputs: [meta, processed sce, results file, table file, heatmap file]
@@ -139,7 +141,7 @@ workflow call_cnvs {
         def infercnv_results = file(meta.infercnv_results_file)
         def infercnv_table   = file(meta.infercnv_table_file)
         def infercnv_heatmap = file(meta.infercnv_heatmap_file)
-        // ensure the infercnv_dir exists before proceeding; all these files are in the same dir
+        // ensure the infercnv_checkpoints_dir exists before proceeding; all these files are in the same dir
         infercnv_results.parent.mkdirs()
         // create empty files if they don't exist
         // https://www.nextflow.io/docs/latest/working-with-files.html#reading-and-writing-an-entire-file
@@ -149,7 +151,13 @@ workflow call_cnvs {
         // return simplified input with gene order file
         [meta, processed_sce, infercnv_results, infercnv_table, infercnv_heatmap]
       }
-      .mix(run_infercnv.out)
+      .mix(
+        // drop the meta json file
+        run_infercnv.out
+          .map{ meta, processed_sce, results_file, table_file, heatmap_file, _meta_json_file ->
+            [meta, processed_sce, results_file, table_file, heatmap_file]
+          }
+      )
 
 
     // add inferCNV results to the SCE object

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -25,11 +25,8 @@ process run_infercnv {
 
     meta_json = Utils.makeJson(meta)
     """
-
-    # Create directories
-    mkdir -p ${meta.infercnv_checkpoints_dir} # infercnv checkpoints dir exists
-    mkdir infercnv_tmp # temporary directory for infercnv intermediate files
-
+    # note that inferCNV fails, the script will output empty results/heatmap files
+    mkdir infercnv_tmp
     run_infercnv.R \
       --input_sce_file ${processed_rds} \
       --output_rds ${results_file} \

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -112,7 +112,7 @@ workflow call_cnvs {
 
 
     // branch to skip libraries when either:
-    // - repeat is off and there are existing results
+    // - repeat is off and there are unchanged existing results
     // - there are not enough normal reference cells
     infercnv_input_ch = infercnv_prepared_ch
       .branch{

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -25,7 +25,7 @@ process run_infercnv {
 
     meta_json = Utils.makeJson(meta)
     """
-    # note that inferCNV fails, the script will output empty results/heatmap files
+    # note that if inferCNV fails, the script will output empty results/heatmap files
     mkdir infercnv_tmp
     run_infercnv.R \
       --input_sce_file ${processed_rds} \

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -437,8 +437,8 @@ workflow annotate_celltypes {
     added_celltypes_ch = add_celltypes_to_sce.out
       .map{ meta_in, annotated_sce, cell_count, cell_hash ->
         def meta = meta_in.clone(); // local copy for safe modification
-        // ensure the count is saved as an integer: either the integer value, or null if it was an empty string since
-        // we can do future math comparisons with null
+        // ensure the count is saved as an integer: either the integer value, or null if it was an
+        // empty string since we can do future math comparisons with null
         meta.infercnv_reference_cell_count = cell_count ? cell_count.toInteger() : null;
         meta.infercnv_reference_cell_hash = cell_hash;
         // return only meta and annotated_sce

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -206,7 +206,7 @@ process add_celltypes_to_sce {
 
     # Set to a value guaranteed to pass the threshold and run
     REFERENCE_CELL_COUNT=${params.infercnv_min_reference_cells + 1}
-    REFERENCE_CELL_HASH="NA"
+    REFERENCE_CELL_HASH=""
     """
 }
 
@@ -437,10 +437,10 @@ workflow annotate_celltypes {
     added_celltypes_ch = add_celltypes_to_sce.out
       .map{ meta_in, annotated_sce, cell_count, cell_hash ->
         def meta = meta_in.clone(); // local copy for safe modification
-        // ensure the count is saved as an integer: either the integer value, or null if it was NA since
-        // we can do future math comparisons with null but not with NA
-        meta.infercnv_reference_cell_count = Utils.parseNA(cell_count) == "" ? null : cell_count.toInteger();
-        meta.infercnv_reference_cell_hash = Utils.parseNA(cell_hash);
+        // ensure the count is saved as an integer: either the integer value, or null if it was an empty string since
+        // we can do future math comparisons with null
+        meta.infercnv_reference_cell_count = cell_count ? cell_count.toInteger() : null;
+        meta.infercnv_reference_cell_hash = cell_hash;
         // return only meta and annotated_sce
         [meta, annotated_sce]
       }

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -169,7 +169,7 @@ process add_celltypes_to_sce {
     path(diagnosis_celltypes_file) // maps broad diagnoses to cell type groups, for counting normal reference cells
     path(diagnosis_groups_file) // maps broad diagnoses to cell type groups, for counting normal reference cells
   output:
-    tuple val(meta), path(annotated_rds), env("REFERENCE_CELL_COUNT")
+    tuple val(meta), path(annotated_rds), env("REFERENCE_CELL_COUNT"), env("REFERENCE_CELL_HASH")
   script:
     annotated_rds = "${meta.library_id}_processed_annotated.rds"
     def singler_results = singler_dir ? "${singler_dir}/singler_results.rds": ""
@@ -192,18 +192,21 @@ process add_celltypes_to_sce {
       --consensus_validation_ref "${validation_ref_file}" \
       --diagnosis_celltype_ref "${diagnosis_celltypes_file}" \
       --diagnosis_groups_ref "${diagnosis_groups_file}" \
-      --reference_cell_count_file "reference_cell_count.txt"
+      --reference_cell_count_file "reference_cell_count.txt" \
+      --reference_cell_hash_file "reference_cell_hash.txt" \
 
       # save so we can export as environment variable
       REFERENCE_CELL_COUNT=\$(cat "reference_cell_count.txt")
+      REFERENCE_CELL_HASH=\$(cat "reference_cell_hash.txt")
     """
   stub:
     annotated_rds = "${meta.library_id}_processed_annotated.rds"
     """
     touch ${annotated_rds}
 
-    # Set to a value guaranteed to pass the threshold
+    # Set to a value guaranteed to pass the threshold and run
     REFERENCE_CELL_COUNT=${params.infercnv_min_reference_cells + 1}
+    REFERENCE_CELL_HASH="NA"
     """
 }
 
@@ -254,7 +257,7 @@ workflow annotate_celltypes {
       // add values to meta for later use
       .map{ _project_id, meta_in, processed_sce, singler_model_file, cellassign_reference_file ->
         def meta = meta_in.clone(); // local copy for safe modification
-        // results directories 
+        // results directories
         meta.celltype_checkpoints_dir = "${params.checkpoints_dir}/celltype/${meta.library_id}";
         meta.singler_dir = "${meta.celltype_checkpoints_dir}/${meta.unique_id}_singler";
         meta.cellassign_dir = "${meta.celltype_checkpoints_dir}/${meta.unique_id}_cellassign";
@@ -264,7 +267,7 @@ workflow annotate_celltypes {
         meta.cellassign_reference_file = cellassign_reference_file;
         meta.scimilarity_model_dir = params.scimilarity_model_dir;
         meta.scimilarity_ontology_map_file = params.scimilarity_ontology_map_file;
-        // output files 
+        // output files
         meta.singler_results_file = "${meta.singler_dir}/singler_results.rds";
         meta.cellassign_predictions_file = "${meta.cellassign_dir}/cellassign_predictions.tsv";
         meta.scimilarity_predictions_file = "${meta.scimilarity_dir}/scimilarity_predictions.tsv";
@@ -298,7 +301,7 @@ workflow annotate_celltypes {
     // singleR output channel: [unique id, singler_results]
     singler_output_ch = singler_input_ch.skip_singler
       // provide existing singler results dir for those we skipped
-      .map{ meta, _processed_sce, _singler_model -> 
+      .map{ meta, _processed_sce, _singler_model ->
         tuple(
           meta.unique_id,
           file(meta.singler_dir, type: 'dir', checkIfExists: true)
@@ -339,7 +342,7 @@ workflow annotate_celltypes {
     // cellassign output channel: [unique id, cellassign_dir]
     cellassign_output_ch = cellassign_input_ch.skip_cellassign
       // provide existing cellassign predictions dir for those we skipped
-      .map{ meta, _processed_sce, _cellassign_ref -> 
+      .map{ meta, _processed_sce, _cellassign_ref ->
         tuple(
           meta.unique_id,
           file(meta.cellassign_dir, type: 'dir', checkIfExists: true)
@@ -358,15 +361,15 @@ workflow annotate_celltypes {
     // create scimilarity input channel: [meta, processed sce, scimilarity dir, ontology map]
     scimilarity_input_ch = celltype_input_ch
       // add in cellassign references
-      .map{meta, processed_sce -> 
-        [ 
-          meta, 
+      .map{meta, processed_sce ->
+        [
+          meta,
           processed_sce,
           file(meta.scimilarity_model_dir, type: 'dir', checkIfExists: true),
           file(meta.scimilarity_ontology_map_file, checkIfExists: true)
         ]
       }
-      // skip if scimilarity results exist and path to the model has not changed 
+      // skip if scimilarity results exist and path to the model has not changed
       .branch{
         skip_scimilarity: (
           !params.repeat_celltyping
@@ -383,7 +386,7 @@ workflow annotate_celltypes {
     // scimilarity output channel: [unique id, scimilarity_dir]
     scimilarity_output_ch = scimilarity_input_ch.skip_scimilarity
       // provide existing scimilarity predictions dir for those we skipped
-      .map{ meta, _processed_sce, _scimilarity_model_dir, _scimilarity_ontology_map_file -> 
+      .map{ meta, _processed_sce, _scimilarity_model_dir, _scimilarity_ontology_map_file ->
         tuple(
           meta.unique_id,
           file(meta.scimilarity_dir, type: 'dir', checkIfExists: true)
@@ -432,10 +435,12 @@ workflow annotate_celltypes {
 
     // add inferCNV logic to meta
     added_celltypes_ch = add_celltypes_to_sce.out
-      .map{ meta_in, annotated_sce, cell_count ->
+      .map{ meta_in, annotated_sce, cell_count, cell_hash ->
         def meta = meta_in.clone(); // local copy for safe modification
-        // ensure it's saved as an integer: either the integer value, or null if it was NA
+        // ensure the count is saved as an integer: either the integer value, or null if it was NA since
+        // we can do future math comparisons with null but not with NA
         meta.infercnv_reference_cell_count = Utils.parseNA(cell_count) == "" ? null : cell_count.toInteger();
+        meta.infercnv_reference_cell_hash = Utils.parseNA(cell_hash);
         // return only meta and annotated_sce
         [meta, annotated_sce]
       }
@@ -449,11 +454,9 @@ workflow annotate_celltypes {
 
     // add back in the unchanged sce files to the results
     export_channel = celltyped_ch
-      .map{meta, processed_sce -> tuple(
-        meta.unique_id,
-        meta,
-        processed_sce
-        )}
+      .map{meta, processed_sce ->
+        [meta.unique_id, meta, processed_sce]
+      }
       // add in unfiltered and filtered sce files, for tissue samples only
       .join(
         sce_files_channel_branched.tissue.map{[it[0]["unique_id"], it[1], it[2]]},


### PR DESCRIPTION
Closes #1039 

This PR updates the inferCNV bits as follows:
- Save a hash for the sorted/collapsed barcodes to meta for comparing to the checkpoint. This is pretty analogous to the existing code that saves the reference cell count
- When branching for skip vs. run inferCNV, include the hash comparison in the logic
- Save meta as a json in the `run_infercnv` process
  - Note that I have to output this file to ensure it's actually published, but I drop it immediately. Let me know if you prefer a different file management strategy here
- One recreational change, renaming `infercnv_dir` to `infercnv_checkpoints_dir`; it's longer (which is why I originally didn't use it), but I think it's better to be explicit especially if we're writing checkpoint jsons now. 

I've tested this and it seems to behave as expected! Doesn't repeat when the hash matches, repeats when the hash has changed.