### PR TITLE
Add proxy config to aws batch settings

### DIFF
--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -23,4 +23,10 @@ process {
   withLabel: long_running {
     queue = { task.attempt < 2 ? 'scpca-nf-batch-default-queue' : 'scpca-nf-batch-priority-queue' }
   }
+  // pass proxy settings into containers
+  containerOptions ='-e HTTP_PROXY=http://172.24.1.10:3128' +
+    ' -e HTTPS_PROXY=http://172.24.1.10:3128' +
+    ' -e http_proxy=http://172.24.1.10:3128' +
+    ' -e https_proxy=http://172.24.1.10:3128' +
+    ' -e NO_PROXY=169.254.169.254,169.254.170.2,s3.amazonaws.com,.s3.amazonaws.com,s3.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,s3.eu-west-1.amazonaws.com,.s3.eu-west-1.amazonaws.com'
 }


### PR DESCRIPTION
Closes https://github.com/AlexsLemonade/scpca-nf-infra/issues/78 (though apparently that was already closed because `fix` is a keyword)

Here I am adding in the http proxy settings so that any requests from within the docker containers are properly handled on the ccdl infrastructure. I have tested this combined with those settings and it seems to work!