### PR TITLE
add a bit more memory for infercnv

### DIFF
--- a/config/process_base.config
+++ b/config/process_base.config
@@ -2,38 +2,41 @@
 params.max_memory = 512.GB
 
 process {
-  resourceLimits = [ cpus: 12, memory: 32.GB ]
-  memory = {4.GB * task.attempt}
+  resourceLimits = [cpus: 12, memory: 32.GB]
+  memory = { 4.GB * task.attempt }
 
   errorStrategy = { task.attempt < 3 ? 'retry' : 'finish' }
   maxRetries = 2
   maxErrors = '-1'
 
   withLabel: mem_8 {
-    memory = {8.GB * task.attempt}
+    memory = { 8.GB * task.attempt }
   }
   withLabel: mem_16 {
-    memory = {16.GB * task.attempt}
+    memory = { 16.GB * task.attempt }
   }
   withLabel: mem_24 {
-    memory = {24.GB * task.attempt}
+    memory = { 24.GB * task.attempt }
   }
   withLabel: mem_32 {
-    memory = {32.GB * task.attempt}
+    memory = { 32.GB * task.attempt }
   }
   withLabel: mem_96 {
-    memory = {48.GB  + 48.GB * task.attempt}
+    memory = { 48.GB + 48.GB * task.attempt }
+  }
+  withLabel: mem_128 {
+    memory = { 64.GB + 64.GB * task.attempt }
   }
   withLabel: mem_max {
-    memory = {(task.attempt > 2  && task.exitStatus in 137..140) ? params.max_memory : 192.GB * task.attempt}
+    memory = { task.attempt > 2 && task.exitStatus in 137..140 ? params.max_memory : 192.GB * task.attempt }
   }
-  withLabel: cpus_2  {
+  withLabel: cpus_2 {
     cpus = 2
   }
-  withLabel: cpus_4  {
+  withLabel: cpus_4 {
     cpus = 4
   }
-  withLabel: cpus_8  {
+  withLabel: cpus_8 {
     cpus = 8
   }
   withLabel: cpus_12 {

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -9,7 +9,7 @@ process run_infercnv {
     mode: 'copy',
     pattern: "{${meta.unique_id}_infercnv-*,scpca-meta.json}"
   )
-  label 'mem_96'
+  label 'mem_128'
   label 'cpus_8'
   tag "${meta.unique_id}"
   input:
@@ -96,7 +96,7 @@ workflow call_cnvs {
     sce_files_channel_branched = sce_files_channel
       .branch{ meta, _unfiltered, _filtered, _processed ->
         no_infercnv: (
-          meta.sample_id.split(",").every{ it in cell_line_samples.getVal() } 
+          meta.sample_id.split(",").every{ it in cell_line_samples.getVal() }
           || meta.infercnv_reference_cell_count == null
         )
         tissue: true


### PR DESCRIPTION
I noticed during the last set of runs runs that infercnv has a strong chance of failure in its first attempt with the current memory setup, so I added a bit more for it. 

This meant adding one more tag, but otherwise a pretty minimal change!