### PR TITLE
Remove special logic for stub processing

### DIFF
--- a/lib/utils.nf
+++ b/lib/utils.nf
@@ -121,21 +121,21 @@ def pullthroughContainer(image_url, pullthrough_url = ""){
 
 
 /**
-  * For a given directory, return its space ranger image files 
+  * For a given directory, return its space ranger image files
   *
   * @param dir Directory to search image files(s) in
   * @param cytaimage Boolean if the image file(s) to grab are the cytaimage
   * @return Array of file paths
   */
 def getImageFiles(dir, cytaimage = false) {
-  
+
   // https://www.10xgenomics.com/support/software/space-ranger/latest/analysis/inputs/image-image-recommendation
   def image_extensions = cytaimage
-    ? ["tif", "tiff"] 
+    ? ["tif", "tiff"]
     : ["tif", "tiff", "btf", "tf2", "tf8", "jpg", "jpeg", "qptiff"]
 
   def f = files("${dir}/*")
-    .findAll { it =~ /(?i)\.(${image_extensions.join('|')})$/ }
+    .findAll { it.name.tokenize('.').last().toLowerCase() in image_extensions }
 
   return (f)
 }

--- a/main.nf
+++ b/main.nf
@@ -326,7 +326,7 @@ workflow {
   // make rds for RNA with feature quants
   all_feature_ch = generate_sce_with_feature(feature_rna_quant_ch, file(params.sample_metafile))
     .branch{ _meta, _unfiltered, filtered ->
-      continue_processing: filtered.size() > 0 || filtered.name.startsWith("STUB")
+      continue_processing: filtered.size() > 0
       skip_processing: true
     }
 
@@ -384,7 +384,7 @@ workflow {
   post_process_ch = post_process_sce.out
     // only continue processing any samples with > 0 cells left after processing
     .branch{ _meta, _unfiltered, _filtered, processed ->
-      continue_processing: processed.size() > 0 || processed.name.startsWith("STUB")
+      continue_processing: processed.size() > 0
       skip_processing: true
     }
 

--- a/main.nf
+++ b/main.nf
@@ -282,7 +282,7 @@ workflow {
   )
   flex_sce_ch = generate_sce_cellranger(flex_quant.out, file(params.sample_metafile))
     .branch{ _meta, _unfiltered, filtered ->
-      continue_processing: filtered.size() > 0 || filtered.name.startsWith("STUBL")
+      continue_processing: filtered.size() > 0
       skip_processing: true
     }
 
@@ -302,7 +302,7 @@ workflow {
   rna_sce_ch = generate_sce(rna_quant_ch, file(params.sample_metafile))
     // only continue processing any samples with > 0 cells left after filtering
     .branch{ _meta, _unfiltered, filtered ->
-      continue_processing: filtered.size() > 0 || filtered.name.startsWith("STUBL")
+      continue_processing: filtered.size() > 0
       skip_processing: true
     }
 

--- a/merge.nf
+++ b/merge.nf
@@ -211,7 +211,7 @@ workflow {
       [it.library_id, processed, meta_json ]
     }
     .subscribe{ library_id, processed, meta_json ->
-      if (!processed.exists() || !(processed.size() > 0 || library_id.startsWith("STUBL"))) {
+      if (!processed.exists() || !(processed.size() > 0)) {
         log.warn("Processed files do not exist for ${library_id}. This library will not be included in the merged object.")
       }
       else if (!(meta_json.exists() && meta_json.size() > 0)) {
@@ -231,7 +231,6 @@ workflow {
     // only include libraries that have been processed through scpca-nf and have at least 3 cells
     .filter{ _project_id, library_id, processed, meta_json ->
       (processed.exists() && processed.size() > 0 && getMetaVal(meta_json, "processed_cells") >= 3)
-      || library_id.startsWith("STUBL")
     }
     // remove metadata file
     .map{ project_id, library_id, processed, _meta_json ->

--- a/merge.nf
+++ b/merge.nf
@@ -229,7 +229,7 @@ workflow {
       [it.project_id, it.library_id, processed, meta_json]
     }
     // only include libraries that have been processed through scpca-nf and have at least 3 cells
-    .filter{ _project_id, library_id, processed, meta_json ->
+    .filter{ _project_id, _library_id, processed, meta_json ->
       (processed.exists() && processed.size() > 0 && getMetaVal(meta_json, "processed_cells") >= 3)
     }
     // remove metadata file

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -185,7 +185,7 @@ process make_unfiltered_sce_cellranger {
     stub:
         unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
         """
-        touch ${unfiltered_rds}
+        echo "unfiltered" > ${unfiltered_rds}
         """
 }
 
@@ -224,7 +224,7 @@ process filter_sce {
   stub:
     filtered_rds = "${meta.unique_id}_filtered.rds"
     """
-    touch ${filtered_rds}
+    echo "filtered" > ${filtered_rds}
     """
 }
 
@@ -250,7 +250,7 @@ process genetic_demux_sce {
   stub:
     demux_rds = "${filtered_rds.baseName}_genetic-demux.rds"
     """
-    touch ${demux_rds}
+    echo "genetic-demux" > ${demux_rds}
     """
 }
 
@@ -278,7 +278,7 @@ process cellhash_demux_sce {
   stub:
     demux_rds = "${filtered_rds.baseName}_cellhash-demux.rds"
     """
-    touch ${demux_rds}
+    echo "cellhash-demux" > ${demux_rds}
     """
 }
 
@@ -307,8 +307,8 @@ process post_process_sce {
     filter_labeled_rds = "${meta.unique_id}_filtered_labeled.rds"
     processed_rds = "${meta.unique_id}_processed.rds"
     """
-    touch ${filter_labeled_rds}
-    touch ${processed_rds}
+    echo "filtered-labeled" > ${filter_labeled_rds}
+    echo "processed" > ${processed_rds}
     """
 }
 

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -4,189 +4,188 @@ include { pullthroughContainer } from '../lib/utils.nf'
 
 // RNA only libraries
 process make_unfiltered_sce {
-    container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
-    label 'mem_8'
-    tag "${meta.unique_id}"
-    input:
-        tuple val(meta), path(alevin_dir),
-              path(mito_file), path(ref_gtf),
-              path(submitter_cell_types_file), path(openscpca_cell_types_file)
-        path sample_metafile
-    output:
-        tuple val(meta), path(unfiltered_rds)
-    script:
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        generate_unfiltered_sce_alevin.R \
-          --alevin_dir ${alevin_dir} \
-          --unfiltered_file ${unfiltered_rds} \
-          --technology ${meta.technology} \
-          --seq_unit ${meta.seq_unit} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --project_id "${meta.project_id}" \
-          ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""} \
-          ${params.spliced_only ? '--spliced_only' : ''}
+  container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
+  label 'mem_8'
+  tag "${meta.unique_id}"
+  input:
+    tuple val(meta), path(alevin_dir),
+          path(mito_file), path(ref_gtf),
+          path(submitter_cell_types_file), path(openscpca_cell_types_file)
+    path sample_metafile
+  output:
+    tuple val(meta), path(unfiltered_rds)
+  script:
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    generate_unfiltered_sce_alevin.R \
+      --alevin_dir ${alevin_dir} \
+      --unfiltered_file ${unfiltered_rds} \
+      --technology ${meta.technology} \
+      --seq_unit ${meta.seq_unit} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --project_id "${meta.project_id}" \
+      ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""} \
+      ${params.spliced_only ? '--spliced_only' : ''}
 
-        format_unfiltered_sce.R \
-          --sce_file ${unfiltered_rds} \
-          --mito_file ${mito_file} \
-          --gtf_file ${ref_gtf} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --sample_metadata_file ${sample_metafile}
+    format_unfiltered_sce.R \
+      --sce_file ${unfiltered_rds} \
+      --mito_file ${mito_file} \
+      --gtf_file ${ref_gtf} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --sample_metadata_file ${sample_metafile}
 
-        # Only run scripts if annotations are available:
-        if [[ -f "${submitter_cell_types_file}" ]]; then
-          add_submitter_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --submitter_cell_types_file "${submitter_cell_types_file}"
-        fi
+    # Only run scripts if annotations are available:
+    if [[ -f "${submitter_cell_types_file}" ]]; then
+      add_submitter_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --submitter_cell_types_file "${submitter_cell_types_file}"
+    fi
 
-        if [[ -f "${openscpca_cell_types_file}" ]]; then
-          add_openscpca_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --openscpca_cell_types_file "${openscpca_cell_types_file}"
-        fi
+    if [[ -f "${openscpca_cell_types_file}" ]]; then
+      add_openscpca_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --openscpca_cell_types_file "${openscpca_cell_types_file}"
+    fi
 
-        """
-    stub:
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        touch ${unfiltered_rds}
-        """
+    """
+  stub:
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    echo "unfiltered" > ${unfiltered_rds}
+    """
 }
 
 // channels with RNA and feature data
 process make_unfiltered_sce_with_feature {
-    label 'mem_8'
-    tag "${rna_meta.unique_id}"
-    container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
-    input:
-        tuple val(feature_meta), path(feature_alevin_dir),
-              val(rna_meta), path(alevin_dir),
-              path(mito_file), path(ref_gtf), path(submitter_cell_types_file), path(openscpca_cell_types_file)
-        path sample_metafile
-    output:
-        tuple val(meta), path(unfiltered_rds)
-    script:
-        // add feature metadata as elements of the main meta object
-        meta = rna_meta.clone()
-        meta.feature_type = feature_meta.technology.split('_')[0]
-        meta.feature_meta = feature_meta
+  label 'mem_8'
+  tag "${rna_meta.unique_id}"
+  container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
+  input:
+    tuple val(feature_meta), path(feature_alevin_dir),
+          val(rna_meta), path(alevin_dir),
+          path(mito_file), path(ref_gtf), path(submitter_cell_types_file), path(openscpca_cell_types_file)
+    path sample_metafile
+  output:
+    tuple val(meta), path(unfiltered_rds)
+  script:
+    // add feature metadata as elements of the main meta object
+    meta = rna_meta.clone()
+    meta.feature_type = feature_meta.technology.split('_')[0]
+    meta.feature_meta = feature_meta
 
-        // If feature_type is "CITEseq", make it "adt"
-        if (meta.feature_type.toLowerCase() == "citeseq") {
-          meta.feature_type = "adt"
-        }
+    // If feature_type is "CITEseq", make it "adt"
+    if (meta.feature_type.toLowerCase() == "citeseq") {
+      meta.feature_type = "adt"
+    }
 
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        generate_unfiltered_sce_alevin.R \
-          --alevin_dir ${alevin_dir} \
-          --feature_dir ${feature_alevin_dir} \
-          --feature_name ${meta.feature_type} \
-          --unfiltered_file ${unfiltered_rds} \
-          --technology ${meta.technology} \
-          --seq_unit ${meta.seq_unit} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --project_id "${meta.project_id}" \
-          ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""} \
-          ${params.spliced_only ? '--spliced_only' : ''}
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    generate_unfiltered_sce_alevin.R \
+      --alevin_dir ${alevin_dir} \
+      --feature_dir ${feature_alevin_dir} \
+      --feature_name ${meta.feature_type} \
+      --unfiltered_file ${unfiltered_rds} \
+      --technology ${meta.technology} \
+      --seq_unit ${meta.seq_unit} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --project_id "${meta.project_id}" \
+      ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""} \
+      ${params.spliced_only ? '--spliced_only' : ''}
 
-        format_unfiltered_sce.R \
-          --sce_file ${unfiltered_rds} \
-          --mito_file ${mito_file} \
-          --gtf_file ${ref_gtf} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --sample_metadata_file ${sample_metafile}
+    format_unfiltered_sce.R \
+      --sce_file ${unfiltered_rds} \
+      --mito_file ${mito_file} \
+      --gtf_file ${ref_gtf} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --sample_metadata_file ${sample_metafile}
 
-        # Only run script if annotations are available:
-        if [[ -f "${submitter_cell_types_file}" ]]; then
-          add_submitter_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --submitter_cell_types_file "${submitter_cell_types_file}"
-        fi
+    # Only run script if annotations are available:
+    if [[ -f "${submitter_cell_types_file}" ]]; then
+      add_submitter_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --submitter_cell_types_file "${submitter_cell_types_file}"
+    fi
 
-        if [[ -f "${openscpca_cell_types_file}" ]]; then
-          add_openscpca_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --openscpca_cell_types_file "${openscpca_cell_types_file}"
-        fi
-        """
-    stub:
-        meta = rna_meta.clone()
-        meta.feature_type = feature_meta.technology.split('_')[0]
-        meta.feature_meta = feature_meta
+    if [[ -f "${openscpca_cell_types_file}" ]]; then
+      add_openscpca_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --openscpca_cell_types_file "${openscpca_cell_types_file}"
+    fi
+    """
+  stub:
+    meta = rna_meta.clone()
+    meta.feature_type = feature_meta.technology.split('_')[0]
+    meta.feature_meta = feature_meta
 
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        touch "${meta.unique_id}_unfiltered.rds"
-        """
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    echo "unfiltered" > ${unfiltered_rds}
+    """
 }
 
 process make_unfiltered_sce_cellranger {
-    container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
-    label 'mem_8'
-    tag "${meta.unique_id}"
-    input:
-        tuple val(meta), path(cellranger_dir),
-              path(versions_file), path(metrics_file),
-              path(ref_gtf), path(submitter_cell_types_file), path(openscpca_cell_types_file)
-        path sample_metafile
-    output:
-        tuple val(meta), path(unfiltered_rds)
-    script:
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        generate_unfiltered_sce_cellranger.R \
-          --cellranger_dir ${cellranger_dir} \
-          --unfiltered_file ${unfiltered_rds} \
-          --versions_file ${versions_file} \
-          --metrics_file ${metrics_file} \
-          --reference_index ${meta.cellranger_index} \
-          --reference_probeset ${meta.flex_probeset} \
-          --technology ${meta.technology} \
-          --seq_unit ${meta.seq_unit} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --project_id "${meta.project_id}" \
-          ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""}
+  container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
+  label 'mem_8'
+  tag "${meta.unique_id}"
+  input:
+    tuple val(meta), path(cellranger_dir),
+          path(versions_file), path(metrics_file),
+          path(ref_gtf), path(submitter_cell_types_file), path(openscpca_cell_types_file)
+    path sample_metafile
+  output:
+    tuple val(meta), path(unfiltered_rds)
+  script:
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    generate_unfiltered_sce_cellranger.R \
+      --cellranger_dir ${cellranger_dir} \
+      --unfiltered_file ${unfiltered_rds} \
+      --versions_file ${versions_file} \
+      --metrics_file ${metrics_file} \
+      --reference_index ${meta.cellranger_index} \
+      --reference_probeset ${meta.flex_probeset} \
+      --technology ${meta.technology} \
+      --seq_unit ${meta.seq_unit} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --project_id "${meta.project_id}" \
+      ${meta.assay_ontology_term_id? "--assay_ontology_term_id ${meta.assay_ontology_term_id}" : ""}
 
-        format_unfiltered_sce.R \
-          --sce_file ${unfiltered_rds} \
-          --gtf_file ${ref_gtf} \
-          --library_id "${meta.library_id}" \
-          --sample_id "${meta.sample_id}" \
-          --sample_metadata_file ${sample_metafile}
+    format_unfiltered_sce.R \
+      --sce_file ${unfiltered_rds} \
+      --gtf_file ${ref_gtf} \
+      --library_id "${meta.library_id}" \
+      --sample_id "${meta.sample_id}" \
+      --sample_metadata_file ${sample_metafile}
 
-        # Only run script if annotations are available:
-        if [[ -f "${submitter_cell_types_file}" ]]; then
-          add_submitter_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --submitter_cell_types_file "${submitter_cell_types_file}"
-        fi
+    # Only run script if annotations are available:
+    if [[ -f "${submitter_cell_types_file}" ]]; then
+      add_submitter_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --submitter_cell_types_file "${submitter_cell_types_file}"
+    fi
 
-        if [[ -f "${openscpca_cell_types_file}" ]]; then
-          add_openscpca_annotations.R \
-            --sce_file "${unfiltered_rds}" \
-            --library_id "${meta.library_id}" \
-            --openscpca_cell_types_file "${openscpca_cell_types_file}"
-        fi
-
-        """
-    stub:
-        unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
-        """
-        echo "unfiltered" > ${unfiltered_rds}
-        """
+    if [[ -f "${openscpca_cell_types_file}" ]]; then
+      add_openscpca_annotations.R \
+        --sce_file "${unfiltered_rds}" \
+        --library_id "${meta.library_id}" \
+        --openscpca_cell_types_file "${openscpca_cell_types_file}"
+    fi
+    """
+  stub:
+    unfiltered_rds = "${meta.unique_id}_unfiltered.rds"
+    """
+    echo "unfiltered" > ${unfiltered_rds}
+    """
 }
 
 process filter_sce {

--- a/test/output/results/STUBP01/STUBS01/STUBL01_processed.rds
+++ b/test/output/results/STUBP01/STUBS01/STUBL01_processed.rds
@@ -1,0 +1,1 @@
+processed

--- a/test/output/results/STUBP01/STUBS16/STUBL16_processed.rds
+++ b/test/output/results/STUBP01/STUBS16/STUBL16_processed.rds
@@ -1,0 +1,1 @@
+processed


### PR DESCRIPTION
To have more complete testing, we should not have any special logic for stub tests outside of the stub blocks themselves. Here I am removing all the places I could find where that had snuck into our workflow. All of these were places that we were checking file sizes and expecting non-zero sizes, so to remove them I simply made the stub block insert some text into the file rather than creating an empty file. 

I also did some indentation cleanup, so you might want to turn off whitespace!