### PR TITLE
QC report updates

### DIFF
--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -6,7 +6,7 @@ innate lymphoid cell	#325A9B
 dendritic cell	#16FF32
 macrophage	#1C8356
 monocyte	#1CBE4F
-myeloid	#90AD1C
+myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
 stem cell	#F7E1A0
@@ -15,12 +15,18 @@ chondrocyte	#B00068
 endothelial cell	#FC1CBF
 epithelial cell	#C075A6
 fibroblast	#B10DA1
-melanocyte	#FE00FA
+myofibroblast cell	#FE00FA
 muscle cell	#F6222E
 pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
-mesangial cell	#E2E2E2
+mesangial cell	#CCD2D8
 unknown	#E5E5E5
+pigment cell	#5A1A00
+kidney cell	#8A8F6A
+endocrine cell	#FF7A00
+embryonic cell (metazoa)	#CEC3B2
+ciliated cell	#00B3B3
+cardiocyte	#7A0019

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -23,7 +23,7 @@ neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
 mesangial cell	#CCD2D8
-unknown	#E5E5E5
+Unknown cell type	#E5E5E5
 pigment cell	#5A1A00
 kidney cell	#8A8F6A
 endocrine cell	#FF7A00

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -591,7 +591,7 @@ The dot plot shows the mean expression and percent of cells expressing the marke
 The y-axis includes marker genes for each cell type.
 Marker genes were obtained from the list of Human cell markers on [`CellMarker2.0`](http://www.bio-bigdata.center/CellMarker_download.html).
 All marker genes shown are specific to a single cell type, with the exception of hematopoietic precursor cells, if present, which express genes found in other, more differentiated immune cells.
-Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown. 
+Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown.
 
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
@@ -616,7 +616,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
-# any cell types missing from the palette should be excluded from the dotplot 
+# any cell types missing from the palette should be excluded from the dotplot
 celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
@@ -694,7 +694,7 @@ group_stats_df <- consensus_df |>
   # this includes all possible marker genes and all possible validation group assignments
   dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
   dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
-  # to be safe, ensure we're only retaining cell type group we have colors for 
+  # to be safe, ensure we're only retaining cell type group we have colors for
   dplyr::filter(broad_celltype_group %in% names(celltype_colors)) |>
   dplyr::mutate(
     # get total percent expressed
@@ -752,7 +752,7 @@ n_markers <- length(unique(dotplot_df$gene_symbol))
 n_celltypes <- length(unique(dotplot_df$broad_celltype_group))
 
 dotplot_height <- 8
-dotplot_width <- 15 
+dotplot_width <- 15
 dotplot_text_size <- 14
 
 # update default sizing if we have a lot of info in the plot
@@ -762,7 +762,7 @@ if (n_markers >= 50) {
   dotplot_text_size <- 18
 } else if (n_celltypes >= 20) {
   dotplot_height <- dotplot_height * 1.25
-} 
+}
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -663,7 +663,7 @@ consensus_df <- celltype_df |>
   dplyr::mutate(
     broad_celltype_group = dplyr::if_else(
       is.na(broad_celltype_group),
-      "Unknown cell type", # match rest of report text
+      "Unknown cell type", # match rest of report text; also must match the unknown label in the palette
       broad_celltype_group
     )
   )

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -591,6 +591,7 @@ The dot plot shows the mean expression and percent of cells expressing the marke
 The y-axis includes marker genes for each cell type.
 Marker genes were obtained from the list of Human cell markers on [`CellMarker2.0`](http://www.bio-bigdata.center/CellMarker_download.html).
 All marker genes shown are specific to a single cell type, with the exception of hematopoietic precursor cells, if present, which express genes found in other, more differentiated immune cells.
+Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown. 
 
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
@@ -662,7 +663,7 @@ consensus_df <- celltype_df |>
   dplyr::mutate(
     broad_celltype_group = dplyr::if_else(
       is.na(broad_celltype_group),
-      "unknown",
+      "Unknown cell type", # match rest of report text
       broad_celltype_group
     )
   )
@@ -746,7 +747,27 @@ dotplot_df <- group_stats_df |>
 ```
 
 
-```{r, eval = has_consensus, fig.height = 7, fig.width = 15}
+```{r, eval = has_consensus}
+n_markers <- length(unique(dotplot_df$gene_symbol))
+n_celltypes <- length(unique(dotplot_df$broad_celltype_group))
+
+dotplot_height <- 8
+dotplot_width <- 15 
+dotplot_text_size <- 14
+
+# update default sizing if we have a lot of info in the plot
+if (n_markers >= 50) {
+  dotplot_width <- pmin(n_markers * 0.3, 30)
+  dotplot_height <- 10
+  dotplot_text_size <- 18
+} else if (n_celltypes >= 20) {
+  dotplot_height <- dotplot_height * 1.25
+} 
+```
+
+
+
+```{r, eval = has_consensus, fig.height = dotplot_height, fig.width = dotplot_width}
 # only make a dot plot if we have at least one validation group annotation present
 if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp
@@ -761,7 +782,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
       strip.text.x = element_blank(),
       axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
       axis.ticks.x = element_blank(),
-      text = element_text(size = 14),
+      text = element_text(size = dotplot_text_size),
       panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
     ) +
     labs(
@@ -780,7 +801,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
     ggmap::theme_nothing() +
     theme(
       strip.background = element_rect(fill = "transparent", color = NA),
-      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
+      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = dotplot_text_size),
       strip.placement = "outside",
       legend.position = "none",
       panel.spacing = unit(0.5, "lines"),

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -615,6 +615,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
+# any cell types missing from the palette should be excluded from the dotplot 
 celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
@@ -692,6 +693,8 @@ group_stats_df <- consensus_df |>
   # this includes all possible marker genes and all possible validation group assignments
   dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
   dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
+  # to be safe, ensure we're only retaining cell type group we have colors for 
+  dplyr::filter(broad_celltype_group %in% names(celltype_colors)) |>
   dplyr::mutate(
     # get total percent expressed
     percent_exp = (detected_count / total_cells) * 100,
@@ -743,7 +746,7 @@ dotplot_df <- group_stats_df |>
 ```
 
 
-```{r, eval = has_consensus, fig.height=7, fig.width=15}
+```{r, eval = has_consensus, fig.height = 7, fig.width = 15}
 # only make a dot plot if we have at least one validation group annotation present
 if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -524,7 +524,7 @@ if (has_processed) {
       <div class=\"alert alert-warning\">
 
       This library contains fewer than {min_processed} cells in the processed `SingleCellExperiment` object after removal of low quality cells.
-      UMAP is unable to be calculated and plots will not be shown.
+      This may affect the interpretation of results.
 
       </div>
     ")
@@ -728,8 +728,8 @@ if (has_filtered && has_processed) {
 The raw counts from all cells that remain after filtering low quality cells (RNA only) are then normalized prior to selection of highly variable genes and dimensionality reduction.
 
 
-<!-- Next section include only if UMAP is present -->
-```{r, child='umap_qc.rmd', eval = has_umap}
+<!-- Next section shows UMAPs, only if present -->
+```{r, child='umap_qc.rmd'}
 ```
 
 <!-- Next section included only if CITE-seq data is present -->

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -148,6 +148,7 @@ if (has_processed) {
   has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
   # Determine inferCNV status
+  include_infercnv_report <- FALSE # overwrite below if TRUE
   infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
   if (!(is.null(infercnv_status))) {
     # turn on the child report

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -1,5 +1,14 @@
 ## Dimensionality reduction {.tabset}
 
+```{r results = 'asis', eval = !has_umap}
+glue::glue("
+  <div class=\"alert alert-info\">
+  No plots are shown in this section because the UMAP (Uniform Manifold Approximation and Projection) embeddings could not be calculated.
+  </div>
+")
+knitr::knit_exit(fully = FALSE) # don't quit the whole report, just this subnotebook
+```
+
 The plots in this section show the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell. 
 
 ```{r}


### PR DESCRIPTION
Closes #1151 
Towards #1146 ? 


This PR takes care of some miscellaneous updates to the QC report (although we're not done!). Changes include:

- For #1151, I updated the messaging in the main report to still print out a warning about 50 cells, but not mention UMAP as part of that warning. At the same time, I added a message box to the UMAP child report to print out if there's no UMAP in the object, and skip the remaining code. Because of this change, we now always run the UMAP child report, but bail after the first chunk if there's no actual UMAP. This is conceptually similar (but not identical) to how we treat the infercnv child report. Tested and working as expected! 
- For #1146, a handful of changes...
  - I updated the palette file as discussed in the issue
  - For future-proofing, I added a filter statement to make sure that we're only including validation groups that have marker genes (aka that have colors). I also added a sentence to print in the report saying that we do this. I think this is probably the move for now, but we can always change the approach to include all the groups, even those without marker genes. Since that would involve much bigger code updates, I suggest this route for now and we can open an issue to circle back to that approach later. 
  - I attempted some more dynamic dotplot sizing, and I think I did _ok_.... It's certainly an improvement on before, but I'm not convinced it's done, so I'm hesitant to close out #1146. 

Here are some reports with resized dotplots (ignore all the warnings about package versions at the top... that's a my-computer problem!). Does this like an ok spot to at least temporarily land for dotplot sizing?
[SCPCL00001.html](https://github.com/user-attachments/files/24919774/SCPCL00001.html)
[SCPCL000859.html](https://github.com/user-attachments/files/24919775/SCPCL000859.html)
[SCPCL000864.html](https://github.com/user-attachments/files/24919776/SCPCL000864.html)

While I was testing all this, I also caught/fixed a bug where `include_infercnv_report` was able to sneak by undefined in certain circumstances. 