### PR TITLE
Update spaceranger image handling

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -185,7 +185,8 @@ workflow spaceranger_quant{
           cytaimage_file = []
         } else { // we have a cytassist tech
           if (cytaimage_file.size() != 1) {
-            log.error("Expected exactly 1 cytaimage file in ${meta.files_directory}/cytaimage but found ${cytaimage_file.size()} files.")
+            // fully error if no cytaimage, since it is required
+            error("Expected exactly 1 cytaimage file in ${meta.files_directory}/cytaimage but found ${cytaimage_file.size()} files.")
             cytaimage_file = []
           } else {
             // we correctly have one cytaimage file, so index it out

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -36,6 +36,10 @@ process spaceranger {
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
 
+    # DEBUGGING - why still intermediates????
+    ls ${out_id} > ${out_id}/contents.txt
+
+
     # TODO: Why is this still present in the checkpoints directory???
     # TODO: Is there more we'd like to remove?
     # remove Space Ranger intermediates directory

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -193,16 +193,37 @@ workflow spaceranger_quant{
           }
         } 
 
-
+        // look for any additional images and check that there are not too many
         def image_file = getImageFiles("${meta.files_directory}/image")
+        if (image_file.size() > 1) {
+          log.error("Expected no more than 1 brightfield image file for ${meta.technology} in ${meta.files_directory}/image but found ${image_file.size()} files.")
+          image_file = []
+        } 
         def colorizedimage_file = getImageFiles("${meta.files_directory}/colorizedimage")
-        def darkimage_files = getImageFiles("${meta.files_directory}/darkimage") 
+        if (colorizedimage_file.size() > 1) {
+          log.error("Expected no more than 1 colorized image file for ${meta.technology} in ${meta.files_directory}/colorizedimage but found ${colorizedimage_file.size()} files.")
+          colorizedimage_file = []
+        } 
+        def darkimage_file = getImageFiles("${meta.files_directory}/darkimage")
+        if (darkimage_file.size() > 6) {
+          log.error("Expected between 1-6 dark image files for ${meta.technology} in ${meta.files_directory}/darkimage but found ${darkimage_file.size()} files.")
+          darkimage_file = []
+        } 
 
-        // use size of the images to determine which one to pass in, since image file values are never falsey
-        def image_type = image_file ? "image" :
-                         colorizedimage_file ? "colorizedimage" :
-                         darkimage_files ? "darkimage" :
-                         ""
+        // Determine which image file to pass in to spaceranger - there can only be one
+        // Here we simultaneously define the image_type (the spaceranger flag), and the image file itself
+        // The first file with size greater than 0 becomes the one we pass in, checking in order of brightfield, colorized, and dark
+        def (selected_image_file, image_type) = [
+            [image_file, "image"],
+            [colorizedimage_file, "colorizedimage"],
+            [darkimage_file, "darkimage"]
+          ].find{ it[0].size() > 0 } ?: [[], ""]
+
+        // if not using cytassist technology confirm there's an image
+        if (meta.technology in non_cytassist_techs && !image_type) {
+          error("At least one image file is required for ${meta.technology} but none were found in ${meta.files_directory}.")
+        }
+
 
         [
           meta,
@@ -210,7 +231,7 @@ workflow spaceranger_quant{
           probeset_file,
           file("${meta.files_directory}/fastq", type: 'dir'),
           cytaimage_file, 
-          image_file, 
+          selected_image_file, 
           image_type   
         ]
     }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -224,7 +224,7 @@ workflow spaceranger_quant{
         // no more than 1 image for any technology, but require 1 for non-cytassist
         if (present_images.size() > 1) {
           error("Expected no more than 1 type of provided image in ${meta.files_directory} but found: ${present_images.collect { "${it[1]}: ${it[0]}" }.join(", ")}")
-        } else if (meta.technology in non_cytassist_techs && !image_type) {
+        } else if (meta.technology in non_cytassist_techs && present_images.size() == 0) {
           error("At least one image file is required for ${meta.technology} but none were found in ${meta.files_directory}.")
         }
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -36,10 +36,6 @@ process spaceranger {
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
 
-    # DEBUGGING - why still intermediates????
-    ls ${out_id} > ${out_id}/contents.txt
-
-
     # TODO: Why is this still present in the checkpoints directory???
     # TODO: Is there more we'd like to remove?
     # remove Space Ranger intermediates directory

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -223,6 +223,7 @@ workflow spaceranger_quant{
         // confirm we have the right number of images:
         // no more than 1 image for any technology, but require 1 for non-cytassist
         if (present_images.size() > 1) {
+          // ensure informative print statement with info about the detected files
           error("Expected no more than 1 type of provided image in ${meta.files_directory} but found: ${present_images.collect { "${it[1]}: ${it[0]}" }.join(", ")}")
         } else if (meta.technology in non_cytassist_techs && present_images.size() == 0) {
           error("At least one image file is required for ${meta.technology} but none were found in ${meta.files_directory}.")

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -211,25 +211,25 @@ workflow spaceranger_quant{
           darkimage_file = []
         } 
 
-        // there can only be one of image, colorizedimage, or darkimage
-        def found_images = [image_file, colorizedimage_file, darkimage_file].count { it.size() > 0 }
-        if (found_images > 1) {
-            error("Expected no more than 1 type of provided image in ${meta.files_directory} but found these: ${found_images}")
-        }
-
         // Determine which image file to pass in to spaceranger 
-        // Here we simultaneously define the the image file itself and image_type (the spaceranger flag)
-        // The first file with size greater than 0 becomes the one we pass in, checking in order of brightfield, colorized, and dark
-        def (selected_image_file, image_type) = [
+        // Pair files and their types, and subset to only existing files
+        def present_images = [
             [image_file, "image"],
             [colorizedimage_file, "colorizedimage"],
             [darkimage_file, "darkimage"]
-          ].find{ it[0].size() > 0 } ?: [[], ""]
+          ]
+          .findAll{ it[0].size() > 0 } 
 
-        // if not using cytassist technology confirm there's an image
-        if (meta.technology in non_cytassist_techs && !image_type) {
+        // confirm we have the right number of images:
+        // no more than 1 image for any technology, but require 1 for non-cytassist
+        if (present_images.size() > 1) {
+          error("Expected no more than 1 type of provided image in ${meta.files_directory} but found: ${present_images.collect { "${it[1]}: ${it[0]}" }.join(", ")}")
+        } else if (meta.technology in non_cytassist_techs && !image_type) {
           error("At least one image file is required for ${meta.technology} but none were found in ${meta.files_directory}.")
         }
+
+        // Simultaneously define the the image file itself and image_type (the spaceranger flag)
+        def (selected_image_file, image_type) = present_images[0] ?: [[], ""]
 
         // input to spaceranger process
         [

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -211,7 +211,13 @@ workflow spaceranger_quant{
           darkimage_file = []
         } 
 
-        // Determine which image file to pass in to spaceranger - there can only be one
+        // there can only be one of image, colorizedimage, or darkimage
+        def found_images = [image_file, colorizedimage_file, darkimage_file].count { it.size() > 0 }
+        if (found_images > 1) {
+            error("Expected no more than 1 type of provided image in ${meta.files_directory} but found these: ${found_images}")
+        }
+
+        // Determine which image file to pass in to spaceranger 
         // Here we simultaneously define the image_type (the spaceranger flag), and the image file itself
         // The first file with size greater than 0 becomes the one we pass in, checking in order of brightfield, colorized, and dark
         def (selected_image_file, image_type) = [
@@ -225,7 +231,7 @@ workflow spaceranger_quant{
           error("At least one image file is required for ${meta.technology} but none were found in ${meta.files_directory}.")
         }
 
-
+        // input to spaceranger process
         [
           meta,
           file(meta.cellranger_index, type: 'dir'),

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -212,7 +212,7 @@ workflow spaceranger_quant{
         } 
 
         // Determine which image file to pass in to spaceranger - there can only be one
-        // Here we simultaneously define the image_type (the spaceranger flag), and the image file itself
+        // Here we simultaneously define the the image file itself and image_type (the spaceranger flag)
         // The first file with size greater than 0 becomes the one we pass in, checking in order of brightfield, colorized, and dark
         def (selected_image_file, image_type) = [
             [image_file, "image"],


### PR DESCRIPTION
Closes #1212 

This PR adds (and fixes on occasion!) some image checks and allows for us to use any kind of image. I have tested this under a variety of conditions: https://github.com/AlexsLemonade/scpca-nf/issues/1212#issuecomment-4047954125 

Here's how it now works (edited for how it final.final actually works):
- if cytassist, _error entirely_ if there is not 1 cytaimage
- for the other images, log an error (but don't error out!) if there are too many images (>1 image and colorized image, >6 darkimage)
- error out if:
  -  there's >1 image type. there can only be one
  - it's not cytassist and there is _no_ image at all
- then, we pick final image as what should now be the only one that exists