### PR TITLE
Fix metrics script and report

### DIFF
--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# This script generates a QC report using scpcaTools from a pair of filtered and unfiltered SCE objects
+# This script generates a JSON file with SCE metrics used by the compare-metrics report
 
 # import libraries
 suppressPackageStartupMessages({

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -292,13 +292,12 @@ metrics_df <- dplyr::full_join(
   by = c("project_id", "sample_id", "library_id"),
   suffix = c(".ref", ".comp")
 )
-# temporary write for testing
+# write for caching
 readr::write_rds(metrics_df, "metrics.rds")
 ```
 
 ```{r, eval=use_cache}
 #| include: false
-# temporary chunk for testing
 metrics_df <- readr::read_rds("metrics.rds")
 ```
 
@@ -1156,7 +1155,10 @@ types_stats <- metrics_df |>
   dplyr::mutate(
     dplyr::across(
       dplyr::ends_with(c("types_added", "types_removed")),
-      \(x) purrr::map_chr(x, \(y) paste0(y, collapse = ","))
+      \(x) purrr::map_chr(x, \(y) {
+	      # use NA_character_ if it's actually NA
+        ifelse(is.na(y), NA_character_, paste0(y, collapse = ","))
+      })
     )
   ) |>
   # pivot by celltype method
@@ -1169,8 +1171,9 @@ types_stats <- metrics_df |>
     # convert characters back to lists for types added and removed prior to counting
     types_added = purrr::map(types_added, \(x) unlist(stringr::str_split(x, ","))),
     types_removed = purrr::map(types_removed, \(x) unlist(stringr::str_split(x, ","))),
-    types_added_count = purrr::map_int(types_added, length),
-    types_removed_count = purrr::map_int(types_removed, length)
+    # record NA instead of length if the value is actually NA
+    types_added_count = dplyr::if_else(is.na(types_added), NA_integer_, purrr::map_int(types_added, length)),
+    types_removed_count = dplyr::if_else(is.na(types_removed), NA_integer_, purrr::map_int(types_removed, length))
   ) |>
   dplyr::relocate(types_added_count, types_removed_count, .before = types_added)
 
@@ -1279,8 +1282,8 @@ changed_types |>
     colnames = c(
       "Project", "Sample", "Library",
       "Cell type method", "Minimum changed cell types", "Scaled distance",
+      "Added cell types", "Removed cell types",
       "Added cell type count", "Removed cell type count",
-      "Added cell types", "Removed cell types"
     )
   )
 ```

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1156,7 +1156,7 @@ types_stats <- metrics_df |>
     dplyr::across(
       dplyr::ends_with(c("types_added", "types_removed")),
       \(x) purrr::map_chr(x, \(y) {
-	      # use NA_character_ if it's actually NA
+        # use NA_character_ if it's actually NA
         ifelse(is.na(y), NA_character_, paste0(y, collapse = ","))
       })
     )

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1282,8 +1282,8 @@ changed_types |>
     colnames = c(
       "Project", "Sample", "Library",
       "Cell type method", "Minimum changed cell types", "Scaled distance",
-      "Added cell types", "Removed cell types",
-      "Added cell type count", "Removed cell type count"
+      "Added cell type count", "Removed cell type count",
+      "Added cell types", "Removed cell types"
     )
   )
 ```

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1283,7 +1283,7 @@ changed_types |>
       "Project", "Sample", "Library",
       "Cell type method", "Minimum changed cell types", "Scaled distance",
       "Added cell types", "Removed cell types",
-      "Added cell type count", "Removed cell type count",
+      "Added cell type count", "Removed cell type count"
     )
   )
 ```


### PR DESCRIPTION
Closes #1175: updates the script comment
Closes #1176: updates the report


For this PR, I updated the metrics report to fix a bug in cell type counting I caught the other week. I tested this with a comparison JSON that had an additional cell type (aptly named `v2 additional celltype`): 
[compare-metrics-template.html](https://github.com/user-attachments/files/25400504/compare-metrics-template.html)
More details about testing are in #1176, but I didn't repeat the full set of testing I did the other week. Please let me know if you would like to see some refreshed examples and I can certainly generate reports for some more cases!

There are also some comments that say temporary for the cache rds - perhaps this began as temporary but ended up being a fixture? I cleaned those up since it doesn't seem temporary anymore - let me know if it should be though and I can take things the other direction.
