### PR TITLE
Add cellhash section of the reference file

### DIFF
--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -31,6 +31,11 @@
                 "altexps_adt_sum": "numeric",
                 "altexps_adt_detected": "integer",
                 "altexps_adt_percent": "numeric"
+            },
+            "has_cellhash": {
+                "altexps_cellhash_sum": "numeric",
+                "altexps_cellhash_detected": "integer",
+                "altexps_cellhash_percent": "numeric"
             }
         },
         "altExp": {
@@ -43,6 +48,15 @@
                     "mean": "numeric",
                     "detected": "numeric",
                     "target_type": "character"
+                }
+            },
+            "cellhash": {
+                "assayNames": [
+                    "counts"
+                ],
+                "rowData": {
+                    "mean": "numeric",
+                    "detected": "numeric"
                 }
             }
         }
@@ -82,6 +96,27 @@
             },
             "has_adt": {
                 "adt_scpca_filter": "character"
+            },
+            "has_cellhash": {
+                "altexps_cellhash_sum": "numeric",
+                "altexps_cellhash_detected": "integer",
+                "altexps_cellhash_percent": "numeric"
+            },
+            "has_hashedDrops": {
+                "hashedDrops_sampleid": "character"
+            },
+            "has_HTODemux": {
+                "HTODemux_sampleid": "character"
+            },
+            "has_vireo": {
+                "vireo_sampleid": "character",
+                "vireo_donor_id": "character",
+                "vireo_prob_max": "numeric",
+                "vireo_prob_doublet": "numeric",
+                "vireo_n_vars": "numeric",
+                "vireo_best_singlet": "character",
+                "vireo_best_doublet": "character",
+                "vireo_doublet_logLikRatio": "numeric"
             }
         },
         "altExp": {
@@ -107,6 +142,40 @@
                     "no_negative_control": {
                         "ambient.scale": "numeric",
                         "high.ambient": "logical"
+                    }
+                }
+            },
+            "cellhash": {
+                "assayNames": [
+                    "counts"
+                ],
+                "rowData": {
+                    "mean": "numeric",
+                    "detected": "numeric",
+                    "barcode_id": "character",
+                    "sample_id": "character"
+                },
+                "colData_conditional": {
+                    "has_hashedDrops": {
+                        "hashedDrops_Total": "numeric",
+                        "hashedDrops_Best": "integer",
+                        "hashedDrops_Second": "integer",
+                        "hashedDrops_LogFC": "numeric",
+                        "hashedDrops_LogFC2": "numeric",
+                        "hashedDrops_Doublet": "logical",
+                        "hashedDrops_Confident": "logical",
+                        "hashedDrops_sampleid": "character",
+                        "hashedDrops_bestsample": "character"
+                    },
+                    "has_HTODemux": {
+                        "HTODemux_maxID": "character",
+                        "HTODemux_secondID": "character",
+                        "HTODemux_margin": "numeric",
+                        "HTODemux_classification": "character",
+                        "HTODemux_classification.global": "character",
+                        "HTODemux_hash.ID": "integer",
+                        "HTODemux_maxsample": "character",
+                        "HTODemux_sampleid": "character"
                     }
                 }
             }
@@ -147,6 +216,27 @@
             },
             "has_adt": {
                 "adt_scpca_filter": "character"
+            },
+            "has_cellhash": {
+                "altexps_cellhash_sum": "numeric",
+                "altexps_cellhash_detected": "integer",
+                "altexps_cellhash_percent": "numeric"
+            },
+            "has_hashedDrops": {
+                "hashedDrops_sampleid": "character"
+            },
+            "has_HTODemux": {
+                "HTODemux_sampleid": "character"
+            },
+            "has_vireo": {
+                "vireo_sampleid": "character",
+                "vireo_donor_id": "character",
+                "vireo_prob_max": "numeric",
+                "vireo_prob_doublet": "numeric",
+                "vireo_n_vars": "numeric",
+                "vireo_best_singlet": "character",
+                "vireo_best_doublet": "character",
+                "vireo_doublet_logLikRatio": "numeric"
             },
             "has_normalization": {
                 "sizeFactor": "numeric"
@@ -206,6 +296,40 @@
                         "high.ambient": "logical"
                     },
                     "sizeFactor": "numeric"
+                }
+            },
+            "cellhash": {
+                "assayNames": [
+                    "counts"
+                ],
+                "rowData": {
+                    "mean": "numeric",
+                    "detected": "numeric",
+                    "barcode_id": "character",
+                    "sample_id": "character"
+                },
+                "colData_conditional": {
+                    "has_hashedDrops": {
+                        "hashedDrops_Total": "numeric",
+                        "hashedDrops_Best": "integer",
+                        "hashedDrops_Second": "integer",
+                        "hashedDrops_LogFC": "numeric",
+                        "hashedDrops_LogFC2": "numeric",
+                        "hashedDrops_Doublet": "logical",
+                        "hashedDrops_Confident": "logical",
+                        "hashedDrops_sampleid": "character",
+                        "hashedDrops_bestsample": "character"
+                    },
+                    "has_HTODemux": {
+                        "HTODemux_maxID": "character",
+                        "HTODemux_secondID": "character",
+                        "HTODemux_margin": "numeric",
+                        "HTODemux_classification": "character",
+                        "HTODemux_classification.global": "character",
+                        "HTODemux_hash.ID": "integer",
+                        "HTODemux_maxsample": "character",
+                        "HTODemux_sampleid": "character"
+                    }
                 }
             }
         }

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -161,6 +161,7 @@ filtered_altexp_cellhash_feature_metadata = {
 filtered_altexp_cellhash_cell_metadata_conditional = {
     # indicate columns that are conditionally present based on demultiplexing methods used
     # this is tracked based on demux columns in colData
+    # this is the same as what's in the processed object
     "has_hashedDrops": {
         "hashedDrops_Total": "numeric",
         "hashedDrops_Best": "integer",

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -14,6 +14,7 @@ anndata_ref_file = "../anndata-formatting-reference.json"
 assays = ["counts", "spliced"]
 processed_assays = ["logcounts"]
 adt_assays = ["counts"]
+cellhash_assays = ["counts"]
 
 # unfiltered cell metadata ------------
 cell_metadata = {
@@ -32,6 +33,16 @@ cell_metadata_conditional = {
         "openscpca_celltype_annotation": "character",
         "openscpca_celltype_ontology": "character",
     },
+    "has_adt": {
+        "altexps_adt_sum": "numeric",
+        "altexps_adt_detected": "integer",
+        "altexps_adt_percent": "numeric",
+    },
+    "has_cellhash": {
+        "altexps_cellhash_sum": "numeric",
+        "altexps_cellhash_detected": "integer",
+        "altexps_cellhash_percent": "numeric",
+    },
 }
 
 # filtered cell metadata ------------
@@ -47,6 +58,19 @@ filtered_cell_metadata = {
 filtered_cell_metadata_conditional = {
     **cell_metadata_conditional,
     "has_adt": {"adt_scpca_filter": "character"},
+    # additional columns that are present based on the type of demultiplexing used
+    "has_hashedDrops": {"hashedDrops_sampleid": "character"},
+    "has_HTODemux": {"HTODemux_sampleid": "character"},
+    "has_vireo": {
+        "vireo_sampleid": "character",
+        "vireo_donor_id": "character",
+        "vireo_prob_max": "numeric",
+        "vireo_prob_doublet": "numeric",
+        "vireo_n_vars": "numeric",
+        "vireo_best_singlet": "character",
+        "vireo_best_doublet": "character",
+        "vireo_doublet_logLikRatio": "numeric",
+    },
 }
 
 # processed cell metadata ------------
@@ -91,17 +115,7 @@ feature_metadata = {
 reduced_dims = ["PCA", "UMAP"]
 
 # alt exps gell/gene metadata ------------
-# add main colData columns to conditional metadata
-cell_metadata_conditional.update(
-    {
-        "has_adt": {
-            "altexps_adt_sum": "numeric",
-            "altexps_adt_detected": "integer",
-            "altexps_adt_percent": "numeric",
-        },
-    }
-)
-
+# adt specific items
 altexp_adt_feature_metadata = {
     "adt_id": "character",
     "mean": "numeric",
@@ -132,6 +146,44 @@ processed_altexp_adt_cell_metadata_conditional = {
     "sizeFactor": "numeric",
 }
 
+# cellhash specific items
+unfiltered_altexp_cellhash_feature_metadata = {
+    "mean": "numeric",
+    "detected": "numeric",
+}
+
+filtered_altexp_cellhash_feature_metadata = {
+    **unfiltered_altexp_cellhash_feature_metadata,
+    "barcode_id": "character",
+    "sample_id": "character",
+}
+
+filtered_altexp_cellhash_cell_metadata_conditional = {
+    # indicate columns that are conditionally present based on demultiplexing methods used
+    # this is tracked based on demux columns in colData
+    "has_hashedDrops": {
+        "hashedDrops_Total": "numeric",
+        "hashedDrops_Best": "integer",
+        "hashedDrops_Second": "integer",
+        "hashedDrops_LogFC": "numeric",
+        "hashedDrops_LogFC2": "numeric",
+        "hashedDrops_Doublet": "logical",
+        "hashedDrops_Confident": "logical",
+        "hashedDrops_sampleid": "character",
+        "hashedDrops_bestsample": "character",
+    },
+    "has_HTODemux": {
+        "HTODemux_maxID": "character",
+        "HTODemux_secondID": "character",
+        "HTODemux_margin": "numeric",
+        "HTODemux_classification": "character",
+        "HTODemux_classification.global": "character",
+        "HTODemux_hash.ID": "integer",
+        "HTODemux_maxsample": "character",
+        "HTODemux_sampleid": "character",
+    },
+}
+
 # build unfiltered SCE -----------------
 
 unfiltered_sce = {
@@ -143,6 +195,10 @@ unfiltered_sce = {
         "adt": {
             "assayNames": adt_assays,
             "rowData": altexp_adt_feature_metadata,
+        },
+        "cellhash": {
+            "assayNames": cellhash_assays,
+            "rowData": unfiltered_altexp_cellhash_feature_metadata,
         },
     },
 }
@@ -162,6 +218,11 @@ filtered_sce = {
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": filtered_altexp_adt_cell_metadata_conditional,
         },
+        "cellhash": {
+            "assayNames": cellhash_assays,
+            "rowData": filtered_altexp_cellhash_feature_metadata,
+            "colData_conditional": filtered_altexp_cellhash_cell_metadata_conditional,
+        },
     },
 }
 
@@ -179,6 +240,11 @@ processed_sce = {
             "colData": filtered_altexp_adt_cell_metadata,
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": processed_altexp_adt_cell_metadata_conditional,
+        },
+        "cellhash": {
+            "assayNames": cellhash_assays,
+            "rowData": filtered_altexp_cellhash_feature_metadata,
+            "colData_conditional": filtered_altexp_cellhash_cell_metadata_conditional,
         },
     },
 }

--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,8 @@
 [files]
 extend-exclude = [
   "references/*.tsv",
-  "references/*.json"
+  "references/*.json",
+  "references/scripts/create-formatting-reference.py"
 ]
 
 [default.extend-identifiers]

--- a/typos.toml
+++ b/typos.toml
@@ -1,6 +1,7 @@
 [files]
 extend-exclude = [
-  "references/*.tsv"
+  "references/*.tsv",
+  "references/*.json"
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
Closes #1193 

Here I'm adding the information for libraries with cell hashing. This includes what's present in both the main experiment and altExp. I think the trickiest thing here is that there are columns present for each of the demultiplexing methods, but depending on how things were run not every method will be present. So I followed the same format we use for cell typing methods where I just use "has_hashedDrops" and "has_vireo" and include the columns that are present for each of those. 