### PR TITLE
remove use of existing output directory for Cell Browser

### DIFF
--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -44,7 +44,7 @@ process cellbrowser_library {
 }
 
 process cellbrowser_site {
-  container "${pullthroughContainer(params.cellbrowser_container, params.pullthrough_registry)}"
+  container "${params.CELLBROWSER_CONTAINER}"
   publishDir "${params.outdir}"
   input:
     tuple val(project_ids), path(library_dirs)


### PR DESCRIPTION
Reusing the output directory seems to have been causing some trouble, so we will try not doing that anymore. 

This will slow down minor rebuilds, so it might be nice to add part of this back in if we want to be able to run a single project at a time and have it added to or updated within the existing site. I think to do this we would need to add a staging step that removed any projects or libraries from the existing site directory before building, but that seems like it will require a lot more testing, so I went with the simpler solution for now. 