### PR TITLE
Add ENV setting to Docker for Singularity

### DIFF
--- a/docker/cellbrowser/Dockerfile
+++ b/docker/cellbrowser/Dockerfile
@@ -21,6 +21,8 @@ WORKDIR /app
 COPY --from=build /app/.pixi/envs/default /app/.pixi/envs/default
 COPY --from=build /shell-hook.sh /shell-hook.sh
 
-ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]
+# ensure pixi environment is in PATH, as Singularity may not run ENTRYPOINT
+ENV PATH="/app/.pixi/envs/default/bin:${PATH}"
 
+ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]
 CMD ["bash"]


### PR DESCRIPTION
Following what we learned in https://github.com/AlexsLemonade/ews-nf/pull/82, I am here adding ENV setting to the pixi-based Cell Browser image to make sure that the image remains compatible with Singularity-based environments.