### PR TITLE
Make sure reference checks are strings

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -157,7 +157,7 @@ workflow {
   ref_ch = channel.fromPath(params.ref_metadata)
     .splitCsv(header: true, sep: '\t')
     .map{ it ->
-      def reference_name = "${it.organism}.${it.assembly}.${it.version}"
+      def reference_name = "${it.organism}.${it.assembly}.${it.version}".toString()
       def ref_name_paths = ref_paths[reference_name]
       // return reference name & reference file paths for each organism
       // return this is as a map (dictionary) so we can refer to items by name
@@ -173,7 +173,7 @@ workflow {
       ]
     }
     // filter to only regenerate specified references
-    .filter{ build_all || it[0] in params.build_refs.tokenize(",") }
+    .filter{ build_all || it.ref_name in params.build_refs.tokenize(",") }
 
   // filter to relevant references and drop the boolean flags
   salmon_ref_ch = ref_ch


### PR DESCRIPTION
While investigating https://github.com/AlexsLemonade/scpca-nf/issues/1125, I found that the code for selecting a particular reference to rebuild was not working. It turns out this is because strings that contain variable interpolation in Groovy are not interpolated until they need to be converted to a normal string type, and retain a different class type so the `in` statement was never `true`. So here I am fixing that by forcing immediate interpolation with a class conversion. 
