### PR TITLE
Fix merge bugs I introduced and address remaining def patterns

### DIFF
--- a/build-cellbrowser.nf
+++ b/build-cellbrowser.nf
@@ -69,7 +69,7 @@ workflow {
     }
     .unique{ it.library_id }
     .map{ meta ->
-      def h5ad_file = file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed_rna.h5ad")
+      def h5ad_file = file("${params.results_dir}/${meta.project_id}/${meta.sample_id}/${meta.library_id}_processed_rna.h5ad")
       [meta, h5ad_file]
     }
     // only include libraries where the h5ad file exists

--- a/build-cellbrowser.nf
+++ b/build-cellbrowser.nf
@@ -68,11 +68,9 @@ workflow {
       || (it.project_id in project_ids)
     }
     .unique{ it.library_id }
-    .map{ it ->
-      [
-        it, // meta
-        file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed_rna.h5ad")
-      ]
+    .map{ meta ->
+      def h5ad_file = file("${params.results_dir}/${it.project_id}/${it.sample_id}/${it.library_id}_processed_rna.h5ad")
+      [meta, h5ad_file]
     }
     // only include libraries where the h5ad file exists
     .filter{ it[1].exists() }

--- a/merge.nf
+++ b/merge.nf
@@ -208,7 +208,7 @@ workflow {
       [it.library_id, processed, meta_json ]
     }
     .subscribe{ library_id, processed, meta_json ->
-      if(!(processed.exists() && processed.size() > 0) && !(processed.exists() && library_id.startsWith("STUBL"))){
+      if(!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL")) )
         log.warn("Processed files do not exist for ${library_id}. This library will not be included in the merged object.")
       }
       else if(!(meta_json.exists() && meta_json.size() > 0)){

--- a/merge.nf
+++ b/merge.nf
@@ -208,7 +208,7 @@ workflow {
       [it.library_id, processed, meta_json ]
     }
     .subscribe{ library_id, processed, meta_json ->
-      if(!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL")) )
+      if(!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL")) ) {
         log.warn("Processed files do not exist for ${library_id}. This library will not be included in the merged object.")
       }
       else if(!(meta_json.exists() && meta_json.size() > 0)){

--- a/merge.nf
+++ b/merge.nf
@@ -208,13 +208,13 @@ workflow {
       [it.library_id, processed, meta_json ]
     }
     .subscribe{ library_id, processed, meta_json ->
-      if(!(processed.exists() && processed.size() > 0) || !(processed.exists() && library_id.starts_with("STUBL"))){
+      if(!(processed.exists() && processed.size() > 0) && !(processed.exists() && library_id.startsWith("STUBL"))){
         log.warn("Processed files do not exist for ${library_id}. This library will not be included in the merged object.")
       }
       else if(!(meta_json.exists() && meta_json.size() > 0)){
         log.warn("Metadata file does not exist for ${library_id}. This library will not be included in the merged object.")
       }
-      else if (Utils.getMetaVal(processed, "processed_cells") < 3){
+      else if (Utils.getMetaVal(meta_json, "processed_cells") < 3){
         log.warn("Library ${library_id} has fewer than 3 cells. This library will not be included in the merged object.")
       }
     }
@@ -243,7 +243,8 @@ workflow {
       [project_id, project_id in adt_projects.getVal(), library_id_list, sce_file_list]
     }
     .branch{ it ->
-      has_merge: file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds").exists() && params.reuse_merge
+      def merged_sce = file("${params.results_dir}/${it[0]}/merged/${it[0]}_merged.rds")
+      has_merge: merged_sce.exists() && params.reuse_merge
       make_merge: true
     }
 

--- a/merge.nf
+++ b/merge.nf
@@ -9,7 +9,7 @@ def check_parameters() {
   def param_error = false
 
   // check that at least one project has been provided
-  if(!params.project) {
+  if (!params.project) {
     log.error("At least one 'project' must be specified for merging.")
     param_error = true
   }
@@ -208,13 +208,13 @@ workflow {
       [it.library_id, processed, meta_json ]
     }
     .subscribe{ library_id, processed, meta_json ->
-      if(!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL")) ) {
+      if (!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL"))) {
         log.warn("Processed files do not exist for ${library_id}. This library will not be included in the merged object.")
       }
-      else if(!(meta_json.exists() && meta_json.size() > 0)){
+      else if (!(meta_json.exists() && meta_json.size() > 0)) {
         log.warn("Metadata file does not exist for ${library_id}. This library will not be included in the merged object.")
       }
-      else if (Utils.getMetaVal(meta_json, "processed_cells") < 3){
+      else if (Utils.getMetaVal(meta_json, "processed_cells") < 3) {
         log.warn("Library ${library_id} has fewer than 3 cells. This library will not be included in the merged object.")
       }
     }


### PR DESCRIPTION
Closes #1074 

This gets the remaining `def`s we should probably add in the top-level `.nf` files. Other spots should be taken care of in the open PRs. Please let me know if you see other spots in the top-level files to catch!


I also did some silly things with `merge.nf` that didn't get flagged but I am fixing them!
1. `starts_with` is R, not groovy which is `startsWith`
2. an `||` should have been `&&`
3. referenced wrong variable in one of the subscribes