### PR TITLE
account for metadata in SCE

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -622,7 +622,8 @@ if (has_cellassign) {
   # if cell assign predictions file exists but is empty then cell assign failed and we want to account for that with Not Run
   if (file.size(opt$cellassign_predictions) > 0) {
     # read in predictions file
-    cellassign_df <- readr::read_tsv(opt$cellassign_predictions)
+    cellassign_df <- readr::read_tsv(opt$cellassign_predictions) |>
+      as.data.frame()
   } else {
     cellassign_df <- NULL
     has_cellassign <- FALSE # reset to false so that we don't add in consensus cell types

--- a/bin/format_unfiltered_sce.R
+++ b/bin/format_unfiltered_sce.R
@@ -82,7 +82,9 @@ sample_metadata_df <- readr::read_tsv(
   dplyr::rename("sample_id" = "scpca_sample_id") |>
   # add library ID as column in sample metadata
   # we need this so we are able to merge sample metadata with colData later
-  dplyr::mutate(library_id = opt$library_id)
+  dplyr::mutate(library_id = opt$library_id) |>
+  # ensure this is a data frame for formatting checks
+  as.data.frame()
 
 if ("upload_date" %in% colnames(sample_metadata_df)) {
   sample_metadata_df <- sample_metadata_df |>

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -38,6 +38,38 @@
                 "altexps_cellhash_percent": "numeric"
             }
         },
+        "metadata": [
+            "library_id",
+            "sample_id",
+            "project_id",
+            "reference_index",
+            "total_reads",
+            "mapping_tool",
+            "tech_version",
+            "assay_ontology_term_id",
+            "seq_unit",
+            "transcript_type",
+            "sample_metadata",
+            "sample_type"
+        ],
+        "metadata_conditional": {
+            "alevin-fry": [
+                "salmon_version",
+                "mapped_reads",
+                "alevinfry_version",
+                "af_permit_type",
+                "af_resolution",
+                "usa_mode",
+                "af_num_cells",
+                "include_unspliced"
+            ],
+            "cellranger-multi": [
+                "cellranger_version",
+                "reference_probeset",
+                "pct_mapped_reads",
+                "cellranger_num_cells"
+            ]
+        },
         "altExp": {
             "adt": {
                 "assayNames": [
@@ -119,6 +151,30 @@
                 "vireo_doublet_logLikRatio": "numeric"
             }
         },
+        "metadata": [
+            "library_id",
+            "sample_id",
+            "project_id",
+            "reference_index",
+            "total_reads",
+            "mapping_tool",
+            "tech_version",
+            "assay_ontology_term_id",
+            "seq_unit",
+            "transcript_type",
+            "sample_metadata",
+            "sample_type",
+            "filtering_method",
+            "miQC_model",
+            "prob_compromised_cutoff",
+            "scpca_filter_method",
+            "min_gene_cutoff"
+        ],
+        "metadata_conditional": {
+            "umi_filtering": [
+                "umi_cutoff"
+            ]
+        },
         "altExp": {
             "adt": {
                 "assayNames": [
@@ -143,7 +199,10 @@
                         "ambient.scale": "numeric",
                         "high.ambient": "logical"
                     }
-                }
+                },
+                "metadata": [
+                    "ambient_profile"
+                ]
             },
             "cellhash": {
                 "assayNames": [
@@ -271,6 +330,81 @@
             "PCA",
             "UMAP"
         ],
+        "metadata": [
+            "library_id",
+            "sample_id",
+            "project_id",
+            "reference_index",
+            "total_reads",
+            "mapping_tool",
+            "tech_version",
+            "assay_ontology_term_id",
+            "seq_unit",
+            "transcript_type",
+            "sample_metadata",
+            "sample_type",
+            "filtering_method",
+            "miQC_model",
+            "prob_compromised_cutoff",
+            "scpca_filter_method",
+            "min_gene_cutoff",
+            "normalization",
+            "highly_variable_genes"
+        ],
+        "metadata_conditional": {
+            "umi_filtering": [
+                "umi_cutoff"
+            ],
+            "has_clusters": [
+                "cluster_algorithm",
+                "cluster_weighting",
+                "cluster_nn"
+            ],
+            "has_submitter": [
+                "celltype_methods"
+            ],
+            "has_openscpca": [
+                "celltype_methods",
+                "openscpca_celltype_module_name",
+                "openscpca_celltype_nf_version",
+                "openscpca_celltype_release_date"
+            ],
+            "has_singler": [
+                "celltype_methods",
+                "singler_results",
+                "singler_reference",
+                "singler_reference_label",
+                "singler_reference_source",
+                "singler_reference_version"
+            ],
+            "has_cellassign": [
+                "celltype_methods",
+                "cellassign_predictions",
+                "cellassign_reference",
+                "cellassign_reference_organs",
+                "cellassign_reference_source",
+                "cellassign_reference_version"
+            ],
+            "has_scimilarity": [
+                "celltype_methods",
+                "scimilarity_model"
+            ],
+            "has_consensus": [
+                "consensus_celltype_methods"
+            ],
+            "has_infercnv": [
+                "infercnv_reference_celltypes",
+                "infercnv_num_reference_cells",
+                "infercnv_diagnosis_groups",
+                "infercnv_status",
+                "infercnv_options",
+                "infercnv_table"
+            ],
+            "has_adt": [
+                "adt_scpca_filter_method",
+                "adt_normalization"
+            ]
+        },
         "altExp": {
             "adt": {
                 "assayNames": [
@@ -296,7 +430,10 @@
                         "high.ambient": "logical"
                     },
                     "sizeFactor": "numeric"
-                }
+                },
+                "metadata": [
+                    "ambient_profile"
+                ]
             },
             "cellhash": {
                 "assayNames": [

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -38,37 +38,37 @@
                 "altexps_cellhash_percent": "numeric"
             }
         },
-        "metadata": [
-            "library_id",
-            "sample_id",
-            "project_id",
-            "reference_index",
-            "total_reads",
-            "mapping_tool",
-            "tech_version",
-            "assay_ontology_term_id",
-            "seq_unit",
-            "transcript_type",
-            "sample_metadata",
-            "sample_type"
-        ],
+        "metadata": {
+            "library_id": "character",
+            "sample_id": "character",
+            "project_id": "character",
+            "reference_index": "character",
+            "total_reads": "integer",
+            "mapping_tool": "character",
+            "tech_version": "character",
+            "assay_ontology_term_id": "character",
+            "seq_unit": "character",
+            "transcript_type": "character",
+            "sample_metadata": "character",
+            "sample_type": "character"
+        },
         "metadata_conditional": {
-            "alevin-fry": [
-                "salmon_version",
-                "mapped_reads",
-                "alevinfry_version",
-                "af_permit_type",
-                "af_resolution",
-                "usa_mode",
-                "af_num_cells",
-                "include_unspliced"
-            ],
-            "cellranger-multi": [
-                "cellranger_version",
-                "reference_probeset",
-                "pct_mapped_reads",
-                "cellranger_num_cells"
-            ]
+            "alevin-fry": {
+                "salmon_version": "character",
+                "mapped_reads": "integer",
+                "alevinfry_version": "character",
+                "af_permit_type": "character",
+                "af_resolution": "character",
+                "usa_mode": "logical",
+                "af_num_cells": "integer",
+                "include_unspliced": "logical"
+            },
+            "cellranger-multi": {
+                "cellranger_version": "character",
+                "reference_probeset": "character",
+                "pct_mapped_reads": "numeric",
+                "cellranger_num_cells": "integer"
+            }
         },
         "altExp": {
             "adt": {
@@ -151,29 +151,32 @@
                 "vireo_doublet_logLikRatio": "numeric"
             }
         },
-        "metadata": [
-            "library_id",
-            "sample_id",
-            "project_id",
-            "reference_index",
-            "total_reads",
-            "mapping_tool",
-            "tech_version",
-            "assay_ontology_term_id",
-            "seq_unit",
-            "transcript_type",
-            "sample_metadata",
-            "sample_type",
-            "filtering_method",
-            "miQC_model",
-            "prob_compromised_cutoff",
-            "scpca_filter_method",
-            "min_gene_cutoff"
-        ],
+        "metadata": {
+            "library_id": "character",
+            "sample_id": "character",
+            "project_id": "character",
+            "reference_index": "character",
+            "total_reads": "integer",
+            "mapping_tool": "character",
+            "tech_version": "character",
+            "assay_ontology_term_id": "character",
+            "seq_unit": "character",
+            "transcript_type": "character",
+            "sample_metadata": "character",
+            "sample_type": "character",
+            "filtering_method": "character",
+            "prob_compromised_cutoff": "NA",
+            "scpca_filter_method": "character",
+            "min_gene_cutoff": "integer"
+        },
         "metadata_conditional": {
-            "umi_filtering": [
-                "umi_cutoff"
-            ]
+            "umi_filtering": {
+                "umi_cutoff": "numeric"
+            },
+            "has_miQC": {
+                "miQC_model": "S4",
+                "prob_compromised_cutoff": "numeric"
+            }
         },
         "altExp": {
             "adt": {
@@ -200,9 +203,9 @@
                         "high.ambient": "logical"
                     }
                 },
-                "metadata": [
-                    "ambient_profile"
-                ]
+                "metadata": {
+                    "ambient_profile": "character"
+                }
             },
             "cellhash": {
                 "assayNames": [
@@ -330,80 +333,83 @@
             "PCA",
             "UMAP"
         ],
-        "metadata": [
-            "library_id",
-            "sample_id",
-            "project_id",
-            "reference_index",
-            "total_reads",
-            "mapping_tool",
-            "tech_version",
-            "assay_ontology_term_id",
-            "seq_unit",
-            "transcript_type",
-            "sample_metadata",
-            "sample_type",
-            "filtering_method",
-            "miQC_model",
-            "prob_compromised_cutoff",
-            "scpca_filter_method",
-            "min_gene_cutoff",
-            "normalization",
-            "highly_variable_genes"
-        ],
+        "metadata": {
+            "library_id": "character",
+            "sample_id": "character",
+            "project_id": "character",
+            "reference_index": "character",
+            "total_reads": "integer",
+            "mapping_tool": "character",
+            "tech_version": "character",
+            "assay_ontology_term_id": "character",
+            "seq_unit": "character",
+            "transcript_type": "character",
+            "sample_metadata": "character",
+            "sample_type": "character",
+            "filtering_method": "character",
+            "prob_compromised_cutoff": "NA",
+            "scpca_filter_method": "character",
+            "min_gene_cutoff": "integer",
+            "normalization": "character",
+            "highly_variable_genes": "character"
+        },
         "metadata_conditional": {
-            "umi_filtering": [
-                "umi_cutoff"
-            ],
-            "has_clusters": [
-                "cluster_algorithm",
-                "cluster_weighting",
-                "cluster_nn"
-            ],
-            "has_submitter": [
-                "celltype_methods"
-            ],
-            "has_openscpca": [
-                "celltype_methods",
-                "openscpca_celltype_module_name",
-                "openscpca_celltype_nf_version",
-                "openscpca_celltype_release_date"
-            ],
-            "has_singler": [
-                "celltype_methods",
-                "singler_results",
-                "singler_reference",
-                "singler_reference_label",
-                "singler_reference_source",
-                "singler_reference_version"
-            ],
-            "has_cellassign": [
-                "celltype_methods",
-                "cellassign_predictions",
-                "cellassign_reference",
-                "cellassign_reference_organs",
-                "cellassign_reference_source",
-                "cellassign_reference_version"
-            ],
-            "has_scimilarity": [
-                "celltype_methods",
-                "scimilarity_model"
-            ],
-            "has_consensus": [
-                "consensus_celltype_methods"
-            ],
-            "has_infercnv": [
-                "infercnv_reference_celltypes",
-                "infercnv_num_reference_cells",
-                "infercnv_diagnosis_groups",
-                "infercnv_status",
-                "infercnv_options",
-                "infercnv_table"
-            ],
-            "has_adt": [
-                "adt_scpca_filter_method",
-                "adt_normalization"
-            ]
+            "umi_filtering": {
+                "umi_cutoff": "numeric"
+            },
+            "has_miQC": {
+                "miQC_model": null,
+                "prob_compromised_cutoff": "numeric"
+            },
+            "has_clusters": {
+                "cluster_algorithm": "character",
+                "cluster_weighting": "character",
+                "cluster_nn": "numeric"
+            },
+            "has_submitter": {
+                "celltype_methods": "character"
+            },
+            "has_openscpca": {
+                "celltype_methods": "character",
+                "openscpca_celltype_module_name": "character",
+                "openscpca_celltype_nf_version": "character",
+                "openscpca_celltype_release_date": "character"
+            },
+            "has_singler": {
+                "celltype_methods": "character",
+                "singler_results": "S4",
+                "singler_reference": "character",
+                "singler_reference_label": "character",
+                "singler_reference_source": "character",
+                "singler_reference_version": "character"
+            },
+            "has_cellassign": {
+                "celltype_methods": "character",
+                "cellassign_predictions": "character",
+                "cellassign_reference": "character",
+                "cellassign_reference_organs": "character",
+                "cellassign_reference_source": "character",
+                "cellassign_reference_version": "character"
+            },
+            "has_scimilarity": {
+                "celltype_methods": "character",
+                "scimilarity_model": "character"
+            },
+            "has_consensus": {
+                "consensus_celltype_methods": "character"
+            },
+            "has_infercnv": {
+                "infercnv_reference_celltypes": "character",
+                "infercnv_num_reference_cells": "integer",
+                "infercnv_diagnosis_groups": "character",
+                "infercnv_status": "character",
+                "infercnv_options": "character",
+                "infercnv_table": "character"
+            },
+            "has_adt": {
+                "adt_scpca_filter_method": "character",
+                "adt_normalization": "character"
+            }
         },
         "altExp": {
             "adt": {
@@ -431,9 +437,9 @@
                     },
                     "sizeFactor": "numeric"
                 },
-                "metadata": [
-                    "ambient_profile"
-                ]
+                "metadata": {
+                    "ambient_profile": "character"
+                }
             },
             "cellhash": {
                 "assayNames": [

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -80,6 +80,38 @@
                     "mean": "numeric",
                     "detected": "numeric",
                     "target_type": "character"
+                },
+                "metadata": {
+                    "library_id": "character",
+                    "sample_id": "character",
+                    "project_id": "character",
+                    "reference_index": "character",
+                    "total_reads": "integer",
+                    "mapping_tool": "character",
+                    "tech_version": "character",
+                    "assay_ontology_term_id": "character",
+                    "seq_unit": "character",
+                    "transcript_type": "character",
+                    "sample_metadata": "data.frame",
+                    "sample_type": "character"
+                },
+                "metadata_conditional": {
+                    "alevin-fry": {
+                        "salmon_version": "character",
+                        "mapped_reads": "integer",
+                        "alevinfry_version": "character",
+                        "af_permit_type": "character",
+                        "af_resolution": "character",
+                        "usa_mode": "logical",
+                        "af_num_cells": "integer",
+                        "include_unspliced": "logical"
+                    },
+                    "cellranger-multi": {
+                        "cellranger_version": "character",
+                        "reference_probeset": "character",
+                        "pct_mapped_reads": "numeric",
+                        "cellranger_num_cells": "integer"
+                    }
                 }
             },
             "cellhash": {
@@ -165,7 +197,7 @@
             "sample_metadata": "data.frame",
             "sample_type": "character",
             "filtering_method": "character",
-            "prob_compromised_cutoff": "NA",
+            "prob_compromised_cutoff": "logical",
             "scpca_filter_method": "character",
             "min_gene_cutoff": "integer"
         },
@@ -204,7 +236,37 @@
                     }
                 },
                 "metadata": {
+                    "library_id": "character",
+                    "sample_id": "character",
+                    "project_id": "character",
+                    "reference_index": "character",
+                    "total_reads": "integer",
+                    "mapping_tool": "character",
+                    "tech_version": "character",
+                    "assay_ontology_term_id": "character",
+                    "seq_unit": "character",
+                    "transcript_type": "character",
+                    "sample_metadata": "data.frame",
+                    "sample_type": "character",
                     "ambient_profile": "character"
+                },
+                "metadata_conditional": {
+                    "alevin-fry": {
+                        "salmon_version": "character",
+                        "mapped_reads": "integer",
+                        "alevinfry_version": "character",
+                        "af_permit_type": "character",
+                        "af_resolution": "character",
+                        "usa_mode": "logical",
+                        "af_num_cells": "integer",
+                        "include_unspliced": "logical"
+                    },
+                    "cellranger-multi": {
+                        "cellranger_version": "character",
+                        "reference_probeset": "character",
+                        "pct_mapped_reads": "numeric",
+                        "cellranger_num_cells": "integer"
+                    }
                 }
             },
             "cellhash": {
@@ -347,7 +409,7 @@
             "sample_metadata": "data.frame",
             "sample_type": "character",
             "filtering_method": "character",
-            "prob_compromised_cutoff": "NA",
+            "prob_compromised_cutoff": "logical",
             "scpca_filter_method": "character",
             "min_gene_cutoff": "integer",
             "normalization": "character",
@@ -358,7 +420,6 @@
                 "umi_cutoff": "numeric"
             },
             "has_miQC": {
-                "miQC_model": null,
                 "prob_compromised_cutoff": "numeric"
             },
             "has_clusters": {
@@ -381,7 +442,9 @@
                 "singler_reference": "character",
                 "singler_reference_label": "character",
                 "singler_reference_source": "character",
-                "singler_reference_version": "character"
+                "singler_reference_version": "character",
+                "singler_gene_set_version": "logical",
+                "singler_date": "logical"
             },
             "has_cellassign": {
                 "celltype_methods": "character",
@@ -438,7 +501,37 @@
                     "sizeFactor": "numeric"
                 },
                 "metadata": {
+                    "library_id": "character",
+                    "sample_id": "character",
+                    "project_id": "character",
+                    "reference_index": "character",
+                    "total_reads": "integer",
+                    "mapping_tool": "character",
+                    "tech_version": "character",
+                    "assay_ontology_term_id": "character",
+                    "seq_unit": "character",
+                    "transcript_type": "character",
+                    "sample_metadata": "data.frame",
+                    "sample_type": "character",
                     "ambient_profile": "character"
+                },
+                "metadata_conditional": {
+                    "alevin-fry": {
+                        "salmon_version": "character",
+                        "mapped_reads": "integer",
+                        "alevinfry_version": "character",
+                        "af_permit_type": "character",
+                        "af_resolution": "character",
+                        "usa_mode": "logical",
+                        "af_num_cells": "integer",
+                        "include_unspliced": "logical"
+                    },
+                    "cellranger-multi": {
+                        "cellranger_version": "character",
+                        "reference_probeset": "character",
+                        "pct_mapped_reads": "numeric",
+                        "cellranger_num_cells": "integer"
+                    }
                 }
             },
             "cellhash": {

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -49,7 +49,7 @@
             "assay_ontology_term_id": "character",
             "seq_unit": "character",
             "transcript_type": "character",
-            "sample_metadata": "character",
+            "sample_metadata": "data.frame",
             "sample_type": "character"
         },
         "metadata_conditional": {
@@ -162,7 +162,7 @@
             "assay_ontology_term_id": "character",
             "seq_unit": "character",
             "transcript_type": "character",
-            "sample_metadata": "character",
+            "sample_metadata": "data.frame",
             "sample_type": "character",
             "filtering_method": "character",
             "prob_compromised_cutoff": "NA",
@@ -344,7 +344,7 @@
             "assay_ontology_term_id": "character",
             "seq_unit": "character",
             "transcript_type": "character",
-            "sample_metadata": "character",
+            "sample_metadata": "data.frame",
             "sample_type": "character",
             "filtering_method": "character",
             "prob_compromised_cutoff": "NA",
@@ -377,7 +377,7 @@
             },
             "has_singler": {
                 "celltype_methods": "character",
-                "singler_results": "S4",
+                "singler_results": "DFrame",
                 "singler_reference": "character",
                 "singler_reference_label": "character",
                 "singler_reference_source": "character",
@@ -385,7 +385,7 @@
             },
             "has_cellassign": {
                 "celltype_methods": "character",
-                "cellassign_predictions": "character",
+                "cellassign_predictions": "data.frame",
                 "cellassign_reference": "character",
                 "cellassign_reference_organs": "character",
                 "cellassign_reference_source": "character",
@@ -403,7 +403,7 @@
                 "infercnv_num_reference_cells": "integer",
                 "infercnv_diagnosis_groups": "character",
                 "infercnv_status": "character",
-                "infercnv_options": "character",
+                "infercnv_options": "list",
                 "infercnv_table": "character"
             },
             "has_adt": {

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -126,7 +126,7 @@ unfiltered_experiment_metadata = {
     "assay_ontology_term_id": "character",
     "seq_unit": "character",
     "transcript_type": "character",
-    "sample_metadata": "character",
+    "sample_metadata": "data.frame",
     "sample_type": "character",
 }
 
@@ -195,7 +195,7 @@ processed_experiment_metadata_conditional = {
     },
     "has_singler": {
         "celltype_methods": "character",
-        "singler_results": "S4",
+        "singler_results": "DFrame",
         "singler_reference": "character",
         "singler_reference_label": "character",
         "singler_reference_source": "character",
@@ -203,7 +203,7 @@ processed_experiment_metadata_conditional = {
     },
     "has_cellassign": {
         "celltype_methods": "character",
-        "cellassign_predictions": "character",
+        "cellassign_predictions": "data.frame",
         "cellassign_reference": "character",
         "cellassign_reference_organs": "character",
         "cellassign_reference_source": "character",
@@ -219,7 +219,7 @@ processed_experiment_metadata_conditional = {
         "infercnv_num_reference_cells": "integer",
         "infercnv_diagnosis_groups": "character",
         "infercnv_status": "character",
-        "infercnv_options": "character",
+        "infercnv_options": "list",
         "infercnv_table": "character",
     },
     "has_adt": {

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -155,7 +155,7 @@ filtered_experiment_metadata = {
     **unfiltered_experiment_metadata,
     "filtering_method": "character",
     # this is NA if miQC failed
-    "prob_compromised_cutoff": "NA",
+    "prob_compromised_cutoff": "logical",
     "scpca_filter_method": "character",
     "min_gene_cutoff": "integer",
 }
@@ -179,7 +179,7 @@ processed_experiment_metadata_conditional = {
     # if empty drops filtering_method is UMI cutoff
     "umi_filtering": {"umi_cutoff": "numeric"},
     # if miQC is present, these should have specific contents
-    "has_miQC": {"miQC_model": None, "prob_compromised_cutoff": "numeric"},
+    "has_miQC": {"prob_compromised_cutoff": "numeric"},
     "has_clusters": {
         "cluster_algorithm": "character",
         "cluster_weighting": "character",
@@ -200,6 +200,10 @@ processed_experiment_metadata_conditional = {
         "singler_reference_label": "character",
         "singler_reference_source": "character",
         "singler_reference_version": "character",
+        # TODO: these are NA right now because we are using the old SingleR refs
+        # only projects that use the new refs will have these set correctly...
+        "singler_gene_set_version": "logical",
+        "singler_date": "logical",
     },
     "has_cellassign": {
         "celltype_methods": "character",
@@ -260,7 +264,10 @@ processed_altexp_adt_cell_metadata_conditional = {
     "sizeFactor": "numeric",
 }
 
-filtered_altexp_adt_experiment_metadata = {"ambient_profile": "character"}
+filtered_altexp_adt_experiment_metadata = {
+    **unfiltered_experiment_metadata,
+    "ambient_profile": "character",
+}
 
 # cellhash specific items
 unfiltered_altexp_cellhash_feature_metadata = {
@@ -314,6 +321,8 @@ unfiltered_sce = {
         "adt": {
             "assayNames": adt_assays,
             "rowData": altexp_adt_feature_metadata,
+            "metadata": unfiltered_experiment_metadata,
+            "metadata_conditional": unfiltered_experiment_metadata_conditional,
         },
         "cellhash": {
             "assayNames": cellhash_assays,
@@ -339,6 +348,7 @@ filtered_sce = {
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": filtered_altexp_adt_cell_metadata_conditional,
             "metadata": filtered_altexp_adt_experiment_metadata,
+            "metadata_conditional": unfiltered_experiment_metadata_conditional,
         },
         "cellhash": {
             "assayNames": cellhash_assays,
@@ -365,6 +375,7 @@ processed_sce = {
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": processed_altexp_adt_cell_metadata_conditional,
             "metadata": filtered_altexp_adt_experiment_metadata,
+            "metadata_conditional": unfiltered_experiment_metadata_conditional,
         },
         "cellhash": {
             "assayNames": cellhash_assays,

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -224,7 +224,7 @@ processed_experiment_metadata_conditional = {
         "infercnv_diagnosis_groups": "character",
         "infercnv_status": "character",
         "infercnv_options": "list",
-        "infercnv_table": "character",
+        "infercnv_table": "data.frame",
     },
     "has_adt": {
         "adt_scpca_filter_method": "character",

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -115,101 +115,117 @@ feature_metadata = {
 reduced_dims = ["PCA", "UMAP"]
 
 # experiment metadata --------------
-unfiltered_experiment_metadata = [
-    "library_id",
-    "sample_id",
-    "project_id",
-    "reference_index",
-    "total_reads",
-    "mapping_tool",
-    "tech_version",
-    "assay_ontology_term_id",
-    "seq_unit",
-    "transcript_type",
-    "sample_metadata",
-    "sample_type",
-]
+unfiltered_experiment_metadata = {
+    "library_id": "character",
+    "sample_id": "character",
+    "project_id": "character",
+    "reference_index": "character",
+    "total_reads": "integer",
+    "mapping_tool": "character",
+    "tech_version": "character",
+    "assay_ontology_term_id": "character",
+    "seq_unit": "character",
+    "transcript_type": "character",
+    "sample_metadata": "character",
+    "sample_type": "character",
+}
 
 unfiltered_experiment_metadata_conditional = {
     # experiment metadata that's based on mapping tool
     # stored in metadata(sce)$mapping_tool
-    "alevin-fry": [
-        "salmon_version",
-        "mapped_reads",
-        "alevinfry_version",
-        "af_permit_type",
-        "af_resolution",
-        "usa_mode",
-        "af_num_cells",
-        "include_unspliced",
-    ],
-    "cellranger-multi": [
-        "cellranger_version",
-        "reference_probeset",
-        "pct_mapped_reads",
-        "cellranger_num_cells",
-    ],
+    "alevin-fry": {
+        "salmon_version": "character",
+        "mapped_reads": "integer",
+        "alevinfry_version": "character",
+        "af_permit_type": "character",
+        "af_resolution": "character",
+        "usa_mode": "logical",
+        "af_num_cells": "integer",
+        "include_unspliced": "logical",
+    },
+    "cellranger-multi": {
+        "cellranger_version": "character",
+        "reference_probeset": "character",
+        "pct_mapped_reads": "numeric",
+        "cellranger_num_cells": "integer",
+    },
 }
 
-filtered_experiment_metadata = unfiltered_experiment_metadata + [
-    "filtering_method",
-    "miQC_model",
-    "prob_compromised_cutoff",
-    "scpca_filter_method",
-    "min_gene_cutoff",
-]
+filtered_experiment_metadata = {
+    **unfiltered_experiment_metadata,
+    "filtering_method": "character",
+    # this is NA if miQC failed
+    "prob_compromised_cutoff": "NA",
+    "scpca_filter_method": "character",
+    "min_gene_cutoff": "integer",
+}
 
 filtered_experiment_metadata_conditional = {
-    # if filtering_method is UMI cutoff
-    "umi_filtering": ["umi_cutoff"]
+    # if empty drops filtering_method is UMI cutoff
+    "umi_filtering": {"umi_cutoff": "numeric"},
+    # if miQC is present, these should have specific contents
+    # miQC model is an S4 object and is removed from the processed
+    "has_miQC": {"miQC_model": "S4", "prob_compromised_cutoff": "numeric"},
 }
 
-processed_experiment_metadata = filtered_experiment_metadata + [
-    "normalization",
-    "highly_variable_genes",
-]
+processed_experiment_metadata = {
+    **filtered_experiment_metadata,
+    "normalization": "character",
+    "highly_variable_genes": "character",
+}
 
 processed_experiment_metadata_conditional = {
-    **filtered_experiment_metadata_conditional,
-    "has_clusters": ["cluster_algorithm", "cluster_weighting", "cluster_nn"],
+    ## reuse filtered conditional since miQC model gets removed for processed
+    # if empty drops filtering_method is UMI cutoff
+    "umi_filtering": {"umi_cutoff": "numeric"},
+    # if miQC is present, these should have specific contents
+    "has_miQC": {"miQC_model": None, "prob_compromised_cutoff": "numeric"},
+    "has_clusters": {
+        "cluster_algorithm": "character",
+        "cluster_weighting": "character",
+        "cluster_nn": "numeric",
+    },
     # note that celltype_methods exists if either one of these methods is present
-    "has_submitter": ["celltype_methods"],
-    "has_openscpca": [
-        "celltype_methods",
-        "openscpca_celltype_module_name",
-        "openscpca_celltype_nf_version",
-        "openscpca_celltype_release_date",
-    ],
-    "has_singler": [
-        "celltype_methods",
-        "singler_results",
-        "singler_reference",
-        "singler_reference_label",
-        "singler_reference_source",
-        "singler_reference_version",
-    ],
-    "has_cellassign": [
-        "celltype_methods",
-        "cellassign_predictions",
-        "cellassign_reference",
-        "cellassign_reference_organs",
-        "cellassign_reference_source",
-        "cellassign_reference_version",
-    ],
-    "has_scimilarity": [
-        "celltype_methods",
-        "scimilarity_model",
-    ],
-    "has_consensus": ["consensus_celltype_methods"],
-    "has_infercnv": [
-        "infercnv_reference_celltypes",
-        "infercnv_num_reference_cells",
-        "infercnv_diagnosis_groups",
-        "infercnv_status",
-        "infercnv_options",
-        "infercnv_table",
-    ],
-    "has_adt": ["adt_scpca_filter_method", "adt_normalization"],
+    "has_submitter": {"celltype_methods": "character"},
+    "has_openscpca": {
+        "celltype_methods": "character",
+        "openscpca_celltype_module_name": "character",
+        "openscpca_celltype_nf_version": "character",
+        "openscpca_celltype_release_date": "character",
+    },
+    "has_singler": {
+        "celltype_methods": "character",
+        "singler_results": "S4",
+        "singler_reference": "character",
+        "singler_reference_label": "character",
+        "singler_reference_source": "character",
+        "singler_reference_version": "character",
+    },
+    "has_cellassign": {
+        "celltype_methods": "character",
+        "cellassign_predictions": "character",
+        "cellassign_reference": "character",
+        "cellassign_reference_organs": "character",
+        "cellassign_reference_source": "character",
+        "cellassign_reference_version": "character",
+    },
+    "has_scimilarity": {
+        "celltype_methods": "character",
+        "scimilarity_model": "character",
+    },
+    "has_consensus": {"consensus_celltype_methods": "character"},
+    "has_infercnv": {
+        "infercnv_reference_celltypes": "character",
+        "infercnv_num_reference_cells": "integer",
+        "infercnv_diagnosis_groups": "character",
+        "infercnv_status": "character",
+        "infercnv_options": "character",
+        "infercnv_table": "character",
+    },
+    "has_adt": {
+        "adt_scpca_filter_method": "character",
+        "adt_normalization": "character",
+    },
 }
 
 # alt exps gell/gene metadata ------------
@@ -244,7 +260,7 @@ processed_altexp_adt_cell_metadata_conditional = {
     "sizeFactor": "numeric",
 }
 
-filtered_altexp_adt_experiment_metadata = ["ambient_profile"]
+filtered_altexp_adt_experiment_metadata = {"ambient_profile": "character"}
 
 # cellhash specific items
 unfiltered_altexp_cellhash_feature_metadata = {

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -114,6 +114,104 @@ feature_metadata = {
 # reduced dimensionality ----------
 reduced_dims = ["PCA", "UMAP"]
 
+# experiment metadata --------------
+unfiltered_experiment_metadata = [
+    "library_id",
+    "sample_id",
+    "project_id",
+    "reference_index",
+    "total_reads",
+    "mapping_tool",
+    "tech_version",
+    "assay_ontology_term_id",
+    "seq_unit",
+    "transcript_type",
+    "sample_metadata",
+    "sample_type",
+]
+
+unfiltered_experiment_metadata_conditional = {
+    # experiment metadata that's based on mapping tool
+    # stored in metadata(sce)$mapping_tool
+    "alevin-fry": [
+        "salmon_version",
+        "mapped_reads",
+        "alevinfry_version",
+        "af_permit_type",
+        "af_resolution",
+        "usa_mode",
+        "af_num_cells",
+        "include_unspliced",
+    ],
+    "cellranger-multi": [
+        "cellranger_version",
+        "reference_probeset",
+        "pct_mapped_reads",
+        "cellranger_num_cells",
+    ],
+}
+
+filtered_experiment_metadata = unfiltered_experiment_metadata + [
+    "filtering_method",
+    "miQC_model",
+    "prob_compromised_cutoff",
+    "scpca_filter_method",
+    "min_gene_cutoff",
+]
+
+filtered_experiment_metadata_conditional = {
+    # if filtering_method is UMI cutoff
+    "umi_filtering": ["umi_cutoff"]
+}
+
+processed_experiment_metadata = filtered_experiment_metadata + [
+    "normalization",
+    "highly_variable_genes",
+]
+
+processed_experiment_metadata_conditional = {
+    **filtered_experiment_metadata_conditional,
+    "has_clusters": ["cluster_algorithm", "cluster_weighting", "cluster_nn"],
+    # note that celltype_methods exists if either one of these methods is present
+    "has_submitter": ["celltype_methods"],
+    "has_openscpca": [
+        "celltype_methods",
+        "openscpca_celltype_module_name",
+        "openscpca_celltype_nf_version",
+        "openscpca_celltype_release_date",
+    ],
+    "has_singler": [
+        "celltype_methods",
+        "singler_results",
+        "singler_reference",
+        "singler_reference_label",
+        "singler_reference_source",
+        "singler_reference_version",
+    ],
+    "has_cellassign": [
+        "celltype_methods",
+        "cellassign_predictions",
+        "cellassign_reference",
+        "cellassign_reference_organs",
+        "cellassign_reference_source",
+        "cellassign_reference_version",
+    ],
+    "has_scimilarity": [
+        "celltype_methods",
+        "scimilarity_model",
+    ],
+    "has_consensus": ["consensus_celltype_methods"],
+    "has_infercnv": [
+        "infercnv_reference_celltypes",
+        "infercnv_num_reference_cells",
+        "infercnv_diagnosis_groups",
+        "infercnv_status",
+        "infercnv_options",
+        "infercnv_table",
+    ],
+    "has_adt": ["adt_scpca_filter_method", "adt_normalization"],
+}
+
 # alt exps gell/gene metadata ------------
 # adt specific items
 altexp_adt_feature_metadata = {
@@ -145,6 +243,8 @@ processed_altexp_adt_cell_metadata_conditional = {
     **filtered_altexp_adt_cell_metadata_conditional,
     "sizeFactor": "numeric",
 }
+
+filtered_altexp_adt_experiment_metadata = ["ambient_profile"]
 
 # cellhash specific items
 unfiltered_altexp_cellhash_feature_metadata = {
@@ -191,6 +291,8 @@ unfiltered_sce = {
     "colData": cell_metadata,
     "rowData": feature_metadata,
     "colData_conditional": cell_metadata_conditional,
+    "metadata": unfiltered_experiment_metadata,
+    "metadata_conditional": unfiltered_experiment_metadata_conditional,
     "altExp": {
         "adt": {
             "assayNames": adt_assays,
@@ -211,12 +313,15 @@ filtered_sce = {
     "colData": filtered_cell_metadata,
     "rowData": feature_metadata,
     "colData_conditional": filtered_cell_metadata_conditional,
+    "metadata": filtered_experiment_metadata,
+    "metadata_conditional": filtered_experiment_metadata_conditional,
     "altExp": {
         "adt": {
             "assayNames": adt_assays,
             "colData": filtered_altexp_adt_cell_metadata,
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": filtered_altexp_adt_cell_metadata_conditional,
+            "metadata": filtered_altexp_adt_experiment_metadata,
         },
         "cellhash": {
             "assayNames": cellhash_assays,
@@ -234,12 +339,15 @@ processed_sce = {
     "rowData": feature_metadata,
     "colData_conditional": processed_cell_metadata_conditional,
     "reducedDimNames": reduced_dims,
+    "metadata": processed_experiment_metadata,
+    "metadata_conditional": processed_experiment_metadata_conditional,
     "altExp": {
         "adt": {
             "assayNames": adt_assays,
             "colData": filtered_altexp_adt_cell_metadata,
             "rowData": altexp_adt_feature_metadata,
             "colData_conditional": processed_altexp_adt_cell_metadata_conditional,
+            "metadata": filtered_altexp_adt_experiment_metadata,
         },
         "cellhash": {
             "assayNames": cellhash_assays,


### PR DESCRIPTION
Stacked on #1200 
Closes #1201 

This PR adds in the contents of the `metadata` slot in the SCE objects. I chose not to track the type for each of the metadata slots since depending on what happens in the workflow the actual content of some of these is slightly different and I think it's more important that we just check they are present. To do this I loaded in different versions of the objects and listed out the names and cross-checked that with what we have in the docs: https://scpca.readthedocs.io/en/stable/sce_file_contents.html#singlecellexperiment-experiment-metadata

There are some minor differences that will ultimately be present for samples processed with cellranger-multi vs alevin-fry so I accounted for that now in the `metadata_conditional` slot. We also have one random metadata value that's only present if the filtering slot is `UMI cutoff` so I included that as a conditional too. The other conditionals mirror the ones we have for other slots (colData, etc). 