### PR TITLE
Refactor add_celltypes_to_sce inferCNV code

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -710,7 +710,7 @@ if (length(automated_methods) > 1) {
     opt$diagnosis_celltype_ref
   )
   # calculate if passing status
-  if (metadata(sce)$infercnv_status == "") {
+  if (metadata(sce)$infercnv_status == "feasible") {
     sce <- add_infercnv_reference_cells(
       sce,
       opt$consensus_validation_ref,


### PR DESCRIPTION
Towards #1127 

This PR takes the first steps of the linked issue to nail down inferCNV behavior:

1. I refactored the script, including getting inferCNV reference cell code into a function
2. I added a bunch of statuses for tracking conditions (keep reading!)
3. I added the associated environment variable to the nextflow code and got it into `meta`, but I'm not using it yet - that'll be in the next PR!

These are the `infercnv_status` values I currently have in the code - feedback appreciated! Please let me know if/where you think these can be tweaked.

| string                                  | meaning                                                                                                                                                                             |
| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| ""                                      | no problems were flagged; infercnv can proceed                                                                                                                                      |
| "no_diagnosis_celltype_reference"       | the broad diagnosis <-> cell type reference wasn't provided                                                                                                                         |
| "no_consensus"                          | no consensus cell types were generated                                                                                                                                              |
| "unknown_diagnosis"                     | no diagnosis was provided in the sample metadata                                                                                                                                    |
| "multiple_diagnoses_multiplexed"        | we have multiple diagnoses for multiplexed, but the diagnosis group file wasn't provided so we can't determine which group to get cell types for                                    |
| "multiple_diagnosis_groups_multiplexed" | we have multiple diagnosis _groups_ for multiplexed. this is sort of similar to "no_diagnosis_multiplexed", except a group mapping was provided and we still ended up with multiple |
| "unknown_diagnosis_group"               | the diagnosis in the sample metadata couldn't be mapped to a diagnosis group                                                                                                        |
| "skipped_non_cancerous"                 | the sample is normal, won't proceed.                                                                                                                                                |
| "unknown_reference_celltypes"           | the diagnosis group doesn't have associated cell types                                                                                                                              |

A couple notes on these:

- There is an edge that I do not currently account for. I went back and forth on this and ended up feeling it's more of an internal implementation detail and not worth reporting as a standalone situation. Please let me know if you disagree!
  - If the diagnosis mapping file (sample diagnosis <-> broad diagnosis) was not provided, this means we'll just assume the sample diagnosis is the broad diagnosis
  - If there are no cell types associated with that broad diagnosis, the code will give the status `"unknown_reference_celltypes"`. But, it's technically a different circumstance from the _broad diagnosis obtained via mapping the sample diagnosis_ not having associated cell types. Do you feel this reaches the level of needing its own flag?
- In addition, I have a TODO in there about the behavior for "non-cancerous." The code was a bit inconsistent on this previously, so now's a good time to lock it down (and in the docs next!)....
  - Currently, if it's not multiplexed and diagnosis is non-cancerous, don't run infercnv. Status is  `"skipped_non_cancerous"`
  - Currently (aka in this PR), if it IS multiplexed and e.g. we have 2 diagnosis: a cancer and a "non-cancerous," do NOT run infercnv. Status would be `"multiple_diagnosis_groups_multiplexed"`. This is the more conservative approach.
  - But, a different way to think about this is - if we have 2 diagnoses and one is "non-cancerous", then we could drop the non-cancerous and favor the other diagnosis and then indeed proceed to process that sample with inferCNV. This would be a more permissive approach. Let me know if you prefer the permissive approach here!

Finally, I've locally run and tested this in a bunch of ways and seems ok 🤞 