### PR TITLE
Add command line for app name

### DIFF
--- a/cavatica/cavatica-build.sh
+++ b/cavatica/cavatica-build.sh
@@ -13,7 +13,17 @@ exclude_file="sb_exclude.txt"
 # use "build" or "push": default is build
 ACTION=${1:-"build"}
 # cavatica app id: <username>/<project>/<app>
-APP_ID=${2:-"jashapiro/scpca-nf-test/scpca-nf-development"}
+APP_TYPE=${2:-development}
+
+project_id="jashapiro/scpca-nf-test"
+
+if [ $APP_TYPE == "development" ] ; then
+  app_id="${project_id}/scpca-nf-development"
+elif [ $APP_TYPE != "main" ]; then
+  app_id="${project_id}/scpca-nf"
+else
+  echo "The second argument must be 'development' or 'main'."
+fi
 
 if [ "$ACTION" == "build" ]; then
     # default to multi-instance mode

--- a/cavatica/cavatica-build.sh
+++ b/cavatica/cavatica-build.sh
@@ -10,10 +10,10 @@ doc_file="sb_doc.md"
 exclude_file="sb_exclude.txt"
 
 # get the action and app ID from the command line
-# cavatica app id: <username>/<project>/<app>
-APP_ID=${2:-"jashapiro/scpca-nf-test/scpca-nf-development"}
 # use "build" or "push": default is build
 ACTION=${1:-"build"}
+# cavatica app id: <username>/<project>/<app>
+APP_ID=${2:-"jashapiro/scpca-nf-test/scpca-nf-development"}
 
 if [ "$ACTION" == "build" ]; then
     # default to multi-instance mode

--- a/cavatica/cavatica-build.sh
+++ b/cavatica/cavatica-build.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Run from the script file location
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# default project
+project_id="jashapiro/scpca-nf-test"
+
 # default files for docs and exclusions for upload
 doc_file="sb_doc.md"
 exclude_file="sb_exclude.txt"
@@ -12,14 +15,12 @@ exclude_file="sb_exclude.txt"
 # get the action and app ID from the command line
 # use "build" or "push": default is build
 ACTION=${1:-"build"}
-# cavatica app id: <username>/<project>/<app>
+# cavatica app type: either "development" or "main"
 APP_TYPE=${2:-development}
-
-project_id="jashapiro/scpca-nf-test"
 
 if [ $APP_TYPE == "development" ] ; then
   app_id="${project_id}/scpca-nf-development"
-elif [ $APP_TYPE != "main" ]; then
+elif [ $APP_TYPE == "main" ]; then
   app_id="${project_id}/scpca-nf"
 else
   echo "The second argument must be 'development' or 'main'."

--- a/cavatica/cavatica-build.sh
+++ b/cavatica/cavatica-build.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 # Run from the script file location
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# cavatica app id: <username>/<project>/<app>
-app_id="jashapiro/scpca-nf-test/scpca-nf"
+# default files for docs and exclusions for upload
 doc_file="sb_doc.md"
 exclude_file="sb_exclude.txt"
 
-# get the action from the command line, default is build
+# get the action and app ID from the command line
+# cavatica app id: <username>/<project>/<app>
+APP_ID=${2:-"jashapiro/scpca-nf-test/scpca-nf-development"}
+# use "build" or "push": default is build
 ACTION=${1:-"build"}
 
 if [ "$ACTION" == "build" ]; then
@@ -27,7 +29,7 @@ if [ "$ACTION" == "build" ]; then
     # Build sb_nextflow_schema.yaml
     pixi run -e cavatica sbpack_nf \
       --workflow-path .. \
-      --appid ${app_id} \
+      --appid ${APP_ID} \
       --sb-doc ${doc_file} \
       ${mode_arg} \
       --dump-sb-app
@@ -45,7 +47,7 @@ elif [ "$ACTION" == "push" ]; then
       --profile . \
       --workflow-path .. \
       --sb-schema sb_nextflow_schema.yaml \
-      --appid ${app_id} \
+      --appid ${APP_ID} \
       --exclude $(< $exclude_file)
 else
     echo "Invalid action: $ACTION"

--- a/cavatica/sb_nextflow_schema.yaml
+++ b/cavatica/sb_nextflow_schema.yaml
@@ -244,7 +244,7 @@ inputs:
     label: Probe files directory
     sbg:category: Reference files
     sbg:icon: fas fa-folder-open
-    sbg:toolDefaultValue: s3://scpca-references/flex-probe-refs
+    sbg:toolDefaultValue: s3://scpca-nf-references/flex-probe-refs
     type:
       - "null"
       - Directory
@@ -255,7 +255,7 @@ inputs:
     label: Probe files directory
     sbg:category: Reference files
     sbg:icon: fas fa-folder-open
-    sbg:toolDefaultValue: s3://scpca-references/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv
+    sbg:toolDefaultValue: s3://scpca-nf-references/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv
     type:
       - "null"
       - File
@@ -299,7 +299,7 @@ inputs:
     label: SCimilarity reference model directory
     sbg:category: Reference files
     sbg:icon: fas fa-folder-open
-    sbg:toolDefaultValue: s3://scpca-references/celltype/scimilarity_references/model_v1.1
+    sbg:toolDefaultValue: s3://scpca-nf-references/celltype/scimilarity_references/model_v1.1
     type:
       - "null"
       - Directory


### PR DESCRIPTION
As part of #1196, we updated the `scpca-nf-test` project to include a new app `scpca-nf-development`.  I'm just adding a command line argument to specify the app name and setting the default to be the new development one so we don't accidentally update the other one while testing. 