### PR TITLE
Add a space in cellranger multi

### DIFF
--- a/bin/generate_unfiltered_sce_cellranger.R
+++ b/bin/generate_unfiltered_sce_cellranger.R
@@ -161,7 +161,7 @@ metadata_list <- list(
   reference_probeset = basename(opt$reference_probeset),
   total_reads = total_reads,
   pct_mapped_reads = pct_mapped_reads,
-  mapping_tool = "cellranger-multi",
+  mapping_tool = "cellranger multi",
   cellranger_num_cells = ncol(unfiltered_sce),
   tech_version = opt$technology,
   assay_ontology_term_id = opt$assay_ontology_term_id,


### PR DESCRIPTION
When working on the docs in https://github.com/AlexsLemonade/scpca-docs/pull/494, I noticed that we use `cellranger-multi` as the `mapping_tool` for flex samples, but the function is actually `cellranger multi`. This PR just adds in the space. 