### PR TITLE
fix AWS ECR image naming to match GHCR

### DIFF
--- a/.github/workflows/docker_cellbrowser.yaml
+++ b/.github/workflows/docker_cellbrowser.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           images: |
             ${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/${{ env.IMAGE_NAME }}
-            ${{ env.AWS_REGISTRY }}/${{ env.AWS_PREFIX }}/${{ env.IMAGE_NAME }}
+            ${{ env.AWS_REGISTRY }}/${{ env.AWS_PREFIX }}/${{ env.GH_REGISTRY_USER }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{raw}}
             type=edge,branch=main

--- a/.github/workflows/docker_vireo-snp.yaml
+++ b/.github/workflows/docker_vireo-snp.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           images: |
             ${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/${{ env.IMAGE_NAME }}
-            ${{ env.AWS_REGISTRY }}/${{ env.AWS_PREFIX }}/${{ env.IMAGE_NAME }}
+            ${{ env.AWS_REGISTRY }}/${{ env.AWS_PREFIX }}/${{ env.GH_REGISTRY_USER }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{raw}}
             type=edge,branch=main


### PR DESCRIPTION
This is the same idea as https://github.com/AlexsLemonade/scpcaTools/pull/333, where I am fixing the ECR push naming to match what comes from ghcr.io