### PR TITLE
remove example containers

### DIFF
--- a/config/profile_example.config
+++ b/config/profile_example.config
@@ -19,8 +19,4 @@ params {
   // celltyping and infercnv on
   perform_celltyping = true
   perform_cnv_inference = true
-
-  // CCDL private containers needed for processes that use cellranger and spaceranger
-  cellranger_container = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:9.0.1'
-  spaceranger_container = '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
 }


### PR DESCRIPTION
As part of the new infra revisions, we don't want to have these containers set, even for the example repo. This PR removes them from the last place we had them.