### PR TITLE
Add inferCNV to metrics report

### DIFF
--- a/bin/sce_metrics.R
+++ b/bin/sce_metrics.R
@@ -142,6 +142,7 @@ if (file.size(opt$processed_sce) > 0) {
   metrics$hv_genes <- metadata(processed_sce)$highly_variable_genes
   metrics$infercnv_total_cnv <- sum(processed_sce$infercnv_total_cnv)
   metrics$infercnv_reference_cells <- metadata(processed_sce)$infercnv_reference_celltypes
+  metrics$infercnv_num_reference_cells <- metadata(processed_sce)$infercnv_num_reference_cells
   metrics$cluster_algorithm <- metadata(processed_sce)$cluster_algorithm
   metrics$cluster_sizes <- as.vector(table(processed_sce$cluster)) # cluster counts as unnamed vector
 

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -46,7 +46,7 @@ HTO
 HTOs
 HVGs
 Ichihara
-inferCNV
+infercnv
 intronic
 JA
 Jaccard

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -46,7 +46,8 @@ HTO
 HTOs
 HVGs
 Ichihara
-infercnv
+inferCNV
+InferCNV
 intronic
 JA
 Jaccard

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1456,13 +1456,12 @@ has_infercnv_num_ref_changes <- nrow(changed_infercnv_num_ref_counts) > 0
 if (!has_infercnv_num_ref_changes) {
   knitr::asis_output(
     "There are no changes in the number of normal inferCNV reference cells between the reference and comparison runs."
-  ) 
+  )
 } else {
   knitr::asis_output(glue::glue(
     "Of the **{nrow(infercnv_num_ref_changes)}** libraries, **{nrow(changed_infercnv_num_ref_counts)}** {ifelse(nrow(changed_infercnv_num_ref_counts) == 1, 'has', 'have')} changes in the number of normal inferCNV reference cells."
   ))
 }
-  
 ```
 
 ```{r, eval=has_infercnv_num_ref_changes}
@@ -1545,13 +1544,12 @@ infercnv_show_df <- changed_infercnv_ref_celltypes |>
       infercnv_ref_added,
       \(x) paste(x, collapse = ", ")
     )
-    
   )
 
 infercnv_show_df |>
   dplyr::select(
     project_id,
-    sample_id, 
+    sample_id,
     library_id,
     num_ref_celltypes,
     num_comp_celltypes,
@@ -1572,7 +1570,7 @@ knitr::asis_output("\n\n##### Detail\n\n")
 infercnv_show_df |>
   dplyr::select(
     project_id,
-    sample_id, 
+    sample_id,
     library_id,
     values_removed,
     values_added

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1189,7 +1189,7 @@ for (method in all_celltype_methods) {
   ref_col <- paste0(method, "_celltypes.ref")
   comp_col <- paste0(method, "_celltypes.comp")
 
-  metrics_df2[[method]] <- purrr::map2(
+  metrics_df[[method]] <- purrr::map2(
     metrics_df[[ref_col]],
     metrics_df[[comp_col]],
     celltype_changes
@@ -1346,6 +1346,81 @@ changed_types |>
     )
   )
 ```
+
+
+
+### InferCNV
+
+#### Total inferCNV 
+
+```{r}
+total_infercnv_changes <- metrics_df |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with("infercnv_total_cnv")
+  ) |>
+  tidyr::pivot_longer(
+    cols = starts_with("infercnv_total_cnv"),
+    names_pattern = "(.+)\\.(ref|comp)$",
+    names_to = c("field", ".value") # .value separates into `ref` and `comp` fields
+  ) |>
+  dplyr::filter(is.finite(comp) | is.finite(ref)) |> # keep where at least one is finite
+  dplyr::mutate(
+    change = comp - ref,
+    change_frac = change / ref
+  ) |>
+  dplyr::select(-field)
+
+changed_total_infercnv_counts <- total_infercnv_changes |>
+  dplyr::filter(is.na(change) | change != 0)
+
+has_total_infercnv_changes <- nrow(changed_total_infercnv_counts) > 0
+```
+
+
+
+```{r}
+# total infercnv summary
+if (!has_total_infercnv_changes) {
+  knitr::asis_output(
+    "There are no changes in the total CNV estimate between the reference and comparison runs."
+  )
+} else {
+  knitr::asis_output(glue::glue(
+    "Of the **{nrow(total_infercnv_changes)}** libraries, **{nrow(total_infercnv_changes)}** {ifelse(nrow(changed_doublet_counts) == 1, 'has', 'have')} changes in total CNV estimate."
+  ))
+}
+```
+
+```{r, eval=has_total_infercnv_changes}
+report_table(
+  total_infercnv_changes,
+  summary = TRUE,
+  colnames = c("Project", "Sample", "Library", "Reference total CNV", "Comparison total CNV", "Change", "% change")
+) |>
+  DT::formatPercentage("change_frac", 2)
+```
+
+
+```{r, eval=has_total_infercnv_changes}
+ggplot(total_infercnv_changes, aes(x = change_frac * 100)) +
+  geom_histogram(bins = 20) +
+  labs(
+    x = "Percent change in total CNV estimate",
+    y = "Number of libraries"
+  ) +
+  theme_bw()
+```
+
+
+
+
+
+
+
+
 ## Session Info
 <details>
 <summary>Click to expand</summary>

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -286,6 +286,9 @@ comp_metrics_paths <- s3fs::s3_dir_ls(
 ```{r, eval=!use_cache}
 #| include: false
 # read metrics files from S3
+
+ref_metrics_files <- list.files("ref_jsons/", full.names = TRUE)
+comp_metrics_paths <- list.files("comp_jsons/", full.names = TRUE)
 ref_data <- read_metrics_files(ref_metrics_files)
 comp_data <- read_metrics_files(comp_metrics_paths)
 
@@ -1417,6 +1420,225 @@ ggplot(total_infercnv_changes, aes(x = change_frac * 100)) +
 
 
 
+
+#### InferCNV reference cells {.tabset}
+
+```{r}
+# reference cells can differ in one of two ways:
+# the total number of cells in the reference, or the cell types themselves
+# a change in one may not appear in the other, so need to consider each separately
+
+# first, we'll do the check number of reference cells
+infercnv_num_ref_changes <- metrics_df |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with("infercnv_num_reference_cells"),
+  ) |>
+  tidyr::pivot_longer(
+    cols = starts_with("infercnv_num_reference_cells"),
+    names_pattern = "(.+)\\.(ref|comp)$",
+    names_to = c("field", ".value") # .value separates into `ref` and `comp` fields
+  ) |>
+  dplyr::filter(is.finite(comp) | is.finite(ref)) |> # keep where at least one is finite
+  dplyr::mutate(
+    change = comp - ref,
+    change_frac = change / ref
+  ) |>
+  dplyr::select(-field)
+
+changed_infercnv_num_ref_counts <- infercnv_num_ref_changes |>
+  dplyr::filter(is.na(change) | change != 0)
+
+has_infercnv_num_ref_changes <- nrow(changed_infercnv_num_ref_counts) > 0
+```
+
+
+
+```{r}
+if (!has_infercnv_num_ref_changes) {
+  knitr::asis_output(
+    "There are no changes in the number of normal inferCNV reference cells between the reference and comparison runs."
+  ) 
+} else {
+  knitr::asis_output(glue::glue(
+    "Of the **{nrow(infercnv_num_ref_changes)}** libraries, **{nrow(changed_infercnv_num_ref_counts)}** {ifelse(nrow(changed_infercnv_num_ref_counts) == 1, 'has', 'have')} changes in the number of normal inferCNV reference cells."
+  ))
+}
+  
+```
+
+```{r, eval=has_infercnv_num_ref_changes}
+# table of doublet changes
+report_table(
+  infercnv_num_ref_changes,
+  summary = TRUE,
+  colnames = c("Project", "Sample", "Library", "Reference inferCNV normal ref cell count", "Comparison inferCNV normal ref cell count", "Change", "% change")
+) |>
+  DT::formatPercentage("change_frac", 2)
+```
+
+
+```{r, eval=has_infercnv_num_ref_changes}
+ggplot(infercnv_num_ref_changes, aes(x = change_frac * 100)) +
+  geom_histogram(bins = 20) +
+  labs(
+    x = "Percent change in number of inferCNV normal reference cells",
+    y = "Number of libraries"
+  ) +
+  theme_bw()
+```
+
+
+
+
+
+```{r}
+
+
+# check reference cell types
+infercnv_ref_celltype_stats <- metrics_df |>
+  dplyr::mutate(
+    infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
+    infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
+    infercnv_ref_added = purrr::map2(infercnv_reference_cells.comp, infercnv_reference_cells.ref, setdiff)
+  ) |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with("infercnv_ref")
+  )
+
+changed_infercnv_ref_celltypes <- infercnv_ref_celltype_stats |>
+  dplyr::filter(!infercnv_ref_identical)
+
+has_infercnv_ref_changes <- nrow(changed_infercnv_num_ref_counts) > 0 | nrow(changed_infercnv_ref_celltypes) > 0
+```
+
+
+
+
+```{r}
+ metrics_df |>
+  dplyr::mutate(
+    infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
+    infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
+    infercnv_ref_added = purrr::map2(infercnv_reference_cells.comp, infercnv_reference_cells.ref, setdiff)
+  ) |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with("infercnv_ref")
+  )
+```
+
+
+
+
+```{r}
+infercnv_ref_stats <- metrics_df |>
+  dplyr::mutate(
+    infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
+    infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
+    infercnv_ref_added = purrr::map2(infercnv_reference_cells.comp, infercnv_reference_cells.ref, setdiff)
+  ) |>
+  dplyr::select(
+    project_id,
+    sample_id,
+    library_id,
+    starts_with("infercnv_ref")
+  )
+
+infercnv_ref_changes <- infercnv_ref_stats |>
+  dplyr::filter(!infercnv_ref_identical)
+
+has_infercnv_ref_changes <- nrow(infercnv_ref_changes) > 0
+```
+
+
+```{r}
+infercnv_summary_df <- infercnv_ref_stats |>
+  dplyr::summarize(
+    n = dplyr::n(),
+    n_changed = n - sum(infercnv_ref_identical),
+  )
+  
+
+if (!has_infercnv_ref_changes) {
+  knitr::asis_output(
+    "There are no changes in the normal reference cell types used for inferCNV between reference and comparison runs."
+  )
+} else {
+  knitr::asis_output(glue::glue_data(
+    infercnv_summary_df,
+    "Of the **{n}** libraries, **{n_changed}** {ifelse(n_changed == 1, 'has', 'have')} changes in the normal reference cell types used for inferCNV between reference and comparison runs.
+    
+    The tables below show only the libraries with changes in normal reference celltypes.
+    "
+  ))
+}
+```
+
+```{r, eval=has_infercnv_ref_changes}
+knitr::asis_output("\n\n##### Summary\n\n")
+```
+
+
+```{r}
+infercnv_show_df <- infercnv_ref_stats |>
+  dplyr::mutate(
+    original_reference_cells = purrr::map_chr(
+      infercnv_reference_cells.ref,
+      \(x) paste(x, collapse = ", ")
+    ),
+    num_removed = purrr::map_int(infercnv_ref_removed, length),
+    values_removed = purrr::map_chr(
+      infercnv_ref_removed,
+      \(x) paste(x, collapse = ", ")
+    ),
+    num_added = purrr::map_int(infercnv_ref_added, length),
+    values_added = purrr::map_chr(
+      infercnv_ref_added,
+      \(x) paste(x, collapse = ", ")
+    )
+  )
+
+
+infercnv_show_df |>
+  dplyr::select(
+    project_id,
+    sample_id, 
+    library_id,
+    num_removed,
+    num_added
+  ) |>
+  report_table(
+    summary = TRUE,
+    colnames = c("Project", "Sample", "Library", "Num cell types removed", "Num cell types added")
+  )
+```
+
+```{r eval=has_infercnv_ref_changes}
+knitr::asis_output("\n\n##### Detail\n\n")
+```
+
+```{r}
+infercnv_show_df |>
+  dplyr::select(
+    project_id,
+    sample_id, 
+    library_id,
+    values_removed,
+    values_added, 
+    original_reference_cells
+  ) |>
+  report_table(
+    colnames = c("Project", "Sample", "Library", "Cell types removed", "Cell types added", "Reference list of reference cells")
+  )
+```
 
 
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -286,9 +286,6 @@ comp_metrics_paths <- s3fs::s3_dir_ls(
 ```{r, eval=!use_cache}
 #| include: false
 # read metrics files from S3
-
-ref_metrics_files <- list.files("ref_jsons/", full.names = TRUE)
-comp_metrics_paths <- list.files("comp_jsons/", full.names = TRUE)
 ref_data <- read_metrics_files(ref_metrics_files)
 comp_data <- read_metrics_files(comp_metrics_paths)
 
@@ -1421,7 +1418,7 @@ ggplot(total_infercnv_changes, aes(x = change_frac * 100)) +
 
 
 
-#### InferCNV reference cells {.tabset}
+#### InferCNV normal reference cell count
 
 ```{r}
 # reference cells can differ in one of two ways:
@@ -1491,12 +1488,10 @@ ggplot(infercnv_num_ref_changes, aes(x = change_frac * 100)) +
 ```
 
 
-
+#### InferCNV normal reference cell types {.tabset}
 
 
 ```{r}
-
-
 # check reference cell types
 infercnv_ref_celltype_stats <- metrics_df |>
   dplyr::mutate(
@@ -1514,53 +1509,12 @@ infercnv_ref_celltype_stats <- metrics_df |>
 changed_infercnv_ref_celltypes <- infercnv_ref_celltype_stats |>
   dplyr::filter(!infercnv_ref_identical)
 
-has_infercnv_ref_changes <- nrow(changed_infercnv_num_ref_counts) > 0 | nrow(changed_infercnv_ref_celltypes) > 0
-```
-
-
-
-
-```{r}
- metrics_df |>
-  dplyr::mutate(
-    infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
-    infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
-    infercnv_ref_added = purrr::map2(infercnv_reference_cells.comp, infercnv_reference_cells.ref, setdiff)
-  ) |>
-  dplyr::select(
-    project_id,
-    sample_id,
-    library_id,
-    starts_with("infercnv_ref")
-  )
-```
-
-
-
-
-```{r}
-infercnv_ref_stats <- metrics_df |>
-  dplyr::mutate(
-    infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
-    infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
-    infercnv_ref_added = purrr::map2(infercnv_reference_cells.comp, infercnv_reference_cells.ref, setdiff)
-  ) |>
-  dplyr::select(
-    project_id,
-    sample_id,
-    library_id,
-    starts_with("infercnv_ref")
-  )
-
-infercnv_ref_changes <- infercnv_ref_stats |>
-  dplyr::filter(!infercnv_ref_identical)
-
-has_infercnv_ref_changes <- nrow(infercnv_ref_changes) > 0
+has_infercnv_ref_changes <- nrow(changed_infercnv_ref_celltypes) > 0
 ```
 
 
 ```{r}
-infercnv_summary_df <- infercnv_ref_stats |>
+infercnv_ref_celltype_summary <- infercnv_ref_celltype_stats |>
   dplyr::summarize(
     n = dplyr::n(),
     n_changed = n - sum(infercnv_ref_identical),
@@ -1573,10 +1527,8 @@ if (!has_infercnv_ref_changes) {
   )
 } else {
   knitr::asis_output(glue::glue_data(
-    infercnv_summary_df,
-    "Of the **{n}** libraries, **{n_changed}** {ifelse(n_changed == 1, 'has', 'have')} changes in the normal reference cell types used for inferCNV between reference and comparison runs.
-    
-    The tables below show only the libraries with changes in normal reference celltypes.
+    infercnv_ref_celltype_summary,
+    "Of the **{n}** libraries, **{n_changed}** {ifelse(n_changed == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
     "
   ))
 }
@@ -1587,13 +1539,11 @@ knitr::asis_output("\n\n##### Summary\n\n")
 ```
 
 
-```{r}
-infercnv_show_df <- infercnv_ref_stats |>
+```{r, eval=has_infercnv_ref_changes}
+infercnv_show_df <- infercnv_ref_celltype_stats |>
   dplyr::mutate(
-    original_reference_cells = purrr::map_chr(
-      infercnv_reference_cells.ref,
-      \(x) paste(x, collapse = ", ")
-    ),
+    num_ref_celltypes = purrr::map_int(infercnv_reference_cells.ref, length),
+    num_comp_celltypes = purrr::map_int(infercnv_reference_cells.comp, length),
     num_removed = purrr::map_int(infercnv_ref_removed, length),
     values_removed = purrr::map_chr(
       infercnv_ref_removed,
@@ -1604,6 +1554,7 @@ infercnv_show_df <- infercnv_ref_stats |>
       infercnv_ref_added,
       \(x) paste(x, collapse = ", ")
     )
+    
   )
 
 
@@ -1612,12 +1563,14 @@ infercnv_show_df |>
     project_id,
     sample_id, 
     library_id,
+    num_ref_celltypes,
+    num_comp_celltypes,
     num_removed,
     num_added
   ) |>
   report_table(
     summary = TRUE,
-    colnames = c("Project", "Sample", "Library", "Num cell types removed", "Num cell types added")
+    colnames = c("Project", "Sample", "Library", "# Reference SCE cell types", "# Comparison SCE cell types", "# Cell types removed", "# Cell types added")
   )
 ```
 
@@ -1625,18 +1578,17 @@ infercnv_show_df |>
 knitr::asis_output("\n\n##### Detail\n\n")
 ```
 
-```{r}
+```{r, eval=has_infercnv_ref_changes}
 infercnv_show_df |>
   dplyr::select(
     project_id,
     sample_id, 
     library_id,
     values_removed,
-    values_added, 
-    original_reference_cells
+    values_added
   ) |>
   report_table(
-    colnames = c("Project", "Sample", "Library", "Cell types removed", "Cell types added", "Reference list of reference cells")
+    colnames = c("Project", "Sample", "Library", "Cell types removed", "Cell types added")
   )
 ```
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1486,7 +1486,7 @@ ggplot(changed_infercnv_num_ref_counts, aes(x = change_frac * 100)) +
 ```
 
 
-#### InferCNV normal reference cell types {.tabset}
+#### InferCNV normal reference cell types
 
 
 ```{r}
@@ -1524,10 +1524,6 @@ if (!has_infercnv_ref_changes) {
 }
 ```
 
-```{r, eval=has_infercnv_ref_changes}
-knitr::asis_output("\n\n##### Summary\n\n")
-```
-
 
 ```{r, eval=has_infercnv_ref_changes}
 infercnv_show_df <- changed_infercnv_ref_celltypes |>
@@ -1554,33 +1550,20 @@ infercnv_show_df |>
     num_ref_celltypes,
     num_comp_celltypes,
     num_removed,
-    num_added
-  ) |>
-  report_table(
-    summary = TRUE,
-    colnames = c("Project", "Sample", "Library", "Reference cell type count", "Comparison cell type count", "Added cell type count" "Removed cell type count")
-  )
-```
-
-```{r eval=has_infercnv_ref_changes}
-knitr::asis_output("\n\n##### Detail\n\n")
-```
-
-```{r, eval=has_infercnv_ref_changes}
-infercnv_show_df |>
-  dplyr::select(
-    project_id,
-    sample_id,
-    library_id,
+    num_added, 
     values_removed,
     values_added
   ) |>
   report_table(
-    colnames = c("Project", "Sample", "Library", "Cell types removed", "Cell types added")
+    summary = TRUE,
+    colnames = 
+      c("Project", "Sample", "Library", 
+        "Reference cell type count", "Comparison cell type count", 
+        "Added cell type count", "Removed cell type count", 
+        "Cell types removed", "Cell types added"
+      )
   )
 ```
-
-
 
 
 ## Session Info

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1560,7 +1560,7 @@ infercnv_show_df |>
       c(
         "Project", "Sample", "Library",
         "Reference cell type count", "Comparison cell type count",
-        "Removed cell type count", "Added cell type count", 
+        "Removed cell type count", "Added cell type count",
         "Cell types removed", "Cell types added"
       )
   )

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1455,11 +1455,11 @@ has_infercnv_num_ref_changes <- nrow(changed_infercnv_num_ref_counts) > 0
 ```{r}
 if (!has_infercnv_num_ref_changes) {
   knitr::asis_output(
-    "There are no changes in the number of normal inferCNV reference cells between the reference and comparison runs."
+    "There are no changes in the number of normal cells used as a reference when running InferCNV between the reference and comparison runs."
   )
 } else {
   knitr::asis_output(glue::glue(
-    "Of the **{nrow(infercnv_num_ref_changes)}** libraries, **{nrow(changed_infercnv_num_ref_counts)}** {ifelse(nrow(changed_infercnv_num_ref_counts) == 1, 'has', 'have')} changes in the number of normal inferCNV reference cells."
+    "Of the **{nrow(infercnv_num_ref_changes)}** libraries, **{nrow(changed_infercnv_num_ref_counts)}** {ifelse(nrow(changed_infercnv_num_ref_counts) == 1, 'has', 'have')} changes in the number of normal cells used as a reference when running InferCNV."
   ))
 }
 ```
@@ -1469,7 +1469,7 @@ if (!has_infercnv_num_ref_changes) {
 report_table(
   changed_infercnv_num_ref_counts,
   summary = TRUE,
-  colnames = c("Project", "Sample", "Library", "Reference inferCNV normal ref cell count", "Comparison inferCNV normal ref cell count", "Change", "% change")
+  colnames = c("Project", "Sample", "Library", "Reference inferCNV normal cell count", "Comparison inferCNV normal cell count", "Change", "% change")
 ) |>
   DT::formatPercentage("change_frac", 2)
 ```
@@ -1514,11 +1514,11 @@ has_infercnv_ref_changes <- nrow(changed_infercnv_ref_celltypes) > 0
 ```{r}
 if (!has_infercnv_ref_changes) {
   knitr::asis_output(
-    "There are no changes in the normal reference cell types used for inferCNV between reference and comparison runs."
+    "There are no changes in the normal cell types used for reference when running InferCNV between reference and comparison runs."
   )
 } else {
   knitr::asis_output(glue::glue(
-    "Of the **{nrow(infercnv_ref_celltype_changes)}** libraries, **{nrow(changed_infercnv_ref_celltypes)}** {ifelse(nrow(changed_infercnv_ref_celltypes) == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
+    "Of the **{nrow(infercnv_ref_celltype_changes)}** libraries, **{nrow(changed_infercnv_ref_celltypes)}** {ifelse(nrow(changed_infercnv_ref_celltypes) == 1, 'has', 'have')} changes in which cell types were used for the normal reference when running InferCNV between reference and comparison runs.
     "
   ))
 }
@@ -1558,7 +1558,7 @@ infercnv_show_df |>
   ) |>
   report_table(
     summary = TRUE,
-    colnames = c("Project", "Sample", "Library", "# Reference SCE cell types", "# Comparison SCE cell types", "# Cell types removed", "# Cell types added")
+    colnames = c("Project", "Sample", "Library", "Reference cell type count", "Comparison cell type count", "Added cell type count" "Removed cell type count")
   )
 ```
 

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1466,7 +1466,7 @@ if (!has_infercnv_num_ref_changes) {
 ```
 
 ```{r, eval=has_infercnv_num_ref_changes}
-# table of doublet changes
+# table of inferCNV reference cell count changes
 report_table(
   changed_infercnv_num_ref_counts,
   summary = TRUE,
@@ -1491,8 +1491,8 @@ ggplot(changed_infercnv_num_ref_counts, aes(x = change_frac * 100)) +
 
 
 ```{r}
-# check reference cell types
-infercnv_ref_celltype_stats <- metrics_df |>
+# Now, we check the actual reference cell types
+infercnv_ref_celltype_changes <- metrics_df |>
   dplyr::mutate(
     infercnv_ref_identical = purrr::map2_lgl(infercnv_reference_cells.ref, infercnv_reference_cells.comp, identical),
     infercnv_ref_removed = purrr::map2(infercnv_reference_cells.ref, infercnv_reference_cells.comp, setdiff),
@@ -1505,7 +1505,7 @@ infercnv_ref_celltype_stats <- metrics_df |>
     starts_with("infercnv_ref")
   )
 
-changed_infercnv_ref_celltypes <- infercnv_ref_celltype_stats |>
+changed_infercnv_ref_celltypes <- infercnv_ref_celltype_changes |>
   dplyr::filter(!infercnv_ref_identical)
 
 has_infercnv_ref_changes <- nrow(changed_infercnv_ref_celltypes) > 0
@@ -1519,7 +1519,7 @@ if (!has_infercnv_ref_changes) {
   )
 } else {
   knitr::asis_output(glue::glue(
-    "Of the **{nrow(infercnv_ref_celltype_stats)}** libraries, **{nrow(changed_infercnv_ref_celltypes)}** {ifelse(nrow(changed_infercnv_ref_celltypes) == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
+    "Of the **{nrow(infercnv_ref_celltype_changes)}** libraries, **{nrow(changed_infercnv_ref_celltypes)}** {ifelse(nrow(changed_infercnv_ref_celltypes) == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
     "
   ))
 }

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1550,16 +1550,17 @@ infercnv_show_df |>
     num_ref_celltypes,
     num_comp_celltypes,
     num_removed,
-    num_added, 
+    num_added,
     values_removed,
     values_added
   ) |>
   report_table(
     summary = TRUE,
-    colnames = 
-      c("Project", "Sample", "Library", 
-        "Reference cell type count", "Comparison cell type count", 
-        "Added cell type count", "Removed cell type count", 
+    colnames =
+      c(
+        "Project", "Sample", "Library",
+        "Reference cell type count", "Comparison cell type count",
+        "Added cell type count", "Removed cell type count",
         "Cell types removed", "Cell types added"
       )
   )

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1389,14 +1389,14 @@ if (!has_total_infercnv_changes) {
   )
 } else {
   knitr::asis_output(glue::glue(
-    "Of the **{nrow(total_infercnv_changes)}** libraries, **{nrow(total_infercnv_changes)}** {ifelse(nrow(changed_doublet_counts) == 1, 'has', 'have')} changes in total CNV estimate."
+    "Of the **{nrow(total_infercnv_changes)}** libraries, **{nrow(changed_total_infercnv_counts)}** {ifelse(nrow(changed_total_infercnv_counts) == 1, 'has', 'have')} changes in total CNV estimate."
   ))
 }
 ```
 
 ```{r, eval=has_total_infercnv_changes}
 report_table(
-  total_infercnv_changes,
+  changed_total_infercnv_counts,
   summary = TRUE,
   colnames = c("Project", "Sample", "Library", "Reference total CNV", "Comparison total CNV", "Change", "% change")
 ) |>
@@ -1405,7 +1405,7 @@ report_table(
 
 
 ```{r, eval=has_total_infercnv_changes}
-ggplot(total_infercnv_changes, aes(x = change_frac * 100)) +
+ggplot(changed_total_infercnv_counts, aes(x = change_frac * 100)) +
   geom_histogram(bins = 20) +
   labs(
     x = "Percent change in total CNV estimate",
@@ -1425,7 +1425,6 @@ ggplot(total_infercnv_changes, aes(x = change_frac * 100)) +
 # the total number of cells in the reference, or the cell types themselves
 # a change in one may not appear in the other, so need to consider each separately
 
-# first, we'll do the check number of reference cells
 infercnv_num_ref_changes <- metrics_df |>
   dplyr::select(
     project_id,
@@ -1469,7 +1468,7 @@ if (!has_infercnv_num_ref_changes) {
 ```{r, eval=has_infercnv_num_ref_changes}
 # table of doublet changes
 report_table(
-  infercnv_num_ref_changes,
+  changed_infercnv_num_ref_counts,
   summary = TRUE,
   colnames = c("Project", "Sample", "Library", "Reference inferCNV normal ref cell count", "Comparison inferCNV normal ref cell count", "Change", "% change")
 ) |>
@@ -1478,7 +1477,7 @@ report_table(
 
 
 ```{r, eval=has_infercnv_num_ref_changes}
-ggplot(infercnv_num_ref_changes, aes(x = change_frac * 100)) +
+ggplot(changed_infercnv_num_ref_counts, aes(x = change_frac * 100)) +
   geom_histogram(bins = 20) +
   labs(
     x = "Percent change in number of inferCNV normal reference cells",
@@ -1514,21 +1513,13 @@ has_infercnv_ref_changes <- nrow(changed_infercnv_ref_celltypes) > 0
 
 
 ```{r}
-infercnv_ref_celltype_summary <- infercnv_ref_celltype_stats |>
-  dplyr::summarize(
-    n = dplyr::n(),
-    n_changed = n - sum(infercnv_ref_identical),
-  )
-  
-
 if (!has_infercnv_ref_changes) {
   knitr::asis_output(
     "There are no changes in the normal reference cell types used for inferCNV between reference and comparison runs."
   )
 } else {
-  knitr::asis_output(glue::glue_data(
-    infercnv_ref_celltype_summary,
-    "Of the **{n}** libraries, **{n_changed}** {ifelse(n_changed == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
+  knitr::asis_output(glue::glue(
+    "Of the **{nrow(infercnv_ref_celltype_stats)}** libraries, **{nrow(changed_infercnv_ref_celltypes)}** {ifelse(nrow(changed_infercnv_ref_celltypes) == 1, 'has', 'have')} changes in which cell types were used for the normal inferCNV reference between reference and comparison runs.
     "
   ))
 }
@@ -1540,7 +1531,7 @@ knitr::asis_output("\n\n##### Summary\n\n")
 
 
 ```{r, eval=has_infercnv_ref_changes}
-infercnv_show_df <- infercnv_ref_celltype_stats |>
+infercnv_show_df <- changed_infercnv_ref_celltypes |>
   dplyr::mutate(
     num_ref_celltypes = purrr::map_int(infercnv_reference_cells.ref, length),
     num_comp_celltypes = purrr::map_int(infercnv_reference_cells.comp, length),
@@ -1556,7 +1547,6 @@ infercnv_show_df <- infercnv_ref_celltype_stats |>
     )
     
   )
-
 
 infercnv_show_df |>
   dplyr::select(

--- a/scripts/compare-metrics/compare-metrics-template.rmd
+++ b/scripts/compare-metrics/compare-metrics-template.rmd
@@ -1560,7 +1560,7 @@ infercnv_show_df |>
       c(
         "Project", "Sample", "Library",
         "Reference cell type count", "Comparison cell type count",
-        "Added cell type count", "Removed cell type count",
+        "Removed cell type count", "Added cell type count", 
         "Cell types removed", "Cell types added"
       )
   )


### PR DESCRIPTION
Closes #1181

This PR adds an inferCNV section to the metrics report, as well as adds `infercnv_num_reference_cells` as a metric itself. I actually ended up with 3 subsections here, because changes can crop up in one of three ways as we are currently tracking. These changes can occur in combination with one another, or they can be mutually exclusive. So, I have a subsection for each where I show...
- Change in the total CNV estimate 
  -  table of number/percent change and histogram of percent change
- Change in the _number of cells_ in the normal reference
  - table of number/percent change and histogram of percent changes 
- Change in the _cell types_ in the normal reference can change
  - summary section: table of number of cell types changes. I also include the total number of cell types in the reference object for comparison
  - detail section: actual cell type changes

A fiddly thing here is the word "reference," since it means two things - we're tracking inferCNV reference changes between reference and comparison objects 😵‍💫  . I tried to make column headers precise without them getting too long. Let me know how I did with that!

Let me know how this looks to you, and if it would help to somehow consolidate. 

Here's some example reports showing 2 libraries:
- No change in any inferCNV metrics:[infercnv-no-changes.html](https://github.com/user-attachments/files/25522139/infercnv-no-changes.html)
- Some metrics for some libraries have changes: [infercnv-only-some-changes.html](https://github.com/user-attachments/files/25522141/infercnv-only-some-changes.html)
- All metrics for all libraries have changes:  [infercnv-with-changes.html](https://github.com/user-attachments/files/25522142/infercnv-with-changes.html)




