### PR TITLE
Update example tsvs and external instructions

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -10,6 +10,7 @@ ARI
 barcode
 bioinformatics
 bioRxiv
+brightfield
 Cavatica
 cDNA
 CellAssign
@@ -20,6 +21,7 @@ conda
 config
 customizable
 customizations
+CytAssist
 data's
 demultiplexed
 demultiplexing
@@ -40,6 +42,7 @@ GEX
 Github
 glioblastoma
 GRCh
+HD
 Heimberg
 Hippen
 HPC

--- a/examples/example_run_metadata.tsv
+++ b/examples/example_run_metadata.tsv
@@ -9,6 +9,6 @@ run07	library05	sample05	project01	paired_end	EFO:0003747	bulk	Mus_musculus.GRCm
 run08	library06	sample06	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run07	NA	NA	NA	NA	example_metadata_files/submitter_celltypes.tsv
 run09	library07	sample07	project02	10Xflex_v1.1_single	EFO:0022606	nucleus	Homo_sapiens.GRCh38.110	example_fastqs/run08	NA	NA	NA	NA	NA
 run10	library08	sample08;sample09;sample10;sample11	project02	10Xflex_v1.1_multi	EFO:0022606	cell	Homo_sapiens.GRCh38.110	example_fastqs/run09	NA	NA	NA	NA	NA
-run11	library09	sample12	project03	visium2	EFO:0010961	spot	Homo_sapiens.GRCh38.104	example_files/run11	NA	NA	A1	VXXXX-XXX	NA
-run12	library10	sample13	project03	visium_hd	EFO:0010961	square	Homo_sapiens.GRCh38.104	example_files/run12	NA	NA	A1	VXXXX-XXX	NA
-run13	library11	sample14	project03	visium_hd_3prime	EFO:0010961	square	Homo_sapiens.GRCh38.104	example_files/run13	NA	NA	A1	VXXXX-XXX	NA
+run11	library09	sample12	project03	visium2	EFO:0010961	spot	Homo_sapiens.GRCh38.110	example_files/run11	NA	NA	A1	VXXXX-XXX	NA
+run12	library10	sample13	project03	visium_hd	EFO:0010961	square	Homo_sapiens.GRCh38.110	example_files/run12	NA	NA	A1	VXXXX-XXX	NA
+run13	library11	sample14	project03	visium_hd_3prime	EFO:0010961	square	Homo_sapiens.GRCh38.110	example_files/run13	NA	NA	A1	VXXXX-XXX	NA

--- a/examples/example_run_metadata.tsv
+++ b/examples/example_run_metadata.tsv
@@ -2,10 +2,13 @@ scpca_run_id	scpca_library_id	scpca_sample_id	scpca_project_id	technology	assay_
 run01	library01	sample01	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run01	NA	NA	NA	NA	NA
 run02	library02	sample01	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run01	NA	NA	NA	NA	NA
 run03	library02	sample01	project01	CITEseq_10Xv3	EFO:0030011	cell	Homo_sapiens.GRCh38.104	example_fastqs/run02	example_barcode_files/cite_barcodes.tsv	2[1-15]	NA	NA	NA
-run04	library03	sample02	project01	visium	EFO:0010961	spot	Homo_sapiens.GRCh38.104	example_fastqs/run03	NA	NA	A1	VXXXX-XXX	NA
+run04	library03	sample02	project01	visium1	EFO:0010961	spot	Homo_sapiens.GRCh38.104	example_files/run03	NA	NA	A1	VXXXX-XXX	NA
 run05	library04	sample03;sample04	project01	10Xv3.1	EFO:0009922	cell	Mus_musculus.GRCm39.104	example_fastqs/run04	NA	NA	NA	NA	NA
 run06	library04	sample03;sample04	project01	cellhash_10Xv3.1	EFO:0030012	cell	Mus_musculus.GRCm39.104	example_fastqs/run05	example_barcode_files/cellhash_barcodes.tsv	2[1-10]	NA	NA	NA
 run07	library05	sample05	project01	paired_end	EFO:0003747	bulk	Mus_musculus.GRCm39.104	example_fastqs/run06	NA	NA	NA	NA	NA
 run08	library06	sample06	project01	10Xv3.1	EFO:0009922	cell	Homo_sapiens.GRCh38.104	example_fastqs/run07	NA	NA	NA	NA	example_metadata_files/submitter_celltypes.tsv
 run09	library07	sample07	project02	10Xflex_v1.1_single	EFO:0022606	nucleus	Homo_sapiens.GRCh38.110	example_fastqs/run08	NA	NA	NA	NA	NA
 run10	library08	sample08;sample09;sample10;sample11	project02	10Xflex_v1.1_multi	EFO:0022606	cell	Homo_sapiens.GRCh38.110	example_fastqs/run09	NA	NA	NA	NA	NA
+run11	library09	sample12	project03	visium2	EFO:0010961	spot	Homo_sapiens.GRCh38.104	example_files/run11	NA	NA	A1	VXXXX-XXX	NA
+run12	library10	sample13	project03	visium_hd	EFO:0010961	square	Homo_sapiens.GRCh38.104	example_files/run12	NA	NA	A1	VXXXX-XXX	NA
+run13	library11	sample14	project03	visium_hd_3prime	EFO:0010961	square	Homo_sapiens.GRCh38.104	example_files/run13	NA	NA	A1	VXXXX-XXX	NA

--- a/examples/example_sample_metadata.tsv
+++ b/examples/example_sample_metadata.tsv
@@ -10,3 +10,6 @@ sample08	FALSE	FALSE	diagnosis3	age8
 sample09	FALSE	FALSE	diagnosis3	age9
 sample10	FALSE	FALSE	diagnosis3	age10
 sample11	FALSE	FALSE	diagnosis3	age11
+sample12	FALSE	FALSE	diagnosis4	age12
+sample13	FALSE	FALSE	diagnosis4	age13
+sample14	FALSE	FALSE	diagnosis4	age14

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -750,7 +750,7 @@ Which specific files you will need depends on the Visium technology version you 
   * The image file should be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory.
   * These directory names correspond to the [`Space Ranger` flag](https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/running-pipelines/command-line-arguments) used to consume the image, so place your image in a directory named according to its type
   * Only the directory that contains the image file needs to exist; empty directories are not necessary to include
-* Visium CytaAssist, Visium HD, and Visium HD 3' libraries require a CytAssist image file provided in the `cytaimage/` directory
+* Visium CytAssist, Visium HD, and Visium HD 3' libraries require a CytAssist image file provided in the `cytaimage/` directory
   * Optionally, a single second image can be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory
   * Only the directory that contains the optional image file needs to exist; empty directories are not necessary to include
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -146,7 +146,7 @@ To run the workflow, you will need to create a tab separated values (TSV) metada
 | `scpca_library_id`     | A unique library ID for each unique set of cells |
 | `scpca_sample_id`      | A unique sample ID for each tissue or unique source. <br> For multiplexed libraries, separate multiple samples with semicolons (`;`) |
 | `scpca_project_id`     | A unique ID for each group of related samples. All results for samples with the same project ID will be returned in the same folder labeled with the project ID. |
-| `technology`           | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, `10Xv3.1`, `10Xv3_5prime`, or `10Xv4`. <br> For ADT (CITE-seq) libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For cellhash libraries use either `cellhash_10Xv2`, `cellhash_10Xv3`, or `cellhash_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use `visium` <br> For GEM-X Flex with probe set version 1.1 use either `10Xflex_v1.1_single` or `10Xflex_v1.1_multi`|
+| `technology`           | Sequencing/library technology used <br> For single-cell/single-nuclei libraries use either `10Xv2`, `10Xv2_5prime`, `10Xv3`, `10Xv3.1`, `10Xv3_5prime`, or `10Xv4`. <br> For ADT (CITE-seq) libraries use either `CITEseq_10Xv2`, `CITEseq_10Xv3`, or `CITEseq_10Xv3.1` <br> For cellhash libraries use either `cellhash_10Xv2`, `cellhash_10Xv3`, or `cellhash_10Xv3.1` <br> For bulk RNA-seq use either `single_end` or `paired_end`. <br> For spatial transcriptomics use either `visium1` (first-generation Visium without CytAssist), `visium2` (second-generation Visium with CytAssist), `visium_hd`, or `visium_hd_3prime` <br> For GEM-X Flex with probe set version 1.1 use either `10Xflex_v1.1_single` or `10Xflex_v1.1_multi`|
 | `assay_ontology_term_id`| [Experimental Factor Ontology](https://www.ebi.ac.uk/ols/ontologies/efo) term ID associated with the `tech_version` |
 | `seq_unit`              | Sequencing unit (one of: `cell`, `nucleus`, `bulk`, or `spot`) |
 | `sample_reference`      | The name of the reference to use for mapping, available references include `Homo_sapiens.GRCh38.104` and `Mus_musculus.GRCm39.104` |
@@ -745,12 +745,14 @@ To process spatial transcriptomic libraries, all FASTQ files for each sequencing
 
 Which specific files you will need depends on the Visium technology version you are using:
 
-* First-generation Visium libraries require require a populated `fastq` directory, and a single type of image file
+* All technologies require a populated `fastq` directory
+* First-generation Visium libraries require a single type of image file
   * The image file should be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory.
-  * These directory names correspond to the [`Space Ranger` flag](https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/running-pipelines/command-line-arguments) used to consume the image
-  * Only the directory that contains the image file needs to exist
-* Visium CytaAssist, Visium HD, and Visium HD 3' libraries require a populated `fastq` directory, and an CytAssist image file provided in the `cytaimage` directory
+  * These directory names correspond to the [`Space Ranger` flag](https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/running-pipelines/command-line-arguments) used to consume the image, so place your image in a directory named according to its type
+  * Only the directory that contains the image file needs to exist; empty directories are not necessary to include
+* Visium CytaAssist, Visium HD, and Visium HD 3' libraries require a CytAssist image file provided in the `cytaimage/` directory
   * Optionally, a single second image can be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory
+  * Only the directory that contains the optional image file needs to exist; empty directories are not necessary to include
 
 The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -747,7 +747,7 @@ Which specific files you will need depends on the Visium technology version you 
 
 * All technologies require a populated `fastq` directory
 * First-generation Visium libraries require a single type of image file
-  * The image file should be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory.
+  * The image file should be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory
   * These directory names correspond to the [`Space Ranger` flag](https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/running-pipelines/command-line-arguments) used to consume the image, so place your image in a directory named according to its type
   * Only the directory that contains the image file needs to exist; empty directories are not necessary to include
 * Visium CytAssist, Visium HD, and Visium HD 3' libraries require a CytAssist image file provided in the `cytaimage/` directory
@@ -761,7 +761,7 @@ For licensing reasons, we cannot provide a Docker container with Space Ranger fo
 As an example, the [Dockerfile that we used to build Space Ranger](docker/spaceranger/Dockerfile) can be found in the `docker/spaceranger` directory of this repository.
 
 After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.spaceranger_container` to the registry location and image ID in the `user_template.config` file.
-_Note: The workflow is currently set up to run Space Ranger version `4.0.1` has not been tested with other Space Ranger versions._
+_Note: The workflow is currently set up to run Space Ranger version `4.0.1` and has not been tested with other Space Ranger versions._
 
 ## Additional workflow settings
 

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -727,7 +727,31 @@ This file will contain one row for each library-sample pair (i.e. a library cont
 
 ### Spatial transcriptomics libraries
 
-To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated `.jpg` file must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file).
+To process spatial transcriptomic libraries, all FASTQ files for each sequencing run and the associated image file(s) must be inside the `files_directory` listed in the [metadata file](#prepare-the-metadata-file), organized into subdirectories named as exactly as shown based on the file type:
+
+```text
+{files_directory}
+├── fastq
+│   ├── X_L001_R1.fastq.gz
+│   ├── X_L001_R2.fastq.gz
+│   ├── Y_L002_R1.fastq.gz
+│   └── Y_L002_R2.fastq.gz
+├── cytaimage
+│   └── image.tiff
+├── image
+├── colorizedimage
+└── darkimage
+```
+
+Which specific files you will need depends on the Visium technology version you are using:
+
+* First-generation Visium libraries require require a populated `fastq` directory, and a single type of image file
+  * The image file should be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory.
+  * These directory names correspond to the [`Space Ranger` flag](https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/running-pipelines/command-line-arguments) used to consume the image
+  * Only the directory that contains the image file needs to exist
+* Visium CytaAssist, Visium HD, and Visium HD 3' libraries require a populated `fastq` directory, and an CytAssist image file provided in the `cytaimage` directory
+  * Optionally, a single second image can be provided in either the `image/` (e.g. for a brightfield image), `colorizedimage/`, or the `darkimage/` directory
+
 The metadata file must also contain columns with the `slide_section` and `slide_serial_number`.
 
 You will also need to provide a [docker image](https://docs.docker.com/get-started/) that contains the [Space Ranger software from 10X Genomics](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest).
@@ -735,8 +759,7 @@ For licensing reasons, we cannot provide a Docker container with Space Ranger fo
 As an example, the [Dockerfile that we used to build Space Ranger](docker/spaceranger/Dockerfile) can be found in the `docker/spaceranger` directory of this repository.
 
 After building the docker image, you will need to push it to a [private docker registry](https://www.docker.com/blog/how-to-use-your-own-registry/) and set `params.spaceranger_container` to the registry location and image ID in the `user_template.config` file.
-_Note: The workflow is currently set up to work only with spatial transcriptomic libraries produced from the [Visium Spatial Gene Expression protocol](https://www.10xgenomics.com/products/spatial-gene-expression) and has not been tested using output from other spatial transcriptomics methods._
-
+_Note: The workflow is currently set up to run Space Ranger version `4.0.1` has not been tested with other Space Ranger versions._
 
 ## Additional workflow settings
 


### PR DESCRIPTION
Close #1217 

This PR updates some of the forward-facing files in scpca-nf for spatial.

- I added new rows to the relevant example metadata files, and updated the existing visium row to be visium1. I thought this was ok to do at this point since but let me know if you want to keep that row as visium for any reason. Either way, the files directory was also updated to not involve the word `fastq` 
- I updated external instructions with current file expectations. Please let me know if this is clear, rephrasing suggestions are welcome!
  - I updated the last sentence here to emphasize the version of space ranger. I thought about but decided against also saying "also we only take visium, not xenium," but given the rest of the document that didn't seem necessary. Let me know if you think I should add something to that effect 