### PR TITLE
Update CCDL profile buckets

### DIFF
--- a/.github/workflows/docker_cellbrowser.yaml
+++ b/.github/workflows/docker_cellbrowser.yaml
@@ -25,13 +25,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  IMAGE_NAME: scpca-nf/cellbrowser
-  GH_REGISTRY: ghcr.io
-  GH_REGISTRY_USER: alexslemonade
-  AWS_REGISTRY: 997241705947.dkr.ecr.us-east-1.amazonaws.com
-  AWS_PREFIX: ghcr_io
-
 jobs:
   test-build:
     name: Test Build Docker Image
@@ -55,6 +48,13 @@ jobs:
     if: github.event_name == 'push'
     environment: prod
     runs-on: ubuntu-latest
+
+    env:
+      IMAGE_NAME: scpca-nf/cellbrowser
+      GH_REGISTRY: ghcr.io
+      GH_REGISTRY_USER: alexslemonade
+      AWS_REGISTRY: "${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com"
+      AWS_PREFIX: ghcr_io
     permissions:
       contents: read
       packages: write
@@ -64,7 +64,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::997241705947:role/gha-ecr-access-role
+          role-to-assume: "arn:aws:iam::${{secrets.AWS_ACCOUNT_ID}}:role/gha-ecr-access-role"
           role-session-name: githubActionSession
           aws-region: us-east-1
 

--- a/.github/workflows/docker_cellbrowser.yaml
+++ b/.github/workflows/docker_cellbrowser.yaml
@@ -48,7 +48,6 @@ jobs:
     if: github.event_name == 'push'
     environment: prod
     runs-on: ubuntu-latest
-
     env:
       IMAGE_NAME: scpca-nf/cellbrowser
       GH_REGISTRY: ghcr.io

--- a/.github/workflows/docker_vireo-snp.yaml
+++ b/.github/workflows/docker_vireo-snp.yaml
@@ -25,13 +25,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  IMAGE_NAME: scpca-nf/vireo-snp
-  GH_REGISTRY: ghcr.io
-  GH_REGISTRY_USER: alexslemonade
-  AWS_REGISTRY: 997241705947.dkr.ecr.us-east-1.amazonaws.com
-  AWS_PREFIX: ghcr_io
-
 jobs:
   test-build:
     name: Test Build Docker Image
@@ -55,6 +48,13 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: prod
+    env:
+      IMAGE_NAME: scpca-nf/vireo-snp
+      GH_REGISTRY: ghcr.io
+      GH_REGISTRY_USER: alexslemonade
+      AWS_REGISTRY: "${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com"
+      AWS_PREFIX: ghcr_io
+
     permissions:
       contents: read
       packages: write
@@ -64,7 +64,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::997241705947:role/gha-ecr-access-role
+          role-to-assume: "arn:aws:iam::${{secrets.AWS_ACCOUNT_ID}}:role/gha-ecr-access-role"
           role-session-name: githubActionSession
           aws-region: us-east-1
       - name: Log in to Amazon ECR

--- a/.github/workflows/docker_vireo-snp.yaml
+++ b/.github/workflows/docker_vireo-snp.yaml
@@ -54,7 +54,6 @@ jobs:
       GH_REGISTRY_USER: alexslemonade
       AWS_REGISTRY: "${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.us-east-1.amazonaws.com"
       AWS_PREFIX: ghcr_io
-
     permissions:
       contents: read
       packages: write

--- a/config/ccdl_inputs.config
+++ b/config/ccdl_inputs.config
@@ -1,7 +1,7 @@
 params {
-  run_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/sample_info/scpca-library-metadata.tsv'
-  sample_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/sample_info/scpca-sample-metadata.tsv'
-  project_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/sample_info/scpca-project-metadata.tsv'
-  cellhash_pool_file = 's3://ccdl-scpca-data-997241705947-us-east-1/sample_info/scpca-multiplex-pools.tsv'
-  project_celltype_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/sample_info/scpca-project-celltype-metadata.tsv'
+  run_metafile = 's3://ccdl-scpca-nf-data/sample_info/scpca-library-metadata.tsv'
+  sample_metafile = 's3://ccdl-scpca-nf-data/sample_info/scpca-sample-metadata.tsv'
+  project_metafile = 's3://ccdl-scpca-nf-data/sample_info/scpca-project-metadata.tsv'
+  cellhash_pool_file = 's3://ccdl-scpca-nf-data/sample_info/scpca-multiplex-pools.tsv'
+  project_celltype_metafile = 's3://ccdl-scpca-nf-data/sample_info/scpca-project-celltype-metadata.tsv'
 }

--- a/config/ccdl_profiles.config
+++ b/config/ccdl_profiles.config
@@ -12,8 +12,8 @@ profiles {
     params {
 
       // output base directory
-      outdir = "s3://ccdl-scpca-results-testing-997241705947-us-east-1/sandbox"
-      ref_outdir = "s3://ccdl-scpca-results-testing-997241705947-us-east-1/references"
+      outdir = "s3://ccdl-scpca-nf-results-testing/sandbox"
+      ref_outdir = "s3://ccdl-scpca-nf-results-testing/references"
 
       // paths to output folders, redefined to use `outdir` above
       checkpoints_dir = "${params.outdir}/checkpoints"
@@ -34,7 +34,7 @@ profiles {
     params {
 
       // output base directory
-      outdir = "s3://ccdl-scpca-results-staging-997241705947-us-east-1"
+      outdir = "s3://ccdl-scpca-nf-results-staging"
       ref_outdir = "s3://scpca-nf-references"
 
       // paths to output folders, redefined to use `outdir` above
@@ -56,7 +56,7 @@ profiles {
     params {
 
       // output base directory
-      outdir = "s3://ccdl-scpca-results-prod-997241705947-us-east-1"
+      outdir = "s3://ccdl-scpca-nf-results-prod"
       ref_outdir = "s3://scpca-nf-references"
 
       // paths to output folders, redefined to use `outdir` above
@@ -74,13 +74,13 @@ profiles {
     tower.workspaceId = '231452676847652'
     includeConfig 'ccdl_inputs.config'
     params {
-      run_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/portal-test-data/run-metadata.tsv'
-      sample_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/portal-test-data/sample-metadata.tsv'
-      cellhash_pool_file = 's3://ccdl-scpca-data-997241705947-us-east-1/portal-test-data/multiplex-pools.tsv'
-      project_celltype_metafile = 's3://ccdl-scpca-data-997241705947-us-east-1/portal-test-data/project-celltype-metadata.tsv'
+      run_metafile = 's3://ccdl-scpca-nf-data/portal-test-data/run-metadata.tsv'
+      sample_metafile = 's3://ccdl-scpca-nf-data/portal-test-data/sample-metadata.tsv'
+      cellhash_pool_file = 's3://ccdl-scpca-nf-data/portal-test-data/multiplex-pools.tsv'
+      project_celltype_metafile = 's3://ccdl-scpca-nf-data/portal-test-data/project-celltype-metadata.tsv'
 
       // output base directory
-      outdir = "s3://ccdl-scpca-results-testing-997241705947-us-east-1/portal-test-data"
+      outdir = "s3://ccdl-scpca-nf-results-testing/portal-test-data"
 
       // paths to output folders, redefined to use `outdir` above
       checkpoints_dir = "${params.outdir}/checkpoints"

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -22,5 +22,9 @@ process {
     queue = { task.attempt < 2 ? 'scpca-nf-batch-default-queue' : 'scpca-nf-batch-priority-queue' }
   }
   // pass proxy settings into containers
-  containerOptions = '-e HTTP_PROXY=http://172.24.1.10:3128' + ' -e HTTPS_PROXY=http://172.24.1.10:3128' + ' -e http_proxy=http://172.24.1.10:3128' + ' -e https_proxy=http://172.24.1.10:3128' + ' -e NO_PROXY=169.254.169.254,169.254.170.2,s3.amazonaws.com,.s3.amazonaws.com,s3.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,s3.eu-west-1.amazonaws.com,.s3.eu-west-1.amazonaws.com'
+  containerOptions = '-e HTTP_PROXY=http://172.24.1.10:3128' +
+    ' -e HTTPS_PROXY=http://172.24.1.10:3128' +
+    ' -e http_proxy=http://172.24.1.10:3128' +
+    ' -e https_proxy=http://172.24.1.10:3128' +
+    ' -e NO_PROXY=169.254.169.254,169.254.170.2,s3.amazonaws.com,.s3.amazonaws.com,s3.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,s3.eu-west-1.amazonaws.com,.s3.eu-west-1.amazonaws.com'
 }

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -1,6 +1,6 @@
 // profile for wave and fusion filesystem enabled batch pipeline
 
-workDir = 's3://ccdl-scpca-workdir-997241705947-us-east-1/work'
+workDir = 's3://ccdl-scpca-nf-workdir/work'
 docker.enabled = true
 wave.enabled = true
 fusion.enabled = true
@@ -24,9 +24,5 @@ process {
     queue = { task.attempt < 2 ? 'scpca-nf-batch-default-queue' : 'scpca-nf-batch-priority-queue' }
   }
   // pass proxy settings into containers
-  containerOptions ='-e HTTP_PROXY=http://172.24.1.10:3128' +
-    ' -e HTTPS_PROXY=http://172.24.1.10:3128' +
-    ' -e http_proxy=http://172.24.1.10:3128' +
-    ' -e https_proxy=http://172.24.1.10:3128' +
-    ' -e NO_PROXY=169.254.169.254,169.254.170.2,s3.amazonaws.com,.s3.amazonaws.com,s3.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,s3.eu-west-1.amazonaws.com,.s3.eu-west-1.amazonaws.com'
+  containerOptions = '-e HTTP_PROXY=http://172.24.1.10:3128' + ' -e HTTPS_PROXY=http://172.24.1.10:3128' + ' -e http_proxy=http://172.24.1.10:3128' + ' -e https_proxy=http://172.24.1.10:3128' + ' -e NO_PROXY=169.254.169.254,169.254.170.2,s3.amazonaws.com,.s3.amazonaws.com,s3.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,s3.eu-west-1.amazonaws.com,.s3.eu-west-1.amazonaws.com'
 }

--- a/config/profile_awsbatch.config
+++ b/config/profile_awsbatch.config
@@ -13,8 +13,6 @@ aws {
   region = 'us-east-1'
 }
 
-params.pullthrough_registry = '997241705947.dkr.ecr.us-east-1.amazonaws.com'
-
 process {
   executor = 'awsbatch'
   scratch = 'false'

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -45,8 +45,7 @@ Please refer to our [`CONTRIBUTING.md`](CONTRIBUTING.md#stub-workflows) for more
 
 When you are ready to test the workflow with real data, you will want to use the `testing` mode in GitHub Actions.
 This can be configured to run the workflow from any branch using a subset of ScPCA data.
-For more information, see the [Data Processing README](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/data-processing-and-handoff/README.md
-)
+For more information, see the [Data Processing README](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/data-processing-and-handoff/README.md)
 
 ## Processing example data
 

--- a/scripts/aws/run_nextflow.sh
+++ b/scripts/aws/run_nextflow.sh
@@ -20,7 +20,7 @@ JOB_NAME=${JOB_NAME:-${RUN_MODE}_${REVISION//[\/.]/-}_${datetime}}
 # set Java memory options for Nextflow
 export NXF_JVM_ARGS="-XX:InitialRAMPercentage=10 -XX:MaxRAMPercentage=40"
 
-log_path=s3://ccdl-scpca-workdir-997241705947-us-east-1/logs/${RUN_MODE}/${date}
+log_path=s3://ccdl-scpca-nf-workdir/logs/${RUN_MODE}/${date}
 
 # Make sure environment includes local bin (where Nextflow is installed)
 if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin" ]]

--- a/scripts/compare-metrics/README.md
+++ b/scripts/compare-metrics/README.md
@@ -14,4 +14,4 @@ Rscript compare-metrics.R \
 Multiple projects can be included using a comma-separated list for the `--project_id` argument.
 
 The default comparison will be between the metrics files available in the production and staging directories, treating the production versions as the reference run.
-The files are expected to be found at `s3://ccdl-scpca-results-prod-997241705947-us-east-1/results` and `s3://ccdl-scpca-results-staging-997241705947-us-east-1/results`, by default, but these can be changed using the `--ref_s3` and `--comp_s3` arguments.
+The files are expected to be found at `s3://ccdl-scpca-nf-results-prod/results` and `s3://ccdl-scpca-nf-results-staging/results`, by default, but these can be changed using the `--ref_s3` and `--comp_s3` arguments.

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1,7 +1,7 @@
 ---
 params:
-  reference_s3: s3://ccdl-scpca-results-prod-997241705947-us-east-1/results
-  comparison_s3: s3://ccdl-scpca-results-staging-997241705947-us-east-1/results
+  reference_s3: s3://ccdl-scpca-nf-results-prod/results
+  comparison_s3: s3://ccdl-scpca-nf-results-staging/results
   project_id: "all"
   use_cache: false
 title: "`scpca-nf` Metrics Comparison"

--- a/scripts/compare-metrics/compare-metrics.R
+++ b/scripts/compare-metrics/compare-metrics.R
@@ -14,13 +14,13 @@ option_list <- list(
   make_option(
     c("-r", "--ref_s3"),
     type = "character",
-    default = "s3://ccdl-scpca-results-prod-997241705947-us-east-1/results",
+    default = "s3://ccdl-scpca-nf-results-prod/results",
     help = "S3 URI for the bucket and prefix for the reference files"
   ),
   make_option(
     c("-c", "--comp_s3"),
     type = "character",
-    default = "s3://ccdl-scpca-results-staging-997241705947-us-east-1/results",
+    default = "s3://ccdl-scpca-nf-results-staging/results",
     help = "S3 URI for the bucket and prefix for the comparison S3 files"
   ),
   make_option(


### PR DESCRIPTION
Here I am updating the default buckets for the CCDL profiles. 

I also updated the actions to use github-held info that is only in the `prod` environment.

I removed the default pull through repository, as we don't really want to have that in this repository. 