### PR TITLE
Account for incompatible HVGs and cell line projects in metrics report

### DIFF
--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1093,8 +1093,8 @@ cluster_changes |>
 # use this to make sure cell types are actually present
 all_celltypes <- metrics_df |>
   dplyr::select(contains("celltypes")) |>
-  tidyr::pivot_longer(everything(), names_to = "celltype_method", values_to = "celltype") |>
-  dplyr::pull(celltype) |>
+  tidyr::pivot_longer(everything(), names_to = "celltype_method", values_to = "celltype_list") |>
+  dplyr::pull(celltype_list) |>
   unlist() |>
   na.omit()
 


### PR DESCRIPTION
I was working on generating the metrics report for all projects and found a few issues that need to be fixed. 

There were a few occasions where the number of HVGs were less than 2000 and the length of the total HVGS did not match between reference and comparison. This seems to happen for low quality libraries that have very few cells. This caused a failure to calculate the correlation, so I added a check for the length of the HVGs and then only compute correlation if they are equal. Otherwise, I report `NA` since we can't get a correlation. 

There was also an issue with the cell line projects where the list of celltypes were all just empty lists in the data frame. I added a check for cell types being present and then skip any cell type summaries if they are missing. 

I decided to generate one notebook per project since looking at all projects together seemed like a lot. With the changes here I'm able to generate a report for each project. 