### PR TITLE
Fix mismatching happening for index building

### DIFF
--- a/build-index.nf
+++ b/build-index.nf
@@ -37,7 +37,7 @@ process salmon_index {
   container "${pullthroughContainer(params.salmon_container, params.pullthrough_registry)}"
   publishDir "${params.ref_outdir}/${meta.ref_dir}/salmon_index", mode: 'copy'
   label 'cpus_8'
-  label 'mem_16'
+  label 'mem_24'
   tag "${ref_name}"
   input:
     tuple val(ref_name), path(splici_fasta), path(spliced_cdna_fasta), 

--- a/build-index.nf
+++ b/build-index.nf
@@ -9,12 +9,13 @@ process generate_reference {
   // publish fasta and annotation files within reference directory
   publishDir "${params.ref_outdir}/${meta.ref_dir}", mode: 'copy'
   label 'mem_32'
+  tag "${ref_name}"
   maxRetries 1
   input:
     tuple val(ref_name), val(meta), path(gtf), path(fasta)
   output:
     tuple val(ref_name), val(meta), emit: ref_info
-    tuple path(splici_fasta), path(spliced_cdna_fasta), emit: fasta_files
+    tuple val(ref_name), path(splici_fasta), path(spliced_cdna_fasta), emit: fasta_files
     tuple path("annotation/*.gtf.gz"), path("annotation/*.tsv"), path("annotation/*.txt"),  emit: annotations
   script:
     splici_fasta = "fasta/" + file(meta.splici_index).name + ".fa.gz"
@@ -37,9 +38,10 @@ process salmon_index {
   publishDir "${params.ref_outdir}/${meta.ref_dir}/salmon_index", mode: 'copy'
   label 'cpus_8'
   label 'mem_16'
+  tag "${ref_name}"
   input:
-    tuple path(splici_fasta), path(spliced_cdna_fasta)
-    tuple val(ref_name), val(meta), path(gtf), path(fasta)
+    tuple val(ref_name), path(splici_fasta), path(spliced_cdna_fasta), 
+          val(meta), path(gtf), path(fasta)
   output:
     path splici_index_dir
     path spliced_cdna_index_dir
@@ -72,6 +74,7 @@ process cellranger_index {
   publishDir "${params.ref_outdir}/${meta.ref_dir}/cellranger_index", mode: 'copy'
   label 'cpus_12'
   label 'mem_24'
+  tag "${ref_name}"
   input:
     tuple val(ref_name), val(meta), path(gtf), path(fasta)
   output:
@@ -99,6 +102,7 @@ process star_index {
   publishDir "${params.ref_outdir}/${meta.ref_dir}/star_index", mode: 'copy'
   label 'cpus_12'
   memory '64.GB'
+  tag "${ref_name}"
   input:
     tuple val(ref_name), val(meta), path(gtf), path(fasta)
   output:
@@ -130,6 +134,7 @@ process infercnv_gene_order {
   container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
   label 'mem_8'
   publishDir "${params.ref_outdir}/${meta.ref_dir}/infercnv", mode: 'copy'
+  tag "${ref_name}"
   input:
     tuple val(ref_name), val(meta), path(gtf), path(cytoband)
   output:
@@ -206,8 +211,11 @@ workflow {
 
   // generate splici and spliced cDNA reference fasta
   generate_reference(salmon_ref_ch)
+
+  salmon_ref_ch = generate_reference.out.fasta_files
+    .join(salmon_ref_ch, by: 0) // join by ref_name 
   // create index using reference fastas
-  salmon_index(generate_reference.out.fasta_files, salmon_ref_ch)
+  salmon_index(salmon_ref_ch)
 
   // create cellranger index
   cellranger_index(cellranger_ref_ch)


### PR DESCRIPTION
While investigating https://github.com/AlexsLemonade/scpca-nf/issues/1197#issuecomment-3998720962, I found that rebuilding the index didn't fix the problem I was having and I was getting the same error with the index files not matching correctly. In looking into this, I realized we weren't matching the fasta output with the correct information in the salmon channel, so sometimes when we ran it, Nextflow would mix the human fasta with the mouse salmon index information. You can see an example of this here: https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch/3Bo7wPnJiOwiSx/tasks

This was the command being executed for the salmon_index process: 
```
salmon index       -t Homo_sapiens.GRCh38.104.spliced_intron.txome.fa.gz       -i Mus_musculus.GRCm39.104.spliced_intron.txome       -k 31       -p 8
gunzip -c Mus_musculus.GRCm39.dna.primary_assembly.fa.gz       | grep "^>" | cut -d " " -f 1       | sed -e 's/>//g' > decoys.txt
cat Homo_sapiens.GRCh38.104.spliced_cdna.txome.fa.gz Mus_musculus.GRCm39.dna.primary_assembly.fa.gz > gentrome.fa.gz

salmon index       -t gentrome.fa.gz       -d decoys.txt       -i Mus_musculus.GRCm39.104.spliced_cdna.txome       -k 31       -p 8
```

I fixed that by joining the channels using the `ref_name` and things now appear to be building correctly (see https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch/447IzDaeaw9z1e/tasks). While here I also increased the memory since I was noticing memory failures in the previous runs and added some tags to easily see which index is being built. 