### PR TITLE
Don't quit on exit status 1

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -5,8 +5,7 @@ process {
   resourceLimits = [ cpus: 12, memory: 32.GB ]
   memory = {4.GB * task.attempt}
 
-  // don't retry if exit status is 1 (usually indicates a script error)
-  errorStrategy = { task.attempt < 3 && task.exitStatus != 1 ? 'retry' : 'finish' }
+  errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 2
   maxErrors = '-1'
 


### PR DESCRIPTION
We have learned that quitting when the exit code is 1 is no good and that sometimes OOM errors report as 1. 