### PR TITLE
Merge changes from `development` to `main`

### DIFF
--- a/.github/workflows/run-batch.yaml
+++ b/.github/workflows/run-batch.yaml
@@ -1,0 +1,80 @@
+name: Run Workflow on AWS Batch
+
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: Branch or tag of Nextflow workflow to run
+        required: true
+        default: main
+      project:
+        description: Project ID
+        required: true
+        default: All
+      run_mode:
+        description: Nextflow workflow run mode
+        type: choice
+        options:
+          - testing
+          - example
+          - staging
+      resume:
+        description: Use -resume flag for Nextflow launch
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Run Code Deploy Job
+    runs-on: ubuntu-latest
+    environment: "prod"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997241705947:role/gha-nf-codedeploy-role
+          role-session-name: githubActionSession
+          aws-region: us-east-1
+
+      - name: Create tmux launch script
+        env:
+          revision: ${{ inputs.revision }}
+          run_mode: ${{ inputs.run_mode }}
+          project_id: ${{ inputs.project }}
+          resume: ${{ inputs.resume }}
+        run: |
+          echo '#!/bin/bash' > scripts/tmux_launch.sh
+          echo "export GITHUB_TAG=$revision" >> scripts/tmux_launch.sh
+          echo "export RUN_MODE=$run_mode" >> scripts/tmux_launch.sh
+          echo "export PROJECT_ID=$project_id"
+          echo "export RESUME=$resume" >> scripts/tmux_launch.sh
+          echo 'tmux new-session -d -s nextflow /opt/nextflow/scripts/run_nextflow.sh' >> scripts/tmux_launch.sh
+          chmod +x scripts/tmux_launch.sh
+
+      - name: Create zip archive
+        run: |
+          zip -r source.zip . -i appspec.yml LICENSE scripts/**
+        working-directory: ${{ github.workspace }}
+
+      - name: Copy zip to S3
+        run: aws s3 cp source.zip s3://pipeline-artifacts-997241705947-us-east-1/
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+
+      - name: Trigger AWS CodeDeploy deployment
+        run: |
+          aws deploy create-deployment \
+            --application-name Nextflow-batch \
+            --deployment-group-name Nextflow-batch-deployment-group \
+                  --s3-location bucket=pipeline-artifacts-997241705947-us-east-1,key=source.zip,bundleType=zip \
+                  --region us-east-1
+        env:
+          AWS_DEFAULT_REGION: us-east-1

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -359,9 +359,9 @@ add_infercnv_reference_cells <- function(
   diagnosis <- unique(metadata(sce)$sample_metadata$diagnosis)
 
   if (is.null(diagnosis)) {
-    infercnv_status <- "no_diagnosis"
+    infercnv_status <- "unknown_diagnosis"
   } else if (length(diagnosis) > 1 && !file.exists(opt$diagnosis_groups_ref)) {
-    infercnv_status <- "no_diagnosis_multiplexed"
+    infercnv_status <- "multiple_diagnoses_multiplexed"
   } else {
     # Determine the broad_diagnosis group and check for edge cases
     if (!file.exists(opt$diagnosis_groups_ref)) {
@@ -381,13 +381,12 @@ add_infercnv_reference_cells <- function(
     if (length(broad_diagnosis) == 0) {
       infercnv_status <- "unknown_diagnosis_group"
     } else if (length(broad_diagnosis) > 1) {
-      infercnv_status <- "multiple_diagnosis_groups"
-      # TODO: Is this the desired behavior? If it's length 2 and 1 value non-cancerous, do we want to proceed with inferCNV with the other diagnosis?
-      # Right now this is more conservative and doesn't run inferCNV in this circumstance.
+      infercnv_status <- "multiple_diagnosis_groups_multiplexed"
     } else if (broad_diagnosis == "Non-cancerous") {
+      # TODO: Is this the desired behavior?
       infercnv_status <- "skipped_non_cancerous"
     } else if (!(broad_diagnosis %in% diagnosis_celltype_df$diagnosis_group)) {
-      infercnv_status <- "missing_reference_celltypes"
+      infercnv_status <- "unknown_reference_celltypes"
     }
   }
 
@@ -679,7 +678,7 @@ if (length(automated_methods) > 1) {
   )
 
   if (!file.exists(opt$diagnosis_celltype_ref)) {
-    infercnv_status <- "no_diagnosis_reference"
+    infercnv_status <- "no_diagnosis_celltype_reference"
   } else {
     sce <- add_infercnv_reference_cells(
       sce,

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -710,7 +710,7 @@ if (length(automated_methods) > 1) {
     opt$diagnosis_celltype_ref
   )
   # calculate if passing status
-  if (metadata(sce)$infercnv_status == "") {
+  if (metadata(sce)$infercnv_status == "feasible") {
     sce <- add_infercnv_reference_cells(
       sce,
       opt$consensus_validation_ref,

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -336,7 +336,9 @@ assign_consensus_celltypes <- function(
 }
 
 
-#' Add reference cell information for inferCNV to SCE
+#' Add reference cell information for inferCNV to an SCE
+#'
+#' This function will also identify edge cases for which inferCNV cannot be run
 #'
 #' @param sce SingleCellExperiment object
 #' @param consensus_validation_ref Path to tsv mapping consensus validation groups to consensus labels
@@ -382,6 +384,13 @@ add_infercnv_reference_cells <- function(
         # in case of multiplexed
         unique()
     }
+    # For a multiplexed edge condition:
+    # if the length is 2 and 1 is non-cancerous, remove non-cancerous first
+    if (length(broad_diagnosis) == 2 & "Non-cancerous" %in% broad_diagnosis) {
+      broad_diagnosis <- broad_diagnosis[broad_diagnosis != "Non-cancerous"]
+    }
+
+    # assign remaining statuses for edge cases
     if (length(broad_diagnosis) == 0) {
       infercnv_status <- "unknown_diagnosis_group"
     } else if (length(broad_diagnosis) > 1) {

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -728,6 +728,6 @@ if (length(automated_methods) > 1) {
 # export annotated object with cell type assignments
 readr::write_rds(sce, opt$output_sce_file, compress = "bz2")
 
-# export normal cell count and hash, and infercnv_status
+# export normal cell count and hash
 readr::write_file(reference_cell_count, opt$reference_cell_count_file)
 readr::write_file(reference_cell_hash, opt$reference_cell_hash_file)

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -444,7 +444,7 @@ add_infercnv_reference_cells <- function(
     dplyr::filter(validation_group_annotation %in% reference_validation_groups) |>
     dplyr::select(consensus_ontology, consensus_annotation) |>
     dplyr::distinct() |>
-    # keep only the cell types that appear in the SCE
+    # keep only the cell types that actually appear in the SCE
     dplyr::filter(consensus_annotation %in% unique(sce$consensus_celltype_annotation))
 
   # Add reference cell information to SCE

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -397,7 +397,6 @@ assign_infercnv_status <- function(
   }
 
   # Assign remaining statuses for edge cases
-
   if (length(broad_diagnosis) > 1) {
     infercnv_status <- "multiple_diagnosis_groups_multiplexed"
   } else if (broad_diagnosis == "Non-cancerous") { # at this point we know it's length 1
@@ -409,8 +408,8 @@ assign_infercnv_status <- function(
   } else { # no edge case
     infercnv_status <- ""
   }
-  
-metadata(sce)$infercnv_status <- infercnv_status
+
+  metadata(sce)$infercnv_status <- infercnv_status
 
   return(sce)
 }

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -347,10 +347,10 @@ assign_consensus_celltypes <- function(
 #'
 #' @returns Updated SCE object with reference cell count information
 add_infercnv_reference_cells <- function(
-    sce,
-    consensus_validation_ref,
-    diagnosis_celltype_ref,
-    diagnosis_groups_ref
+  sce,
+  consensus_validation_ref,
+  diagnosis_celltype_ref,
+  diagnosis_groups_ref
 ) {
   # will be populated with an edge case, or remain empty to be updated later
   # in add_infercnv_to_sce.R

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -372,7 +372,8 @@ assign_infercnv_status <- function(
     diagnosis_groups <- readr::read_tsv(diagnosis_groups_ref)
     broad_diagnosis <- data.frame(sample_diagnosis = diagnosis) |>
       dplyr::left_join(diagnosis_groups, by = "sample_diagnosis") |>
-      # replace NA with sample diagnosis
+      # replace NA diagnosis_group with sample diagnosis
+      # this means diagnosis_group will never be length 0
       dplyr::mutate(
         diagnosis_group = dplyr::coalesce(diagnosis_group, sample_diagnosis)
       ) |>
@@ -394,7 +395,7 @@ assign_infercnv_status <- function(
     metadata(sce)$infercnv_status <- "multiple_diagnosis_groups_multiplexed"
     return(sce)
   }
-  if (broad_diagnosis == "Non-cancerous") {
+  if (broad_diagnosis == "Non-cancerous") { # at this point we know it's length 1
     metadata(sce)$infercnv_status <- "skipped_non_cancerous"
     return(sce)
   }

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -443,7 +443,7 @@ add_infercnv_reference_cells <- function(
   ref_df <- consensus_validation_df |>
     dplyr::filter(validation_group_annotation %in% reference_validation_groups) |>
     dplyr::select(consensus_ontology, consensus_annotation) |>
-    dplyr::distinct()
+    dplyr::distinct() |>
     # keep only the cell types that appear in the SCE
     dplyr::filter(consensus_annotation %in% unique(sce$consensus_celltype_annotation))
 

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -348,7 +348,7 @@ add_infercnv_reference_cells <- function(
     sce,
     consensus_validation_ref,
     diagnosis_celltype_ref,
-    diagnosis_groups_ref,
+    diagnosis_groups_ref
 ) {
 
   # read in tsvs we know exist

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -405,8 +405,8 @@ assign_infercnv_status <- function(
     infercnv_status <- "no_diagnosis_celltype_reference"
   } else if (!(broad_diagnosis %in% diagnosis_celltype_df$diagnosis_group)) {
     infercnv_status <- "unknown_reference_celltypes"
-  } else { # no edge case
-    infercnv_status <- ""
+  } else { # no edge case - we can feasibly run inferCNV
+    infercnv_status <- "feasible"
   }
 
   metadata(sce)$infercnv_status <- infercnv_status

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -396,7 +396,6 @@ add_infercnv_reference_cells <- function(
     } else if (length(broad_diagnosis) > 1) {
       infercnv_status <- "multiple_diagnosis_groups_multiplexed"
     } else if (broad_diagnosis == "Non-cancerous") {
-      # TODO: Is this the desired behavior?
       infercnv_status <- "skipped_non_cancerous"
     } else if (!(broad_diagnosis %in% diagnosis_celltype_df$diagnosis_group)) {
       infercnv_status <- "unknown_reference_celltypes"

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -716,7 +716,8 @@ if (length(automated_methods) > 1) {
       opt$consensus_validation_ref,
       opt$diagnosis_celltype_ref
     )
-    reference_cell_count <- metadata(sce)$infercnv_num_reference_cells
+    # convert to character for readr::write_file
+    reference_cell_count <- as.character(metadata(sce)$infercnv_num_reference_cells)
     reference_cell_hash <- sort(sce$barcodes[sce$is_infercnv_reference]) |>
       paste(collapse = "") |>
       digest::digest()

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -345,12 +345,11 @@ assign_consensus_celltypes <- function(
 #'
 #' @returns Updated SCE object with reference cell count information
 add_infercnv_reference_cells <- function(
-    sce,
-    consensus_validation_ref,
-    diagnosis_celltype_ref,
-    diagnosis_groups_ref
+  sce,
+  consensus_validation_ref,
+  diagnosis_celltype_ref,
+  diagnosis_groups_ref
 ) {
-
   # read in tsvs we know exist
   diagnosis_celltype_df <- readr::read_tsv(opt$diagnosis_celltype_ref)
   consensus_validation_df <- readr::read_tsv(opt$consensus_validation_ref)
@@ -418,7 +417,6 @@ add_infercnv_reference_cells <- function(
   }
 
   return(sce)
-
 }
 
 

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -390,7 +390,7 @@ assign_infercnv_status <- function(
   metadata(sce)$infercnv_diagnosis_groups <- broad_diagnosis
 
   # define data frame for use in checks
-  if (file.exists(diagnosis_celltype_ref)){
+  if (file.exists(diagnosis_celltype_ref)) {
     diagnosis_celltype_df <- readr::read_tsv(diagnosis_celltype_ref)
   } else {
     diagnosis_celltype_df <- data.frame()

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -444,6 +444,8 @@ add_infercnv_reference_cells <- function(
     dplyr::filter(validation_group_annotation %in% reference_validation_groups) |>
     dplyr::select(consensus_ontology, consensus_annotation) |>
     dplyr::distinct()
+    # keep only the cell types that appear in the SCE
+    dplyr::filter(consensus_annotation %in% unique(sce$consensus_celltype_annotation))
 
   # Add reference cell information to SCE
   metadata(sce)$infercnv_reference_celltypes <- ref_df$consensus_annotation # vector of reference cell types

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -397,22 +397,20 @@ assign_infercnv_status <- function(
   }
 
   # Assign remaining statuses for edge cases
-  if (length(broad_diagnosis) > 1) {
-    metadata(sce)$infercnv_status <- "multiple_diagnosis_groups_multiplexed"
-  }
-  if (broad_diagnosis == "Non-cancerous") { # at this point we know it's length 1
-    metadata(sce)$infercnv_status <- "skipped_non_cancerous"
-  }
-  if (nrow(diagnosis_celltype_df) == 0) {
-    metadata(sce)$infercnv_status <- "no_diagnosis_celltype_reference"
-  } else if (!(broad_diagnosis %in% diagnosis_celltype_df$diagnosis_group)) {
-    metadata(sce)$infercnv_status <- "unknown_reference_celltypes"
-  }
 
-  # Empty string if no edge case was found
-  if (is.null(metadata(sce)$infercnv_status)) {
-    metadata(sce)$infercnv_status <- ""
+  if (length(broad_diagnosis) > 1) {
+    infercnv_status <- "multiple_diagnosis_groups_multiplexed"
+  } else if (broad_diagnosis == "Non-cancerous") { # at this point we know it's length 1
+    infercnv_status <- "skipped_non_cancerous"
+  } else if (nrow(diagnosis_celltype_df) == 0) {
+    infercnv_status <- "no_diagnosis_celltype_reference"
+  } else if (!(broad_diagnosis %in% diagnosis_celltype_df$diagnosis_group)) {
+    infercnv_status <- "unknown_reference_celltypes"
+  } else { # no edge case
+    infercnv_status <- ""
   }
+  
+metadata(sce)$infercnv_status <- infercnv_status
 
   return(sce)
 }

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -443,7 +443,9 @@ add_infercnv_reference_cells <- function(
   ref_df <- consensus_validation_df |>
     dplyr::filter(validation_group_annotation %in% reference_validation_groups) |>
     dplyr::select(consensus_ontology, consensus_annotation) |>
-    dplyr::distinct()
+    dplyr::distinct() |>
+    # keep only the cell types that actually appear in the SCE
+    dplyr::filter(consensus_annotation %in% unique(sce$consensus_celltype_annotation))
 
   # Add reference cell information to SCE
   metadata(sce)$infercnv_reference_celltypes <- ref_df$consensus_annotation # vector of reference cell types

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -347,9 +347,9 @@ assign_consensus_celltypes <- function(
 #'
 #' @returns Updated SCE object with infercnv_status and infercnv_diagnosis_groups added to SCE metadata
 assign_infercnv_status <- function(
-    sce,
-    diagnosis_groups_ref,
-    diagnosis_celltype_ref
+  sce,
+  diagnosis_groups_ref,
+  diagnosis_celltype_ref
 ) {
   # unique in case of multiplexed
   diagnosis <- unique(metadata(sce)$sample_metadata$diagnosis)

--- a/bin/add_infercnv_to_sce.R
+++ b/bin/add_infercnv_to_sce.R
@@ -58,7 +58,8 @@ sce <- readRDS(opts$input_sce_file)
 
 # check if we have inferCNV results based on file size
 if (file.info(opts$infercnv_results_file)$size == 0) {
-  if (is.na(metadata(sce)$infercnv_num_reference_cells) || metadata(sce)$infercnv_num_reference_cells < opts$infercnv_threshold) {
+  # check reference cells
+  if (metadata(sce)$infercnv_num_reference_cells < opts$infercnv_threshold) {
     metadata(sce)$infercnv_status <- "insufficient_reference_cells"
   } else {
     metadata(sce)$infercnv_status <- "failure"

--- a/bin/add_infercnv_to_sce.R
+++ b/bin/add_infercnv_to_sce.R
@@ -6,10 +6,7 @@
 #  from the @options slot of the inferCNV output object
 # colData column `infercnv_total_cnv`: The sum of CNV per cell, calculated from the HMM output
 #
-# For all SCEs, we add a metadata field `infercnv_success` with a logical value, where we assign:
-# `TRUE`, if inferCNV successfully ran and produced results
-# `FALSE`, if inferCNV attempted but failed to run
-# `NA`, if inferCNV was not run; this case corresponds to insufficient reference cells
+# The metadata field `infercnv_status` is also updated
 
 suppressPackageStartupMessages({
   library(SingleCellExperiment)
@@ -62,9 +59,9 @@ sce <- readRDS(opts$input_sce_file)
 # check if we have inferCNV results based on file size
 if (file.info(opts$infercnv_results_file)$size == 0) {
   if (is.na(metadata(sce)$infercnv_num_reference_cells) || metadata(sce)$infercnv_num_reference_cells < opts$infercnv_threshold) {
-    metadata(sce)$infercnv_success <- NA # infercnv wasn't run; it neither succeeded nor failed
+    metadata(sce)$infercnv_status <- "insufficient_reference_cells"
   } else {
-    metadata(sce)$infercnv_success <- FALSE # actually failed
+    metadata(sce)$infercnv_status <- "failure"
   }
 } else {
   # read inferCNV results
@@ -73,7 +70,7 @@ if (file.info(opts$infercnv_results_file)$size == 0) {
     tibble::rownames_to_column(var = "barcodes")
 
   # add inferCNV results to metadata
-  metadata(sce)$infercnv_success <- TRUE
+  metadata(sce)$infercnv_status <- "success"
   metadata(sce)$infercnv_options <- infercnv_results@options
   metadata(sce)$infercnv_table <- infercnv_table
 

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -140,13 +140,10 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$processed_expressed_genes <- sum(rowSums(counts(processed_sce)) > 0)
   metrics$processed_altexp_total <- altexp_totals(processed_sce)
   metrics$hv_genes <- metadata(processed_sce)$highly_variable_genes
-  metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
   metrics$infercnv_total_cnv <- sum(processed_sce$infercnv_total_cnv)
-  # cluster counts as unnamed vector
-  metrics$cluster_sizes <- as.vector(table(processed_sce$cluster))
-
-  # infercnv reference cells as named list
   metrics$infercnv_reference_cells <- metadata(processed_sce)$infercnv_reference_celltypes
+  metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
+  metrics$cluster_sizes <- as.vector(table(processed_sce$cluster)) # cluster counts as unnamed vector
 
   metrics$singler_reference <- ifelse(
     is.null(metadata(processed_sce)$singler_reference),

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -146,12 +146,7 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$cluster_sizes <- as.vector(table(processed_sce$cluster))
 
   # infercnv reference cells as named list
-  metrics$infercnv_reference_cells <- colData(processed_sce) |>
-    as.data.frame() |>
-    dplyr::filter(is_infercnv_reference) |>
-    dplyr::pull(consensus_celltype_annotation) |>
-    table() |>
-    as.list()
+  metrics$infercnv_reference_cells <- metadata(processed_sce)$infercnv_reference_celltypes
 
   metrics$singler_reference <- ifelse(
     is.null(metadata(processed_sce)$singler_reference),

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -126,7 +126,7 @@ if (file.size(opt$filtered_sce) > 0) {
     NA_integer_,
     sum(filtered_sce$adt_scpca_filter == "Keep")
   )
-  metrics$scdblfinder_total_doublets <- sum(filtered_sce$scdblfinder_class == "doublet")
+  metrics$scdblfinder_total_doublets <- sum(filtered_sce$scDblFinder_class == "doublet")
 
   rm(filtered_sce)
 }

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -162,10 +162,16 @@ if (file.size(opt$processed_sce) > 0) {
     NA_character_,
     metadata(processed_sce)$cellassign_reference
   )
+  metrics$scimilarity_model <- ifelse(
+    is.null(metadata(processed_sce)$scimilarity_model),
+    NA_character_,
+    metadata(processed_sce)$scimilarity_model
+  )
   # convert celltype annotation counts to named lists
   metrics$singler_celltypes <- as.list(table(processed_sce$singler_celltype_annotation))
   metrics$cellassign_celltypes <- as.list(table(processed_sce$cellassign_celltype_annotation))
   metrics$consensus_celltypes <- as.list(table(processed_sce$consensus_celltype_annotation))
+  metrics$scimilarity_celltypes <- as.list(table(processed_sce$scimilarity_celltype_annotation))
 }
 
 jsonlite::write_json(

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -31,7 +31,6 @@ altexp_totals <- function(sce) {
   return(exp_totals)
 }
 
-
 # set up arguments
 option_list <- list(
   make_option(

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -140,8 +140,18 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$processed_altexp_total <- altexp_totals(processed_sce)
   metrics$hv_genes <- metadata(processed_sce)$highly_variable_genes
   metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
+  metrics$infercnv_total_cnv <- sum(processed_sce$infercnv_total_cnv)
   # cluster counts as unnamed vector
   metrics$cluster_sizes <- as.vector(table(processed_sce$cluster))
+
+  # infercnv reference cells as named list
+  metrics$infercnv_reference_cells <- colData(processed_sce) |>
+    as.data.frame() |>
+    dplyr::filter(is_infercnv_reference) |>
+    dplyr::pull(consensus_celltype_annotation) |>
+    table() |>
+    as.list()
+
   metrics$singler_reference <- ifelse(
     is.null(metadata(processed_sce)$singler_reference),
     NA_character_,

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -126,6 +126,7 @@ if (file.size(opt$filtered_sce) > 0) {
     NA_integer_,
     sum(filtered_sce$adt_scpca_filter == "Keep")
   )
+  metrics$scdblfinder_total_doublets <- sum(filtered_sce$scdblfinder_class == "doublet")
 
   rm(filtered_sce)
 }

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -31,6 +31,7 @@ altexp_totals <- function(sce) {
   return(exp_totals)
 }
 
+
 # set up arguments
 option_list <- list(
   make_option(
@@ -171,8 +172,8 @@ if (file.size(opt$processed_sce) > 0) {
   # convert celltype annotation counts to named lists
   metrics$singler_celltypes <- as.list(table(processed_sce$singler_celltype_annotation))
   metrics$cellassign_celltypes <- as.list(table(processed_sce$cellassign_celltype_annotation))
-  metrics$consensus_celltypes <- as.list(table(processed_sce$consensus_celltype_annotation))
   metrics$scimilarity_celltypes <- as.list(table(processed_sce$scimilarity_celltype_annotation))
+  metrics$consensus_celltypes <- as.list(table(processed_sce$consensus_celltype_annotation))
 }
 
 jsonlite::write_json(

--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -126,6 +126,7 @@ if (file.size(opt$filtered_sce) > 0) {
     NA_integer_,
     sum(filtered_sce$adt_scpca_filter == "Keep")
   )
+  metrics$scdblfinder_total_doublets <- sum(filtered_sce$scDblFinder_class == "doublet")
 
   rm(filtered_sce)
 }
@@ -139,9 +140,11 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$processed_expressed_genes <- sum(rowSums(counts(processed_sce)) > 0)
   metrics$processed_altexp_total <- altexp_totals(processed_sce)
   metrics$hv_genes <- metadata(processed_sce)$highly_variable_genes
+  metrics$infercnv_total_cnv <- sum(processed_sce$infercnv_total_cnv)
+  metrics$infercnv_reference_cells <- metadata(processed_sce)$infercnv_reference_celltypes
   metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
-  # cluster counts as unnamed vector
-  metrics$cluster_sizes <- as.vector(table(processed_sce$cluster))
+  metrics$cluster_sizes <- as.vector(table(processed_sce$cluster)) # cluster counts as unnamed vector
+
   metrics$singler_reference <- ifelse(
     is.null(metadata(processed_sce)$singler_reference),
     NA_character_,
@@ -152,9 +155,15 @@ if (file.size(opt$processed_sce) > 0) {
     NA_character_,
     metadata(processed_sce)$cellassign_reference
   )
+  metrics$scimilarity_model <- ifelse(
+    is.null(metadata(processed_sce)$scimilarity_model),
+    NA_character_,
+    metadata(processed_sce)$scimilarity_model
+  )
   # convert celltype annotation counts to named lists
   metrics$singler_celltypes <- as.list(table(processed_sce$singler_celltype_annotation))
   metrics$cellassign_celltypes <- as.list(table(processed_sce$cellassign_celltype_annotation))
+  metrics$scimilarity_celltypes <- as.list(table(processed_sce$scimilarity_celltype_annotation))
   metrics$consensus_celltypes <- as.list(table(processed_sce$consensus_celltype_annotation))
 }
 

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -321,7 +321,6 @@ if (has_consensus) {
 # only the two conditions checked require any input to the report
 heatmap_path <- NULL
 if (!is.null(metadata(processed_sce)$infercnv_status)) {
-
   if (metadata(processed_sce)$infercnv_status == "insufficient_reference_cells") {
     stopifnot("infercnv_min_reference_cells parameter value was not provided" = !is.na(opt$infercnv_min_reference_cells))
   }

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -317,24 +317,20 @@ if (has_consensus) {
   validation_palette_df <- NULL
 }
 
-
-# first check that inferCNV was actually run, otherwise skip these checks
-has_infercnv <- !is.null(metadata(processed_sce)$infercnv_success)
+# check for inferCNV input if inferCNV was feasible and did not fail
+# only the two conditions checked require any input to the report
 heatmap_path <- NULL
-if (has_infercnv) {
-  # check for inferCNV input if success is TRUE or NA, but not if it's FALSE
-  # if NA, we just need the infercnv_min_reference_cells
-  # if TRUE, we need infercnv_min_reference_cells and a heatmap file
-  infercnv_success <- metadata(processed_sce)$infercnv_success
-  if (is.na(infercnv_success) | infercnv_success) {
+if (!is.null(metadata(processed_sce)$infercnv_status)) {
+  if (metadata(processed_sce)$infercnv_status == "insufficient_reference_cells") {
     stopifnot("infercnv_min_reference_cells parameter value was not provided" = !is.na(opt$infercnv_min_reference_cells))
-    if (isTRUE(infercnv_success)) {
-      stopifnot("inferCNV heatmap file does not exist" = file.exists(opt$infercnv_heatmap_file))
-      # MUST use an absolute path for pandoc to find the file in the report
-      heatmap_path <- normalizePath(opt$infercnv_heatmap_file)
-    }
+  }
+  if (metadata(processed_sce)$infercnv_status == "success") {
+    stopifnot("inferCNV heatmap file does not exist" = file.exists(opt$infercnv_heatmap_file))
+    # MUST use an absolute path for pandoc to find the file in the report
+    heatmap_path <- normalizePath(opt$infercnv_heatmap_file)
   }
 }
+
 
 # render main QC report
 scpcaTools::generate_qc_report(

--- a/bin/sce_qc_report.R
+++ b/bin/sce_qc_report.R
@@ -317,24 +317,21 @@ if (has_consensus) {
   validation_palette_df <- NULL
 }
 
-
-# first check that inferCNV was actually run, otherwise skip these checks
-has_infercnv <- !is.null(metadata(processed_sce)$infercnv_success)
+# check for inferCNV input if inferCNV was feasible and did not fail
+# only the two conditions checked require any input to the report
 heatmap_path <- NULL
-if (has_infercnv) {
-  # check for inferCNV input if success is TRUE or NA, but not if it's FALSE
-  # if NA, we just need the infercnv_min_reference_cells
-  # if TRUE, we need infercnv_min_reference_cells and a heatmap file
-  infercnv_success <- metadata(processed_sce)$infercnv_success
-  if (is.na(infercnv_success) | infercnv_success) {
+if (!is.null(metadata(processed_sce)$infercnv_status)) {
+
+  if (metadata(processed_sce)$infercnv_status == "insufficient_reference_cells") {
     stopifnot("infercnv_min_reference_cells parameter value was not provided" = !is.na(opt$infercnv_min_reference_cells))
-    if (isTRUE(infercnv_success)) {
-      stopifnot("inferCNV heatmap file does not exist" = file.exists(opt$infercnv_heatmap_file))
-      # MUST use an absolute path for pandoc to find the file in the report
-      heatmap_path <- normalizePath(opt$infercnv_heatmap_file)
-    }
+  }
+  if (metadata(processed_sce)$infercnv_status == "success") {
+    stopifnot("inferCNV heatmap file does not exist" = file.exists(opt$infercnv_heatmap_file))
+    # MUST use an absolute path for pandoc to find the file in the report
+    heatmap_path <- normalizePath(opt$infercnv_heatmap_file)
   }
 }
+
 
 # render main QC report
 scpcaTools::generate_qc_report(

--- a/cavatica/sb_doc.md
+++ b/cavatica/sb_doc.md
@@ -1,4 +1,4 @@
-# scpca-nf v0.9.1a
+# scpca-nf v0.9.2
 
 
 The  `scpca-nf` workflow is used to process 10x single-cell data as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).

--- a/cavatica/sb_doc.md
+++ b/cavatica/sb_doc.md
@@ -1,4 +1,4 @@
-# scpca-nf v0.9.2
+# scpca-nf v0.9.3
 
 
 The  `scpca-nf` workflow is used to process 10x single-cell data as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).

--- a/cavatica/sb_nextflow_schema.yaml
+++ b/cavatica/sb_nextflow_schema.yaml
@@ -3,7 +3,7 @@ app_content:
   executor_version: 24.10.6
 class: nextflow
 cwlVersion: None
-doc: "# scpca-nf v0.9.2
+doc: "# scpca-nf v0.9.3
 
 
   The `scpca-nf` workflow is used to process 10x single-cell data as part of the

--- a/cavatica/sb_nextflow_schema.yaml
+++ b/cavatica/sb_nextflow_schema.yaml
@@ -3,7 +3,7 @@ app_content:
   executor_version: 24.10.6
 class: nextflow
 cwlVersion: None
-doc: "# scpca-nf v0.9.1a
+doc: "# scpca-nf v0.9.2
 
 
   The `scpca-nf` workflow is used to process 10x single-cell data as part of the

--- a/config/containers.config
+++ b/config/containers.config
@@ -10,8 +10,8 @@ params {
   SCPCATOOLS_SCIMILARITY_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scimilarity:v0.4.4'
   SCPCATOOLS_INFERCNV_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-infercnv:v0.4.4'
 
-  CELLBROWSER_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.2'
-  VIREO_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.2'
+  CELLBROWSER_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.3'
+  VIREO_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.3'
 
   // External containers
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'

--- a/config/containers.config
+++ b/config/containers.config
@@ -10,8 +10,8 @@ params {
   SCPCATOOLS_SCIMILARITY_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-scimilarity:v0.4.4'
   SCPCATOOLS_INFERCNV_CONTAINER = 'ghcr.io/alexslemonade/scpcatools-infercnv:v0.4.4'
 
-  CELLBROWSER_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.1a'
-  VIREO_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.1a'
+  CELLBROWSER_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.2'
+  VIREO_CONTAINER = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.2'
 
   // External containers
   ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -96,12 +96,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.9.2` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.9.3` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.9.2 \
+  -r v0.9.3 \
   -config {path to config file}  \
   -profile {name of profile}
 ```
@@ -332,7 +332,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.9.2`, then you will want to set `-r v0.9.2` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.9.3`, then you will want to set `-r v0.9.3` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -96,12 +96,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.9.1a` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.9.2` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.9.1a \
+  -r v0.9.2 \
   -config {path to config file}  \
   -profile {name of profile}
 ```
@@ -332,7 +332,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.9.1a`, then you will want to set `-r v0.9.1a` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.9.2`, then you will want to set `-r v0.9.2` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -360,7 +360,7 @@ You will also need to set the `singularity.cacheDir` variable to match this loca
   - the cell atlas foundation model [`SCimilarity`](https://genentech.github.io/scimilarity/index.html)
  
 Additionally, annotations from these three methods are used to assign a consensus cell type annotation.
-For more on how consensus cell types are assigned, see the [`cell-type-consensus` module in `OpenScPCA-analysis`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/v0.2.3/analyses/cell-type-consensus).
+For more on how consensus cell types are assigned, see the [`cell-type-consensus` module in `OpenScPCA-analysis`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/v0.2.4/analyses/cell-type-consensus).
 
 By default, no cell type annotation is performed.
 You can turn on cell type annotation by taking the following steps:

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -105,14 +105,14 @@ Be sure to use the `-r` flag to specify the latest release tag for the workflow,
 For example:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.9.1a -profile ccdl_staging,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.9.2 -profile ccdl_staging,batch --project SCPCP000000
 ```
 
 When that run has completed successfully, check that the outputs are as expected.
 You can then run the workflow using the `ccdl_prod` profile:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.9.1a -profile ccdl_prod,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.9.2 -profile ccdl_prod,batch --project SCPCP000000
 ```
 
 Both of these profiles have `-with-tower` set by default, and will use the [ScPCA workspace](https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch) for monitoring (allowing all team members to see progress).

--- a/internal-instructions.md
+++ b/internal-instructions.md
@@ -105,14 +105,14 @@ Be sure to use the `-r` flag to specify the latest release tag for the workflow,
 For example:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.9.2 -profile ccdl_staging,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.9.3 -profile ccdl_staging,batch --project SCPCP000000
 ```
 
 When that run has completed successfully, check that the outputs are as expected.
 You can then run the workflow using the `ccdl_prod` profile:
 
 ```
-nextflow run AlexsLemonade/scpca-nf -r v0.9.2 -profile ccdl_prod,batch --project SCPCP000000
+nextflow run AlexsLemonade/scpca-nf -r v0.9.3 -profile ccdl_prod,batch --project SCPCP000000
 ```
 
 Both of these profiles have `-with-tower` set by default, and will use the [ScPCA workspace](https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch) for monitoring (allowing all team members to see progress).

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -485,7 +485,7 @@ workflow annotate_celltypes {
       // ensure meta.infercnv_reference_cell_count exists
       .map{ meta, unfiltered_sce, filtered_sce, processed_sce -> 
         // make sure not to overwrite a literal 0 value with null
-        meta.putIfAbsent('infercnv_reference_cell_count', null)) 
+        meta.putIfAbsent('infercnv_reference_cell_count', null)
         [meta, unfiltered_sce, filtered_sce, processed_sce]
       }
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -194,7 +194,6 @@ process add_celltypes_to_sce {
       --diagnosis_groups_ref "${diagnosis_groups_file}" \
       --reference_cell_count_file "reference_cell_count.txt" \
       --reference_cell_hash_file "reference_cell_hash.txt" \
-      --reference_cell_hash_file "reference_cell_hash.txt"
 
       # save so we can export as environment variable
       REFERENCE_CELL_COUNT=\$(cat "reference_cell_count.txt")

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -483,7 +483,8 @@ workflow annotate_celltypes {
       // mix in cell line libraries which were not cell typed
       .mix(sce_files_channel_branched.cell_line)
       // ensure meta.infercnv_reference_cell_count exists
-      .map{ meta, unfiltered_sce, filtered_sce, processed_sce -> 
+      .map{ meta_in, unfiltered_sce, filtered_sce, processed_sce -> 
+        def meta = meta_in.clone()
         // make sure not to overwrite a literal 0 value with null
         meta.putIfAbsent('infercnv_reference_cell_count', null)
         [meta, unfiltered_sce, filtered_sce, processed_sce]

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -169,7 +169,7 @@ process add_celltypes_to_sce {
     path(diagnosis_celltypes_file) // maps broad diagnoses to cell type groups, for counting normal reference cells
     path(diagnosis_groups_file) // maps broad diagnoses to cell type groups, for counting normal reference cells
   output:
-    tuple val(meta), path(annotated_rds), env("REFERENCE_CELL_COUNT"), env("REFERENCE_CELL_HASH"), env("INFERCNV_STATUS")
+    tuple val(meta), path(annotated_rds), env("REFERENCE_CELL_COUNT"), env("REFERENCE_CELL_HASH")
   script:
     annotated_rds = "${meta.unique_id}_processed_annotated.rds"
     def singler_results = singler_dir ? "${singler_dir}/singler_results.rds": ""
@@ -194,13 +194,11 @@ process add_celltypes_to_sce {
       --diagnosis_groups_ref "${diagnosis_groups_file}" \
       --reference_cell_count_file "reference_cell_count.txt" \
       --reference_cell_hash_file "reference_cell_hash.txt" \
-      --reference_cell_hash_file "reference_cell_hash.txt" \
-      --infercnv_status_file "infercnv_status.txt" \
+      --reference_cell_hash_file "reference_cell_hash.txt"
 
       # save so we can export as environment variable
       REFERENCE_CELL_COUNT=\$(cat "reference_cell_count.txt")
       REFERENCE_CELL_HASH=\$(cat "reference_cell_hash.txt")
-      INFERCNV_STATUS=\$(cat "infercnv_status.txt")
     """
   stub:
     annotated_rds = "${meta.unique_id}_processed_annotated.rds"
@@ -444,13 +442,12 @@ workflow annotate_celltypes {
 
     // add inferCNV logic to meta
     added_celltypes_ch = add_celltypes_to_sce.out
-      .map{ meta_in, annotated_sce, cell_count, cell_hash, infercnv_status ->
+      .map{ meta_in, annotated_sce, cell_count, cell_hash ->
         def meta = meta_in.clone() // local copy for safe modification
         // ensure the count is saved as an integer: either the integer value, or null if it was an
         // empty string since we can do future math comparisons with null
         meta.infercnv_reference_cell_count = cell_count ? cell_count.toInteger() : null
         meta.infercnv_reference_cell_hash = cell_hash
-        meta.infercnv_status = infercnv_status
 
         // return only meta and annotated_sce
         [meta, annotated_sce]

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -485,9 +485,7 @@ workflow annotate_celltypes {
       // ensure meta.infercnv_reference_cell_count exists
       .map{ meta, unfiltered_sce, filtered_sce, processed_sce -> 
         // make sure not to overwrite a literal 0 value with null
-        if (!meta.containsKey('infercnv_reference_cell_count')) {
-          meta.infercnv_reference_cell_count = null
-        }
+        meta.putIfAbsent('infercnv_reference_cell_count', null)) 
         [meta, unfiltered_sce, filtered_sce, processed_sce]
       }
 

--- a/modules/classify-celltypes.nf
+++ b/modules/classify-celltypes.nf
@@ -445,7 +445,8 @@ workflow annotate_celltypes {
         def meta = meta_in.clone() // local copy for safe modification
         // ensure the count is saved as an integer: either the integer value, or null if it was an
         // empty string since we can do future math comparisons with null
-        meta.infercnv_reference_cell_count = cell_count ? cell_count.toInteger() : null
+        // note that this code assures that the literal number 0 remains a 0 (vs becoming null)
+        meta.infercnv_reference_cell_count = cell_count == "" ? null : cell_count.toInteger()
         meta.infercnv_reference_cell_hash = cell_hash
 
         // return only meta and annotated_sce
@@ -481,6 +482,13 @@ workflow annotate_celltypes {
       }
       // mix in cell line libraries which were not cell typed
       .mix(sce_files_channel_branched.cell_line)
+      // ensure meta.infercnv_reference_cell_count exists
+      .map{ meta_in, unfiltered_sce, filtered_sce, processed_sce -> 
+        def meta = meta_in.clone()
+        // make sure not to overwrite a literal 0 value with null
+        meta.putIfAbsent('infercnv_reference_cell_count', null)
+        [meta, unfiltered_sce, filtered_sce, processed_sce]
+      }
 
   emit: export_channel
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   nextflowVersion = '>=24.09'
-  version = 'v0.9.2'
+  version = 'v0.9.3'
   contributors = [
     [
       name: "Allegra Hawkins",

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   nextflowVersion = '>=24.09'
-  version = 'v0.9.1a'
+  version = 'v0.9.2'
   contributors = [
     [
       name: "Allegra Hawkins",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -632,12 +632,12 @@
         },
         "CELLBROWSER_CONTAINER": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.2",
+          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.3",
           "fa_icon": "fab fa-docker"
         },
         "VIREO_CONTAINER": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.2",
+          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.3",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -632,12 +632,12 @@
         },
         "CELLBROWSER_CONTAINER": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.1a",
+          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.2",
           "fa_icon": "fab fa-docker"
         },
         "VIREO_CONTAINER": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.1a",
+          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.2",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },

--- a/references/README.md
+++ b/references/README.md
@@ -21,10 +21,10 @@ These files are used by `build-celltype-ref.nf` to generate cell type annotation
 - `PanglaoDB_markers_<date>.tsv` is the full set of marker genes exported from [PanglaoDB](https://panglaodb.se), versioned at the given date.
 
 These files are copies of reference files that were created as part of `OpenScPCA`.
-See the [`cell-type-consensus` module as part of the `OpenScPCA-analysis` repository](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/v0.2.3/analyses/cell-type-consensus) to learn more about how these file were originally created.
-These files were copied from the `v0.2.3` release.
+See the [`cell-type-consensus` module as part of the `OpenScPCA-analysis` repository](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/v0.2.4/analyses/cell-type-consensus) to learn more about how these file were originally created.
+These files were copied from the `v0.2.4` release.
 
-- [`panglao-cell-type-ontologies.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.3/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv) contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `PanglaoDB` reference used when running `CellAssign`.
+- [`panglao-cell-type-ontologies.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.4/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv) contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `PanglaoDB` reference used when running `CellAssign`.
 The table includes the following columns:
 
 |  |   |
@@ -33,7 +33,7 @@ The table includes the following columns:
 | `human_readable_value` | Label associated with the cell type ontology term |
 | `panglao_cell_type` | Original name for the cell type as set by `PanglaoDB` |
 
-- [`scimilarity-mapped-ontologies.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.3/analyses/cell-type-scimilarity/references/scimilarity-mapped-ontologies.tsv) contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `SCimilarity` foundational model, [`model_v1.1`](https://zenodo.org/records/10685499).
+- [`scimilarity-mapped-ontologies.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.4/analyses/cell-type-scimilarity/references/scimilarity-mapped-ontologies.tsv) contains the [Cell Ontology identifier term](https://www.ebi.ac.uk/ols4/ontologies/cl) for all cell types available in the `SCimilarity` foundational model, [`model_v1.1`](https://zenodo.org/records/10685499).
 The table includes the following columns:
 
 | | |
@@ -42,7 +42,7 @@ The table includes the following columns:
 | `cl_annotation` | The human readable name of the cell type found in the Cell Ontology |
 | `scimilarity_celltype_ontology` | The ontology identifier associated with the name of the cell type in the Cell Ontology |
 
-- [`consensus-cell-type-reference.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.3/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv) contains a table with all cell type combinations between the `PanglaoDB` reference (used with `CellAssign`), the `BlueprintEncodeData` reference (used with `SingleR`), and the `SCimilarity` reference (used with `SCimilarity`) for which a consensus cell type is identified.
+- [`consensus-cell-type-reference.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.4/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv) contains a table with all cell type combinations between the `PanglaoDB` reference (used with `CellAssign`), the `BlueprintEncodeData` reference (used with `SingleR`), and the `SCimilarity` reference (used with `SCimilarity`) for which a consensus cell type is identified.
 
 The table includes the following columns:
 
@@ -65,7 +65,7 @@ The table includes the following columns:
 | `consensus_ontology` | Cell type ontology term for consensus cell type |
 | `consensus_annotation` | Name for the `consensus_ontology` term as defined by [Cell Ontology](https://www.ebi.ac.uk/ols4/ontologies/cl) |
 
-- [`consensus-validation-groups.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.3/analyses/cell-type-consensus/references/consensus-validation-groups.tsv) contains a table of all possible consensus cell type labels and assigns a broader group to use for validating consensus cell type assignments using marker genes.
+- [`consensus-validation-groups.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.4/analyses/cell-type-consensus/references/consensus-validation-groups.tsv) contains a table of all possible consensus cell type labels and assigns a broader group to use for validating consensus cell type assignments using marker genes.
 This table includes the following columns:
 
 
@@ -76,7 +76,7 @@ This table includes the following columns:
 | `validation_group_ontology` | Cell type ontology term for broader cell type group used for validation |
 | `consensus_annotation` | Human readable name for broader cell type group used for validation |
 
-- [`validation-markers.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.3/analyses/cell-type-consensus/references/validation-markers.tsv) contains a list of marker genes to aid in validating consensus cell types.
+- [`validation-markers.tsv`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/v0.2.4/analyses/cell-type-consensus/references/validation-markers.tsv) contains a list of marker genes to aid in validating consensus cell types.
 These markers were obtained by grabbing the most frequently observed markers for each cell type included in `consensus-validation-groups.tsv` from the [`CellMarker2.0` list of human marker genes](http://117.50.127.228/CellMarker/CellMarker_download.html).
 The top 10 genes (sometimes more if there is a tie in the frequency) are included for each cell type.
 

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -9,6 +9,7 @@ monocyte	#1CBE4F
 myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
+histamine secreting cell 	 #FF6F61 
 stem cell	#F7E1A0
 adipocyte	#FA0087
 chondrocyte	#B00068
@@ -21,6 +22,7 @@ pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
+chemoreceptor cell	#6A5ACD
 glial cell	#565656
 mesangial cell	#CCD2D8
 Unknown cell type	#E5E5E5
@@ -30,3 +32,6 @@ endocrine cell	#FF7A00
 embryonic cell (metazoa)	#CEC3B2
 ciliated cell	#00B3B3
 cardiocyte	#7A0019
+lung secretory cell    #8B5A2B
+retinal cell	#C19A6B
+surfactant secreting cell     #D94F8E

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -9,6 +9,7 @@ monocyte	#1CBE4F
 myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
+histamine secreting cell 	 #F79F81 
 stem cell	#F7E1A0
 adipocyte	#FA0087
 chondrocyte	#B00068
@@ -21,6 +22,7 @@ pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
+chemoreceptor cell	#6A5ACD
 glial cell	#565656
 mesangial cell	#CCD2D8
 Unknown cell type	#E5E5E5
@@ -30,3 +32,6 @@ endocrine cell	#FF7A00
 embryonic cell (metazoa)	#CEC3B2
 ciliated cell	#00B3B3
 cardiocyte	#7A0019
+lung secretory cell    #8B5A2B
+retinal cell	#C19A6B
+surfactant secreting cell     #D94F8E

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -6,7 +6,7 @@ innate lymphoid cell	#325A9B
 dendritic cell	#16FF32
 macrophage	#1C8356
 monocyte	#1CBE4F
-myeloid	#90AD1C
+myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
 stem cell	#F7E1A0
@@ -15,12 +15,18 @@ chondrocyte	#B00068
 endothelial cell	#FC1CBF
 epithelial cell	#C075A6
 fibroblast	#B10DA1
-melanocyte	#FE00FA
+myofibroblast cell	#FE00FA
 muscle cell	#F6222E
 pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
-mesangial cell	#E2E2E2
-unknown	#E5E5E5
+mesangial cell	#CCD2D8
+Unknown cell type	#E5E5E5
+pigment cell	#5A1A00
+kidney cell	#8A8F6A
+endocrine cell	#FF7A00
+embryonic cell (metazoa)	#CEC3B2
+ciliated cell	#00B3B3
+cardiocyte	#7A0019

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -6,7 +6,7 @@ innate lymphoid cell	#325A9B
 dendritic cell	#16FF32
 macrophage	#1C8356
 monocyte	#1CBE4F
-myeloid	#90AD1C
+myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
 stem cell	#F7E1A0
@@ -15,12 +15,18 @@ chondrocyte	#B00068
 endothelial cell	#FC1CBF
 epithelial cell	#C075A6
 fibroblast	#B10DA1
-melanocyte	#FE00FA
+myofibroblast cell	#FE00FA
 muscle cell	#F6222E
 pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
-mesangial cell	#E2E2E2
+mesangial cell	#CCD2D8
 unknown	#E5E5E5
+pigment cell	#5A1A00
+kidney cell	#8A8F6A
+endocrine cell	#FF7A00
+embryonic cell (metazoa)	#CEC3B2
+ciliated cell	#00B3B3
+cardiocyte	#7A0019

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -9,7 +9,7 @@ monocyte	#1CBE4F
 myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
-histamine secreting cell 	 #F79F81 
+histamine secreting cell 	 #FF6F61 
 stem cell	#F7E1A0
 adipocyte	#FA0087
 chondrocyte	#B00068

--- a/templates/palettes/validation-group-palette.tsv
+++ b/templates/palettes/validation-group-palette.tsv
@@ -23,7 +23,7 @@ neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
 mesangial cell	#CCD2D8
-unknown	#E5E5E5
+Unknown cell type	#E5E5E5
 pigment cell	#5A1A00
 kidney cell	#8A8F6A
 endocrine cell	#FF7A00

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -591,7 +591,7 @@ The dot plot shows the mean expression and percent of cells expressing the marke
 The y-axis includes marker genes for each cell type.
 Marker genes were obtained from the list of Human cell markers on [`CellMarker2.0`](http://www.bio-bigdata.center/CellMarker_download.html).
 All marker genes shown are specific to a single cell type, with the exception of hematopoietic precursor cells, if present, which express genes found in other, more differentiated immune cells.
-Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown. 
+Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown.
 
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
@@ -616,7 +616,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
-# any cell types missing from the palette should be excluded from the dotplot 
+# any cell types missing from the palette should be excluded from the dotplot
 celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
@@ -694,7 +694,7 @@ group_stats_df <- consensus_df |>
   # this includes all possible marker genes and all possible validation group assignments
   dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
   dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
-  # to be safe, ensure we're only retaining cell type group we have colors for 
+  # to be safe, ensure we're only retaining cell type group we have colors for
   dplyr::filter(broad_celltype_group %in% names(celltype_colors)) |>
   dplyr::mutate(
     # get total percent expressed
@@ -752,7 +752,7 @@ n_markers <- length(unique(dotplot_df$gene_symbol))
 n_celltypes <- length(unique(dotplot_df$broad_celltype_group))
 
 dotplot_height <- 8
-dotplot_width <- 15 
+dotplot_width <- 15
 dotplot_text_size <- 14
 
 # update default sizing if we have a lot of info in the plot
@@ -762,7 +762,7 @@ if (n_markers >= 50) {
   dotplot_text_size <- 18
 } else if (n_celltypes >= 20) {
   dotplot_height <- dotplot_height * 1.25
-} 
+}
 ```
 
 

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -663,7 +663,7 @@ consensus_df <- celltype_df |>
   dplyr::mutate(
     broad_celltype_group = dplyr::if_else(
       is.na(broad_celltype_group),
-      "Unknown cell type", # match rest of report text
+      "Unknown cell type", # match rest of report text; also must match the unknown label in the palette
       broad_celltype_group
     )
   )

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -591,6 +591,7 @@ The dot plot shows the mean expression and percent of cells expressing the marke
 The y-axis includes marker genes for each cell type.
 Marker genes were obtained from the list of Human cell markers on [`CellMarker2.0`](http://www.bio-bigdata.center/CellMarker_download.html).
 All marker genes shown are specific to a single cell type, with the exception of hematopoietic precursor cells, if present, which express genes found in other, more differentiated immune cells.
+Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown. 
 
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
@@ -662,7 +663,7 @@ consensus_df <- celltype_df |>
   dplyr::mutate(
     broad_celltype_group = dplyr::if_else(
       is.na(broad_celltype_group),
-      "unknown",
+      "Unknown cell type", # match rest of report text
       broad_celltype_group
     )
   )
@@ -746,7 +747,27 @@ dotplot_df <- group_stats_df |>
 ```
 
 
-```{r, eval = has_consensus, fig.height = 7, fig.width = 15}
+```{r, eval = has_consensus}
+n_markers <- length(unique(dotplot_df$gene_symbol))
+n_celltypes <- length(unique(dotplot_df$broad_celltype_group))
+
+dotplot_height <- 8
+dotplot_width <- 15 
+dotplot_text_size <- 14
+
+# update default sizing if we have a lot of info in the plot
+if (n_markers >= 50) {
+  dotplot_width <- pmin(n_markers * 0.3, 30)
+  dotplot_height <- 10
+  dotplot_text_size <- 18
+} else if (n_celltypes >= 20) {
+  dotplot_height <- dotplot_height * 1.25
+} 
+```
+
+
+
+```{r, eval = has_consensus, fig.height = dotplot_height, fig.width = dotplot_width}
 # only make a dot plot if we have at least one validation group annotation present
 if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp
@@ -761,7 +782,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
       strip.text.x = element_blank(),
       axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
       axis.ticks.x = element_blank(),
-      text = element_text(size = 14),
+      text = element_text(size = dotplot_text_size),
       panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
     ) +
     labs(
@@ -780,7 +801,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
     ggmap::theme_nothing() +
     theme(
       strip.background = element_rect(fill = "transparent", color = NA),
-      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
+      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = dotplot_text_size),
       strip.placement = "outside",
       legend.position = "none",
       panel.spacing = unit(0.5, "lines"),

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -591,6 +591,7 @@ The dot plot shows the mean expression and percent of cells expressing the marke
 The y-axis includes marker genes for each cell type.
 Marker genes were obtained from the list of Human cell markers on [`CellMarker2.0`](http://www.bio-bigdata.center/CellMarker_download.html).
 All marker genes shown are specific to a single cell type, with the exception of hematopoietic precursor cells, if present, which express genes found in other, more differentiated immune cells.
+Note that broad cell type groups without associated marker genes in `CellMarker2.0` are not shown.
 
 We expect that each cell type group should show high expression of marker genes associated with that cell type compared to all other cells in the dataset.
 
@@ -615,6 +616,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
+# any cell types missing from the palette should be excluded from the dotplot
 celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
@@ -661,7 +663,7 @@ consensus_df <- celltype_df |>
   dplyr::mutate(
     broad_celltype_group = dplyr::if_else(
       is.na(broad_celltype_group),
-      "unknown",
+      "Unknown cell type", # match rest of report text; also must match the unknown label in the palette
       broad_celltype_group
     )
   )
@@ -692,6 +694,8 @@ group_stats_df <- consensus_df |>
   # this includes all possible marker genes and all possible validation group assignments
   dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
   dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
+  # to be safe, ensure we're only retaining cell type group we have colors for
+  dplyr::filter(broad_celltype_group %in% names(celltype_colors)) |>
   dplyr::mutate(
     # get total percent expressed
     percent_exp = (detected_count / total_cells) * 100,
@@ -743,7 +747,27 @@ dotplot_df <- group_stats_df |>
 ```
 
 
-```{r, eval = has_consensus, fig.height=7, fig.width=15}
+```{r, eval = has_consensus}
+n_markers <- length(unique(dotplot_df$gene_symbol))
+n_celltypes <- length(unique(dotplot_df$broad_celltype_group))
+
+dotplot_height <- 8
+dotplot_width <- 15
+dotplot_text_size <- 14
+
+# update default sizing if we have a lot of info in the plot
+if (n_markers >= 50) {
+  dotplot_width <- pmin(n_markers * 0.3, 30)
+  dotplot_height <- 10
+  dotplot_text_size <- 18
+} else if (n_celltypes >= 20) {
+  dotplot_height <- dotplot_height * 1.25
+}
+```
+
+
+
+```{r, eval = has_consensus, fig.height = dotplot_height, fig.width = dotplot_width}
 # only make a dot plot if we have at least one validation group annotation present
 if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp
@@ -758,7 +782,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
       strip.text.x = element_blank(),
       axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
       axis.ticks.x = element_blank(),
-      text = element_text(size = 14),
+      text = element_text(size = dotplot_text_size),
       panel.spacing = unit(0.5, "lines") # adjust spacing and match with annotation bar
     ) +
     labs(
@@ -777,7 +801,7 @@ if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
     ggmap::theme_nothing() +
     theme(
       strip.background = element_rect(fill = "transparent", color = NA),
-      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = 12),
+      strip.text.x = element_text(angle = 90, hjust = 0, vjust = 0.5, size = dotplot_text_size),
       strip.placement = "outside",
       legend.position = "none",
       panel.spacing = unit(0.5, "lines"),

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -615,6 +615,7 @@ markers_df <- validation_markers_df |>
   dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
 # define color palette
+# any cell types missing from the palette should be excluded from the dotplot 
 celltype_colors <- params$validation_palette_df |>
   tibble::deframe()
 ```
@@ -692,6 +693,8 @@ group_stats_df <- consensus_df |>
   # this includes all possible marker genes and all possible validation group assignments
   dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
   dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
+  # to be safe, ensure we're only retaining cell type group we have colors for 
+  dplyr::filter(broad_celltype_group %in% names(celltype_colors)) |>
   dplyr::mutate(
     # get total percent expressed
     percent_exp = (detected_count / total_cells) * 100,
@@ -743,7 +746,7 @@ dotplot_df <- group_stats_df |>
 ```
 
 
-```{r, eval = has_consensus, fig.height=7, fig.width=15}
+```{r, eval = has_consensus, fig.height = 7, fig.width = 15}
 # only make a dot plot if we have at least one validation group annotation present
 if (length(unique(dotplot_df$validation_group_annotation)) > 0) {
   # make dotplot with marker gene exp

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -26,63 +26,63 @@ if (infercnv_status == "unknown_diagnosis") {
     <div class=\"alert alert-info\">
     inferCNV was not run because a sample diagnosis was not provided in the sample metadata file.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "multiple_diagnoses_multiplexed") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because multiple diagnoses were detected across multiplexed samples.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "multiple_diagnosis_groups_multiplexed") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because multiple diagnosis groups were detected across multiplexed samples.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "skipped_non_cancerous") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because this library is from a non-cancerous sample or collection of non-cancerous samples.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "no_diagnosis_celltype_reference") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because the diagnosis cell types metadata file was not provided.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "unknown_reference_celltypes") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because reference cell types for the sample's diagnosis group were not present in the cell types metadata file.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "unknown_reference_celltypes") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because consensus cell type annotations were not assigned.
     </div>
-  ")  
+  ")
 } else if (infercnv_status == "insufficient_reference_cells") {
-glue::glue("
+  glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because there were not enough normal reference cells present in the processed object.
     At least {params$infercnv_min_reference_cells} normal reference cells are required, but only {sum(processed_sce$is_infercnv_reference)} cells were present.
     </div>
-  ") 
+  ")
 } else if (infercnv_status == "failure") {
-glue::glue("
+  glue::glue("
     <div class=\"alert alert-info\">
     inferCNV failed to run; no results are included in this section.
     </div>
-  ") 
+  ")
 } else {
-glue::glue("
+  glue::glue("
     <div class=\"alert alert-info\">
     An unknown error with inferCNV occurred; no results are included in this section.
     </div>
-  ") 
-} 
+  ")
+}
 
 knitr::knit_exit(fully = FALSE) # don't quit the whole report, just this subnotebook
 ```

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -3,30 +3,87 @@
 <!--
 This file is meant to be run as a child report from `main_qc_report.rmd`
 -->
+
+<!--
+InferCNV status meanings:
+
+"unknown_diagnosis": No diagnosis provided in the sample metadata file
+"multiple_diagnoses_multiplexed": Multiple diagnoses across multiplexed and mapping file not provided
+"multiple_diagnosis_groups_multiplexed": Multiple diagnoses across multiplexed and mapping file *was* provided
+"skipped_non_cancerous": skipped since non-tumor
+"no_diagnosis_celltype_reference": No cell type reference file was provided
+"unknown_reference_celltypes": Diagnosis not present in the reference cell types file
+"no_consensus": No cell type consensus results
+"insufficient_reference_cells": Fewer than 100 (default param) normal cells
+"failure": Failed to run
+
+"success": Success!
+--> 
+
 ```{r results = 'asis', eval = infercnv_unsuccessful}
-# metadata(processed_sce)$infercnv_success is NA: insufficient reference cells so inferCNV wasn't run or is non-cancerous
-# metadata(processed_sce)$infercnv_success is FALSE: inferCNV actually failed
-infercnv_success <- metadata(processed_sce)$infercnv_success
-if (is.na(infercnv_success) && metadata(processed_sce)$infercnv_diagnosis_groups == "Non-cancerous") {
+if (infercnv_status == "unknown_diagnosis") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because a sample diagnosis was not provided in the sample metadata file.
+    </div>
+  ")
+} else if (infercnv_status == "multiple_diagnoses_multiplexed") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because multiple diagnoses were detected across multiplexed samples.
+    </div>
+  ")
+} else if (infercnv_status == "multiple_diagnosis_groups_multiplexed") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because multiple diagnosis groups were detected across multiplexed samples.
+    </div>
+  ")
+} else if (infercnv_status == "skipped_non_cancerous") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because this library is from a non-cancerous sample or collection of non-cancerous samples.
     </div>
   ")
-} else if (is.na(infercnv_success) && metadata(processed_sce)$infercnv_num_reference_cells < params$infercnv_min_reference_cells) {
+} else if (infercnv_status == "no_diagnosis_celltype_reference") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because the diagnosis cell types metadata file was not provided.
+    </div>
+  ")
+} else if (infercnv_status == "unknown_reference_celltypes") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because reference cell types for the sample's diagnosis group were not present in the cell types metadata file.
+    </div>
+  ")
+} else if (infercnv_status == "unknown_reference_celltypes") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because consensus cell type annotations were not assigned.
+    </div>
+  ")
+} else if (infercnv_status == "insufficient_reference_cells") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because there were not enough normal reference cells present in the processed object.
     At least {params$infercnv_min_reference_cells} normal reference cells are required, but only {sum(processed_sce$is_infercnv_reference)} cells were present.
     </div>
   ")
-} else if (!(infercnv_success)) {
+} else if (infercnv_status == "failure") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV failed to run; no results are included in this section.
     </div>
   ")
+} else {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    An unknown error with inferCNV occurred; no results are included in this section.
+    </div>
+  ")
 }
+
 knitr::knit_exit(fully = FALSE) # don't quit the whole report, just this subnotebook
 ```
 

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -3,30 +3,87 @@
 <!--
 This file is meant to be run as a child report from `main_qc_report.rmd`
 -->
-```{r results = 'asis', eval = infercnv_unsuccessful}
-# metadata(processed_sce)$infercnv_success is NA: insufficient reference cells so inferCNV wasn't run or is non-cancerous
-# metadata(processed_sce)$infercnv_success is FALSE: inferCNV actually failed
-infercnv_success <- metadata(processed_sce)$infercnv_success
-if (is.na(infercnv_success) && metadata(processed_sce)$infercnv_diagnosis_groups == "Non-cancerous") {
+
+<!--
+InferCNV status meanings:
+
+"unknown_diagnosis": No diagnosis provided in the sample metadata file
+"multiple_diagnoses_multiplexed": Multiple diagnoses across multiplexed and mapping file not provided
+"multiple_diagnosis_groups_multiplexed": Multiple diagnoses across multiplexed and mapping file *was* provided
+"skipped_non_cancerous": skipped since non-tumor
+"no_diagnosis_celltype_reference": No cell type reference file was provided
+"unknown_reference_celltypes": Diagnosis not present in the reference cell types file
+"no_consensus": No cell type consensus results
+"insufficient_reference_cells": Fewer than 100 (default param) normal cells
+"failure": Failed to run
+
+"success": Success!
+--> 
+
+```{r results = 'asis', eval = show_infercnv_message}
+if (infercnv_status == "unknown_diagnosis") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because a sample diagnosis was not provided in the sample metadata file.
+    </div>
+  ")  
+} else if (infercnv_status == "multiple_diagnoses_multiplexed") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because multiple diagnoses were detected across multiplexed samples.
+    </div>
+  ")  
+} else if (infercnv_status == "multiple_diagnosis_groups_multiplexed") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because multiple diagnosis groups were detected across multiplexed samples.
+    </div>
+  ")  
+} else if (infercnv_status == "skipped_non_cancerous") {
   glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because this library is from a non-cancerous sample or collection of non-cancerous samples.
     </div>
-  ")
-} else if (is.na(infercnv_success) && metadata(processed_sce)$infercnv_num_reference_cells < params$infercnv_min_reference_cells) {
+  ")  
+} else if (infercnv_status == "no_diagnosis_celltype_reference") {
   glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because the diagnosis cell types metadata file was not provided.
+    </div>
+  ")  
+} else if (infercnv_status == "unknown_reference_celltypes") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because reference cell types for the sample's diagnosis group were not present in the cell types metadata file.
+    </div>
+  ")  
+} else if (infercnv_status == "unknown_reference_celltypes") {
+  glue::glue("
+    <div class=\"alert alert-info\">
+    inferCNV was not run because consensus cell type annotations were not assigned.
+    </div>
+  ")  
+} else if (infercnv_status == "insufficient_reference_cells") {
+glue::glue("
     <div class=\"alert alert-info\">
     inferCNV was not run because there were not enough normal reference cells present in the processed object.
     At least {params$infercnv_min_reference_cells} normal reference cells are required, but only {sum(processed_sce$is_infercnv_reference)} cells were present.
     </div>
-  ")
-} else if (!(infercnv_success)) {
-  glue::glue("
+  ") 
+} else if (infercnv_status == "failure") {
+glue::glue("
     <div class=\"alert alert-info\">
     inferCNV failed to run; no results are included in this section.
     </div>
-  ")
-}
+  ") 
+} else {
+glue::glue("
+    <div class=\"alert alert-info\">
+    An unknown error with inferCNV occurred; no results are included in this section.
+    </div>
+  ") 
+} 
+
 knitr::knit_exit(fully = FALSE) # don't quit the whole report, just this subnotebook
 ```
 

--- a/templates/qc_report/infercnv_qc.rmd
+++ b/templates/qc_report/infercnv_qc.rmd
@@ -20,7 +20,7 @@ InferCNV status meanings:
 "success": Success!
 --> 
 
-```{r results = 'asis', eval = show_infercnv_message}
+```{r results = 'asis', eval = infercnv_unsuccessful}
 if (infercnv_status == "unknown_diagnosis") {
   glue::glue("
     <div class=\"alert alert-info\">

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -148,6 +148,7 @@ if (has_processed) {
   has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
   # Determine inferCNV status
+  include_infercnv_report <- FALSE # overwrite below if TRUE
   infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
   if (!(is.null(infercnv_status))) {
     # turn on the child report
@@ -524,7 +525,7 @@ if (has_processed) {
       <div class=\"alert alert-warning\">
 
       This library contains fewer than {min_processed} cells in the processed `SingleCellExperiment` object after removal of low quality cells.
-      UMAP is unable to be calculated and plots will not be shown.
+      This may affect the interpretation of results.
 
       </div>
     ")
@@ -728,8 +729,8 @@ if (has_filtered && has_processed) {
 The raw counts from all cells that remain after filtering low quality cells (RNA only) are then normalized prior to selection of highly variable genes and dimensionality reduction.
 
 
-<!-- Next section include only if UMAP is present -->
-```{r, child='umap_qc.rmd', eval = has_umap}
+<!-- Next section shows UMAPs, only if present -->
+```{r, child='umap_qc.rmd'}
 ```
 
 <!-- Next section included only if CITE-seq data is present -->

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -154,7 +154,7 @@ if (has_processed) {
     run_infercnv_report <- TRUE
 
     # whether to print non-successful messages - only used if run_infercnv_report is TRUE
-    show_infercnv_message <- infercnv_status != "success"
+    infercnv_unsuccessful <- infercnv_status != "success"
 
     # associated checks
     if (infercnv_status == "insufficient_reference_cells") {
@@ -748,7 +748,7 @@ The raw counts from all cells that remain after filtering low quality cells (RNA
 ```
 
 <!-- Next section only included if there is an inferCNV status to report on -->
-```{r, child='infercnv_qc.rmd', eval = run_infercnv_report}
+```{r, child='infercnv_qc.rmd', eval = include_infercnv_report}
 ```
 
 # Session Info

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -147,21 +147,24 @@ if (has_processed) {
   # If at least 1 is present, we have cell type annotations.
   has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
-  # Determine inferCNV condition and include one check while we're in this if
-  # define these with FALSE baseline, to be overridden if present
-  has_infercnv_results <- FALSE
-  infercnv_unsuccessful <- FALSE
-  if (!is.null(metadata(processed_sce)$infercnv_success)) {
-    # TRUE or FALSE only
-    has_infercnv_results <- tidyr::replace_na(metadata(processed_sce)$infercnv_success, FALSE)
+  # Determine inferCNV status
+  infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
+  if (!(is.null(infercnv_status))) {
+    # turn on the child report
+    include_infercnv_report <- TRUE
 
-    # infercnv_unsuccessful used when there are no results but a success status
-    infercnv_unsuccessful <- !has_infercnv_results
+    # whether to print non-successful messages - only used if run_infercnv_report is TRUE
+    infercnv_unsuccessful <- infercnv_status != "success"
 
-    # this is the only condition we'll need this information
-    if (is.na(metadata(processed_sce)$infercnv_success)) {
+    # associated checks
+    if (infercnv_status == "insufficient_reference_cells") {
       stopifnot(
         "infercnv_min_reference_cells was not specified" = !is.null(params$infercnv_min_reference_cells)
+      )
+    } else if (infercnv_status == "success") {
+      stopifnot(
+        "inferCNV results are present but the heatmap file has not been provided" = !is.null(params$infercnv_heatmap_file),
+        "inferCNV heatmap file is empty" = file.info(params$infercnv_heatmap_file)$size > 0
       )
     }
   }
@@ -177,8 +180,7 @@ if (has_processed) {
   has_openscpca <- FALSE
   has_submitter <- FALSE
   has_celltypes <- FALSE
-  infercnv_unsuccessful <- FALSE
-  has_infercnv_results <- FALSE
+  include_infercnv_report <- FALSE
 }
 
 
@@ -196,13 +198,6 @@ if (has_consensus) {
   )
 }
 
-# check for heatmap if inferCNV is present
-if (has_infercnv_results) {
-  stopifnot(
-    "inferCNV results are present but the heatmap file has not been provided" = !is.null(params$infercnv_heatmap_file),
-    "inferCNV heatmap file is empty" = file.info(params$infercnv_heatmap_file)$size > 0
-  )
-}
 
 # check if we have multiplex
 has_multiplex <- length(sample_id) > 1
@@ -752,9 +747,8 @@ The raw counts from all cells that remain after filtering low quality cells (RNA
 ```{r, child='celltypes_qc.rmd', eval = has_celltypes}
 ```
 
-<!-- Next sections only included if inferCNV is present or was attempted unsuccessfully -->
-
-```{r, child='infercnv_qc.rmd', eval = has_infercnv_results || infercnv_unsuccessful}
+<!-- Next section only included if there is an inferCNV status to report on -->
+```{r, child='infercnv_qc.rmd', eval = include_infercnv_report}
 ```
 
 # Session Info

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -150,13 +150,12 @@ if (has_processed) {
   # Determine inferCNV status
   infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
   if (!(is.null(infercnv_status))) {
-
     # turn on the child report
-    run_infercnv_report <- TRUE 
+    run_infercnv_report <- TRUE
 
     # whether to print non-successful messages - only used if run_infercnv_report is TRUE
-    show_infercnv_message <- infercnv_status != "success" 
-    
+    show_infercnv_message <- infercnv_status != "success"
+
     # associated checks
     if (infercnv_status == "insufficient_reference_cells") {
       stopifnot(
@@ -166,7 +165,7 @@ if (has_processed) {
       stopifnot(
         "inferCNV results are present but the heatmap file has not been provided" = !is.null(params$infercnv_heatmap_file),
         "inferCNV heatmap file is empty" = file.info(params$infercnv_heatmap_file)$size > 0
-        )
+      )
     }
   }
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -524,7 +524,7 @@ if (has_processed) {
       <div class=\"alert alert-warning\">
 
       This library contains fewer than {min_processed} cells in the processed `SingleCellExperiment` object after removal of low quality cells.
-      UMAP is unable to be calculated and plots will not be shown.
+      This may affect the interpretation of results.
 
       </div>
     ")
@@ -728,8 +728,8 @@ if (has_filtered && has_processed) {
 The raw counts from all cells that remain after filtering low quality cells (RNA only) are then normalized prior to selection of highly variable genes and dimensionality reduction.
 
 
-<!-- Next section include only if UMAP is present -->
-```{r, child='umap_qc.rmd', eval = has_umap}
+<!-- Next section shows UMAPs, only if present -->
+```{r, child='umap_qc.rmd'}
 ```
 
 <!-- Next section included only if CITE-seq data is present -->

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -151,7 +151,7 @@ if (has_processed) {
   infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
   if (!(is.null(infercnv_status))) {
     # turn on the child report
-    run_infercnv_report <- TRUE
+    include_infercnv_report <- TRUE
 
     # whether to print non-successful messages - only used if run_infercnv_report is TRUE
     infercnv_unsuccessful <- infercnv_status != "success"

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -148,6 +148,7 @@ if (has_processed) {
   has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
   # Determine inferCNV status
+  include_infercnv_report <- FALSE # overwrite below if TRUE
   infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
   if (!(is.null(infercnv_status))) {
     # turn on the child report

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -180,7 +180,7 @@ if (has_processed) {
   has_openscpca <- FALSE
   has_submitter <- FALSE
   has_celltypes <- FALSE
-  run_infercnv_report <- FALSE
+  include_infercnv_report <- FALSE
 }
 
 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -147,22 +147,26 @@ if (has_processed) {
   # If at least 1 is present, we have cell type annotations.
   has_celltypes <- any(has_singler, has_cellassign, has_scimilarity, has_consensus, has_submitter, has_openscpca)
 
-  # Determine inferCNV condition and include one check while we're in this if
-  # define these with FALSE baseline, to be overridden if present
-  has_infercnv_results <- FALSE
-  infercnv_unsuccessful <- FALSE
-  if (!is.null(metadata(processed_sce)$infercnv_success)) {
-    # TRUE or FALSE only
-    has_infercnv_results <- tidyr::replace_na(metadata(processed_sce)$infercnv_success, FALSE)
+  # Determine inferCNV status
+  infercnv_status <- metadata(processed_sce)$infercnv_status # save some typing
+  if (!(is.null(infercnv_status))) {
 
-    # infercnv_unsuccessful used when there are no results but a success status
-    infercnv_unsuccessful <- !has_infercnv_results
+    # turn on the child report
+    run_infercnv_report <- TRUE 
 
-    # this is the only condition we'll need this information
-    if (is.na(metadata(processed_sce)$infercnv_success)) {
+    # whether to print non-successful messages - only used if run_infercnv_report is TRUE
+    show_infercnv_message <- infercnv_status != "success" 
+    
+    # associated checks
+    if (infercnv_status == "insufficient_reference_cells") {
       stopifnot(
         "infercnv_min_reference_cells was not specified" = !is.null(params$infercnv_min_reference_cells)
       )
+    } else if (infercnv_status == "success") {
+      stopifnot(
+        "inferCNV results are present but the heatmap file has not been provided" = !is.null(params$infercnv_heatmap_file),
+        "inferCNV heatmap file is empty" = file.info(params$infercnv_heatmap_file)$size > 0
+        )
     }
   }
 
@@ -177,8 +181,7 @@ if (has_processed) {
   has_openscpca <- FALSE
   has_submitter <- FALSE
   has_celltypes <- FALSE
-  infercnv_unsuccessful <- FALSE
-  has_infercnv_results <- FALSE
+  run_infercnv_report <- FALSE
 }
 
 
@@ -196,13 +199,6 @@ if (has_consensus) {
   )
 }
 
-# check for heatmap if inferCNV is present
-if (has_infercnv_results) {
-  stopifnot(
-    "inferCNV results are present but the heatmap file has not been provided" = !is.null(params$infercnv_heatmap_file),
-    "inferCNV heatmap file is empty" = file.info(params$infercnv_heatmap_file)$size > 0
-  )
-}
 
 # check if we have multiplex
 has_multiplex <- length(sample_id) > 1
@@ -752,9 +748,8 @@ The raw counts from all cells that remain after filtering low quality cells (RNA
 ```{r, child='celltypes_qc.rmd', eval = has_celltypes}
 ```
 
-<!-- Next sections only included if inferCNV is present or was attempted unsuccessfully -->
-
-```{r, child='infercnv_qc.rmd', eval = has_infercnv_results || infercnv_unsuccessful}
+<!-- Next section only included if there is an inferCNV status to report on -->
+```{r, child='infercnv_qc.rmd', eval = run_infercnv_report}
 ```
 
 # Session Info

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -1,5 +1,14 @@
 ## Dimensionality reduction {.tabset}
 
+```{r results = 'asis', eval = !has_umap}
+glue::glue("
+  <div class=\"alert alert-info\">
+  No plots are shown in this section because the UMAP (Uniform Manifold Approximation and Projection) embeddings could not be calculated.
+  </div>
+")
+knitr::knit_exit(fully = FALSE) # don't quit the whole report, just this subnotebook
+```
+
 The plots in this section show the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell. 
 
 ```{r}


### PR DESCRIPTION
Re-opened version of #1172 but using a feature branch instead. 

Towards #1160 

This merges in the changes that are in `development` to `main`, which includes: 

- Refactoring of inferCNV to use `infercnv_status`
- Updates to the QC report to account for missing validation groups and update dot plot sizing
- A new copy of the consensus cell type reference from `OpenScPCA-analysis` v0.2.4
- An update to the validation palette to include all possible validation groups 

I ran this through with `-profile ccdl,batch --perform_celltyping --perform_cnv_inference` and everything looked as expected. 