### PR TITLE
Add token permission for AWS ECR

### DIFF
--- a/.github/workflows/docker_cellbrowser.yaml
+++ b/.github/workflows/docker_cellbrowser.yaml
@@ -58,6 +58,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
Trying to fix the error I got with https://github.com/AlexsLemonade/scpca-nf/actions/runs/18730009327/job/53424447553

Add id-token write permissions