### PR TITLE
Shorten internal instructions to reference GHA

### DIFF
--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -19,6 +19,8 @@ The Data Lab will usually launch the `scpca-nf` workflows via GitHub Actions in 
 This is used to ensure that appropriate output locations and permissions are used.
 For details about those runs, see the [Data Processing README](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/data-processing-and-handoff/README.md)
 
+Note that you may want to take advantage of the "Additional Nextflow options` field to set any parameters that are not already integrated with the GitHub Actions there.
+
 
 ## Testing the workflow during development
 


### PR DESCRIPTION
Here I am removing the vast majority of the internal instructions, as they are not going to be the way we use this workflow internally any more. 

I mostly tried to reduce down to links to the instructions in the admin repo, as that is where I expect our internal instructions to be maintained, but I did leave a bit of extra comment for the main phases of development. Let me know if you think these changes are appropriate, or if you think there are places where I should have left more (or less!) detail.

closes #1121 