### PR TITLE
Compress the spaceranger hd outs

### DIFF
--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -79,12 +79,11 @@ process spaceranger_hd {
     meta_json = makeJson(meta)
     image_arg = meta.visium_image_type ? "--${meta.visium_image_type} ${image_file.join(',')}" : "" // join in case of multiple darkimages
     
-    outdir_full ="${out_id}_full"
     // may help avoid OOM errors, but needs to be a rounded integer sans decimal
     spaceranger_mem = Math.ceil(task.memory.toGiga() * 0.9) as int
     """
     spaceranger count \
-      --id=${outdir_full} \
+      --id=${out_id} \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \
@@ -97,47 +96,26 @@ process spaceranger_hd {
       ${cytaimage_file ? "--cytaimage ${cytaimage_file}" : ""} \
       ${image_arg}
 
-    # create publish dir
-    mkdir -p ${out_id}/outs 
 
     # remove files we dont want to publish
-    for square_src in ${outdir_full}/outs/binned_outputs/square_*; do
-      rm -rf \${square_src}/analysis                     # only in 008, 016
-      rm -f \${square_src}/cloupe.cloupe                 # only in 008
-      rm -f \${square_src}/raw_feature_bc_matrix.h5      # all binned dirs
-      rm -f \${square_src}/filtered_feature_bc_matrix.h5 # all binned dirs
-      rm -f \${square_src}/spatial/.fusion.symlinks      # all binned dirs
+    rm -rf ${out_id}/SPATIAL_RNA_COUNTER_CS
+    find ${out_id} -type f -name "*.cloupe" -delete
+    find ${out_id} -type l -name "*.cloupe" -delete
+    find ${out_id} -type f -name "*.h5" -delete
+    find ${out_id} -type f -name ".fusion.symlinks" -delete
+    for square_src in ${out_id}/outs/binned_outputs/square_*; do
+      rm -rf \${square_src}/analysis # only in 008, 016
     done
-    seg_dir="${outdir_full}/outs/segmented_outputs"
+    seg_dir="${out_id}/outs/segmented_outputs"
     if [ -d "\${seg_dir}" ]; then
-      # add output indicator to use for checks
-      touch ${out_id}/segmented_exists.txt
-      # now, remove files we don't need if segmentation was successful
-      if [ -d "\${seg_dir}/filtered_feature_bc_matrix" ]; then
-        rm -rf \${seg_dir}/analysis
-        rm -f \${seg_dir}/cloupe.cloupe
-        rm -f \${seg_dir}/raw_feature_bc_matrix.h5
-        rm -f \${seg_dir}/filtered_feature_bc_matrix.h5
-        rm -f \${seg_dir}/spatial/.fusion.symlinks
-      fi
+      rm -rf \${seg_dir}/analysis
+      # we retain cell_segmentations.geojson and nucleus_segmentations.geojson but remove versions augmented with spaceranger clustering
+      rm -f \${seg_dir}/graphclust_annotated_cell_segmentations.geojson
+      rm -f \${seg_dir}/graphclust_annotated_nucleus_segmentations.geojson
     fi
-  
-    # compress outs/ into out_id
-    tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${outdir_full}/outs
-
-    # get rest of the things into out_id
-    cp ${outdir_full}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz ${out_id}/raw-barcodes.tsv.gz
-    cp ${outdir_full}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz ${out_id}/filtered-barcodes.tsv.gz
-    cp ${outdir_full}/outs/metrics_summary.csv ${out_id}/outs/metrics_summary.csv
-    cp ${outdir_full}/outs/web_summary.html ${out_id}/outs/web_summary.html
-    cp ${outdir_full}/_versions ${out_id}/_versions
 
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
-
-    # TESTING 
-    ls -lahR ${outdir_full}/outs > ${out_id}/final_outdir_full_contents.txt
-    ls -lahR ${out_id} > ${out_id}/final_out_id_contents.txt
     """
   stub:
     out_id = file(meta.spaceranger_results_dir).name
@@ -146,9 +124,6 @@ process spaceranger_hd {
     """
     mkdir -p ${out_id}/outs
     echo '${meta_json}' > ${out_id}/scpca-meta.json
-    if [ "${meta.visium_image_type}" == "image" ]; then
-      touch ${out_id}/segmented_exists.txt
-    fi
     """
 }
 
@@ -176,10 +151,10 @@ process spaceranger_publish {
 
     # copy over files that depend on the technology, and define associated inputs to the R script
     if [[ ${is_hd} == "true" ]]; then
-       cp ${spatial_out}/${meta.library_id}_spatial.tar.gz ${spatial_publish_dir}/
+      tar -czf ${spatial_publish_dir}/${meta.library_id}_outs.tar.gz ${spatial_out}/outs
 
-      unfiltered_barcodes_file="${spatial_out}/raw-barcodes.tsv.gz"
-      filtered_barcodes_file="${spatial_out}/filtered-barcodes.tsv.gz"
+      unfiltered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz"
+      filtered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz"
     else 
       cp -r ${spatial_out}/outs/raw_feature_bc_matrix ${spatial_publish_dir}
       cp -r ${spatial_out}/outs/filtered_feature_bc_matrix ${spatial_publish_dir}
@@ -383,7 +358,8 @@ workflow spaceranger_quant{
     // log error about segmented_outputs as needed
     spaceranger_hd.out
       .subscribe{ meta, out_dir ->
-        if (meta.visium_image_type == "image" && !file("${out_dir}/segmented_exists.txt").exists()) { 
+        def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
+        if (meta.visium_image_type == "image" && !segmented_dir_exists) { 
           log.error("Expected segmented_outputs directory for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
         }
       }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -108,6 +108,7 @@ process spaceranger_hd {
     done
     seg_dir="${out_id}/outs/segmented_outputs"
     if [ -d "\${seg_dir}" ]; then
+      touch ${out_id}/segmented_exists.txt
       rm -rf \${seg_dir}/analysis
       # we retain cell_segmentations.geojson and nucleus_segmentations.geojson but remove versions augmented with spaceranger clustering
       rm -f \${seg_dir}/graphclust_annotated_cell_segmentations.geojson
@@ -361,9 +362,14 @@ workflow spaceranger_quant{
         log.info("Checking segmented_outputs at: ${out_dir}/outs/segmented_outputs")
         log.info("out_dir real path: ${out_dir.toRealPath()}")
         def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
+        def segmented_exists_exists = out_dir.resolve("segmented_exists.txt").exists()
         log.info("isDirectory result: ${segmented_dir_exists}")
+        log.info("segmented_exists.txt result: ${segmented_exists_exists}")
         if (meta.visium_image_type == "image" && !segmented_dir_exists) { 
           log.error("Expected segmented_outputs directory for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
+        }
+        if (meta.visium_image_type == "image" && !segmented_exists_exists) { 
+          log.error("Expected segmented_exists.txt file for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
         }
       }
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -153,8 +153,8 @@ process spaceranger_publish {
     if [[ ${is_hd} == "true" ]]; then
       # remove before tar'ing
       find ${spatial_out}/outs -type f -name ".fusion.symlinks" -delete 
-      # -C to just get outs.tar.gz itself sans extra nesting
-      tar -czf ${spatial_publish_dir}/${meta.library_id}_outs.tar.gz -C ${spatial_out} outs 
+      # -C to just get outs.tar.gz itself sans extra nesting, and need to give users permissions
+      tar -czf ${spatial_publish_dir}/${meta.library_id}_outs.tar.gz -C ${spatial_out} outs --mode='u+rw,go+r'
 
       unfiltered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz"
       filtered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz"
@@ -362,7 +362,6 @@ workflow spaceranger_quant{
     spaceranger_hd.out
       .subscribe{ meta, out_dir ->
         log.info("Checking segmented_outputs at: ${out_dir}/outs/segmented_outputs")
-        log.info("out_dir real path: ${out_dir.toRealPath()}")
         def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
         def segmented_exists_exists = out_dir.resolve("segmented_exists.txt").exists()
         log.info("isDirectory result: ${segmented_dir_exists}")

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -102,7 +102,6 @@ process spaceranger_hd {
     find ${out_id} -type f -name "*.cloupe" -delete
     find ${out_id} -type l -name "*.cloupe" -delete
     find ${out_id} -type f -name "*.h5" -delete
-    find ${out_id} -type f -name ".fusion.symlinks" -delete
     for square_src in ${out_id}/outs/binned_outputs/square_*; do
       rm -rf \${square_src}/analysis # only in 008, 016
     done
@@ -152,7 +151,10 @@ process spaceranger_publish {
 
     # copy over files that depend on the technology, and define associated inputs to the R script
     if [[ ${is_hd} == "true" ]]; then
-      tar -czf ${spatial_publish_dir}/${meta.library_id}_outs.tar.gz ${spatial_out}/outs
+      # remove before tar'ing
+      find ${spatial_out}/outs -type f -name ".fusion.symlinks" -delete 
+      # -C to just get outs.tar.gz itself sans extra nesting
+      tar -czf ${spatial_publish_dir}/${meta.library_id}_outs.tar.gz -C ${spatial_out} outs 
 
       unfiltered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz"
       filtered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz"

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -101,8 +101,8 @@ process spaceranger_hd {
     # compress outs/ into out_id
     tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${out_id}-uncompressed/outs
 
-    # add indicator if the segmented directory exists
-    if [ -d "${out_id}-uncompressed/outs/segmented_outputs" ]; then
+    # add indicator if the segmented internal directories exist
+    if [ -d "${out_id}-uncompressed/outs/segmented_outputs/filtered_feature_bc_matrix" ]; then
       touch ${out_id}/segmented_exists.txt
     fi
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -97,6 +97,9 @@ process spaceranger_hd {
       ${image_arg}
 
     mkdir -p ${out_id}/outs 
+
+    # remove the .fusion.symlinks files
+    find ${out_id}-uncompressed/outs -name ".fusion.symlinks" -delete
   
     # compress outs/ into out_id
     tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${out_id}-uncompressed/outs

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -79,11 +79,12 @@ process spaceranger_hd {
     meta_json = makeJson(meta)
     image_arg = meta.visium_image_type ? "--${meta.visium_image_type} ${image_file.join(',')}" : "" // join in case of multiple darkimages
     
+    outdir_full ="${out_id}_full"
     // may help avoid OOM errors, but needs to be a rounded integer sans decimal
     spaceranger_mem = Math.ceil(task.memory.toGiga() * 0.9) as int
     """
     spaceranger count \
-      --id=${out_id}-uncompressed \
+      --id=${outdir_full} \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \
@@ -96,28 +97,47 @@ process spaceranger_hd {
       ${cytaimage_file ? "--cytaimage ${cytaimage_file}" : ""} \
       ${image_arg}
 
+    # create publish dir
     mkdir -p ${out_id}/outs 
 
-    # remove the .fusion.symlinks files
-    find ${out_id}-uncompressed/outs -name ".fusion.symlinks" -delete
+    # remove files we dont want to publish
+    for square_src in ${outdir_full}/outs/binned_outputs/square_*; do
+      rm -rf ${square_src}/analysis                     # only in 008, 016
+      rm -f ${square_src}/cloupe.cloupe                 # only in 008
+      rm -f ${square_src}/raw_feature_bc_matrix.h5      # all binned dirs
+      rm -f ${square_src}/filtered_feature_bc_matrix.h5 # all binned dirs
+      rm -f ${square_src}/spatial/.fusion.symlinks      # all binned dirs
+    done
+    seg_dir="${outdir_full}/outs/segmented_outputs"
+    if [ -d "${seg_dir}" ]; then
+      # add output indicator to use for checks
+      touch ${out_id}/segmented_exists.txt
+      # now, remove files we don't need if segmentation was successful
+      if [ -d "${seg_dir}/filtered_feature_bc_matrix" ]; then
+        rm -rf ${seg_dir}/analysis
+        rm -f ${seg_dir}/cloupe.cloupe
+        rm -f ${seg_dir}/raw_feature_bc_matrix.h5
+        rm -f ${seg_dir}/filtered_feature_bc_matrix.h5
+        rm -f ${seg_dir}/spatial/.fusion.symlinks
+      fi
+    fi
   
     # compress outs/ into out_id
-    tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${out_id}-uncompressed/outs
-
-    # add indicator if the segmented internal directories exist
-    if [ -d "${out_id}-uncompressed/outs/segmented_outputs/filtered_feature_bc_matrix" ]; then
-      touch ${out_id}/segmented_exists.txt
-    fi
+    tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${outdir_full}/outs
 
     # get rest of the things into out_id
-    cp ${out_id}-uncompressed/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz ${out_id}/raw-barcodes.tsv.gz
-    cp ${out_id}-uncompressed/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz ${out_id}/filtered-barcodes.tsv.gz
-    cp ${out_id}-uncompressed/outs/metrics_summary.csv ${out_id}/outs/metrics_summary.csv
-    cp ${out_id}-uncompressed/outs/web_summary.html ${out_id}/outs/web_summary.html
-    cp ${out_id}-uncompressed/_versions ${out_id}/_versions
+    cp ${outdir_full}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz ${out_id}/raw-barcodes.tsv.gz
+    cp ${outdir_full}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz ${out_id}/filtered-barcodes.tsv.gz
+    cp ${outdir_full}/outs/metrics_summary.csv ${out_id}/outs/metrics_summary.csv
+    cp ${outdir_full}/outs/web_summary.html ${out_id}/outs/web_summary.html
+    cp ${outdir_full}/_versions ${out_id}/_versions
 
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
+
+    # TESTING 
+    ls -lahR ${outdir_full}/outs > ${out_id}/final_outdir_full_contents.txt
+    ls -lahR ${out_id} > ${out_id}/final_out_id_contents.txt
     """
   stub:
     out_id = file(meta.spaceranger_results_dir).name

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -107,7 +107,7 @@ process spaceranger_hd {
     done
     seg_dir="${out_id}/outs/segmented_outputs"
     if [ -d "\${seg_dir}" ]; then
-      touch ${out_id}/segmented_exists.txt
+      touch ${out_id}/segmented_exists.txt # for checking directory later
       rm -rf \${seg_dir}/analysis
       # we retain cell_segmentations.geojson and nucleus_segmentations.geojson but remove versions augmented with spaceranger clustering
       rm -f \${seg_dir}/graphclust_annotated_cell_segmentations.geojson
@@ -361,16 +361,9 @@ workflow spaceranger_quant{
     // log error about segmented_outputs as needed
     spaceranger_hd.out
       .subscribe{ meta, out_dir ->
-        log.info("Checking segmented_outputs at: ${out_dir}/outs/segmented_outputs")
-        def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
-        def segmented_exists_exists = out_dir.resolve("segmented_exists.txt").exists()
-        log.info("isDirectory result: ${segmented_dir_exists}")
-        log.info("segmented_exists.txt result: ${segmented_exists_exists}")
-        if (meta.visium_image_type == "image" && !segmented_dir_exists) { 
+        def segmented_exists = out_dir.resolve("segmented_exists.txt").exists()
+        if (meta.visium_image_type == "image" && !segmented_exists) { 
           log.error("Expected segmented_outputs directory for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
-        }
-        if (meta.visium_image_type == "image" && !segmented_exists_exists) { 
-          log.error("Expected segmented_exists.txt file for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
         }
       }
 

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -102,23 +102,23 @@ process spaceranger_hd {
 
     # remove files we dont want to publish
     for square_src in ${outdir_full}/outs/binned_outputs/square_*; do
-      rm -rf ${square_src}/analysis                     # only in 008, 016
-      rm -f ${square_src}/cloupe.cloupe                 # only in 008
-      rm -f ${square_src}/raw_feature_bc_matrix.h5      # all binned dirs
-      rm -f ${square_src}/filtered_feature_bc_matrix.h5 # all binned dirs
-      rm -f ${square_src}/spatial/.fusion.symlinks      # all binned dirs
+      rm -rf \${square_src}/analysis                     # only in 008, 016
+      rm -f \${square_src}/cloupe.cloupe                 # only in 008
+      rm -f \${square_src}/raw_feature_bc_matrix.h5      # all binned dirs
+      rm -f \${square_src}/filtered_feature_bc_matrix.h5 # all binned dirs
+      rm -f \${square_src}/spatial/.fusion.symlinks      # all binned dirs
     done
     seg_dir="${outdir_full}/outs/segmented_outputs"
-    if [ -d "${seg_dir}" ]; then
+    if [ -d "\${seg_dir}" ]; then
       # add output indicator to use for checks
       touch ${out_id}/segmented_exists.txt
       # now, remove files we don't need if segmentation was successful
-      if [ -d "${seg_dir}/filtered_feature_bc_matrix" ]; then
-        rm -rf ${seg_dir}/analysis
-        rm -f ${seg_dir}/cloupe.cloupe
-        rm -f ${seg_dir}/raw_feature_bc_matrix.h5
-        rm -f ${seg_dir}/filtered_feature_bc_matrix.h5
-        rm -f ${seg_dir}/spatial/.fusion.symlinks
+      if [ -d "\${seg_dir}/filtered_feature_bc_matrix" ]; then
+        rm -rf \${seg_dir}/analysis
+        rm -f \${seg_dir}/cloupe.cloupe
+        rm -f \${seg_dir}/raw_feature_bc_matrix.h5
+        rm -f \${seg_dir}/filtered_feature_bc_matrix.h5
+        rm -f \${seg_dir}/spatial/.fusion.symlinks
       fi
     fi
   

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -83,7 +83,7 @@ process spaceranger_hd {
     spaceranger_mem = Math.ceil(task.memory.toGiga() * 0.9) as int
     """
     spaceranger count \
-      --id=${out_id} \
+      --id=${out_id}-uncompressed \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
       --sample=${meta.cr_samples} \
@@ -95,10 +95,23 @@ process spaceranger_hd {
       ${probeset_file ? "--probe-set ${probeset_file}" : ""} \
       ${cytaimage_file ? "--cytaimage ${cytaimage_file}" : ""} \
       ${image_arg}
-    
-    # remove Space Ranger intermediates directory 
-    # do this before saving the json
-    rm -rf ${out_id}/SPATIAL_RNA_COUNTER_CS
+
+    mkdir -p ${out_id}/outs 
+  
+    # compress outs/ into out_id
+    tar -czf ${out_id}/${meta.library_id}_spatial.tar.gz ${out_id}-uncompressed/outs
+
+    # add indicator if the segmented directory exists
+    if [ -d "${out_id}-uncompressed/outs/segmented_outputs" ]; then
+      touch ${out_id}/segmented_exists.txt
+    fi
+
+    # get rest of the things into out_id
+    cp ${out_id}-uncompressed/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz ${out_id}/raw-barcodes.tsv.gz
+    cp ${out_id}-uncompressed/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz ${out_id}/filtered-barcodes.tsv.gz
+    cp ${out_id}-uncompressed/outs/metrics_summary.csv ${out_id}/outs/metrics_summary.csv
+    cp ${out_id}-uncompressed/outs/web_summary.html ${out_id}/outs/web_summary.html
+    cp ${out_id}-uncompressed/_versions ${out_id}/_versions
 
     # write metadata
     echo '${meta_json}' > ${out_id}/scpca-meta.json
@@ -110,9 +123,8 @@ process spaceranger_hd {
     """
     mkdir -p ${out_id}/outs
     echo '${meta_json}' > ${out_id}/scpca-meta.json
-
     if [ "${meta.visium_image_type}" == "image" ]; then
-      mkdir -p ${out_id}/outs/segmented_outputs
+      touch ${out_id}/segmented_exists.txt
     fi
     """
 }
@@ -136,59 +148,22 @@ process spaceranger_publish {
     # make a new directory to hold only the outs file we want to publish
     mkdir ${spatial_publish_dir}
 
-    # copy over files present for all technologies
-    cp -r ${spatial_out}/outs/spatial ${spatial_publish_dir}
+    # copy over summary html, present for all technologies
     cp ${spatial_out}/outs/web_summary.html ${spatial_publish_dir}/${meta.library_id}_spaceranger-summary.html
 
     # copy over files that depend on the technology, and define associated inputs to the R script
-    if [[ ${is_hd} != "true" ]]; then
+    if [[ ${is_hd} == "true" ]]; then
+       cp ${spatial_out}/${meta.library_id}_spatial.tar.gz ${spatial_publish_dir}/
+
+      unfiltered_barcodes_file="${spatial_out}/raw-barcodes.tsv.gz"
+      filtered_barcodes_file="${spatial_out}/filtered-barcodes.tsv.gz"
+    else 
       cp -r ${spatial_out}/outs/raw_feature_bc_matrix ${spatial_publish_dir}
       cp -r ${spatial_out}/outs/filtered_feature_bc_matrix ${spatial_publish_dir}
+      cp -r ${spatial_out}/outs/spatial ${spatial_publish_dir}
       
       unfiltered_barcodes_file="${spatial_out}/outs/raw_feature_bc_matrix/barcodes.tsv.gz"
       filtered_barcodes_file="${spatial_out}/outs/filtered_feature_bc_matrix/barcodes.tsv.gz"
-    else  
-      # For HD runs, ensure we are only copying over the count & spatial results, not any nested analysis dirs
-
-      cp ${spatial_out}/outs/barcode_mappings.parquet ${spatial_publish_dir}/${meta.library_id}_barcode_mappings.parquet
-
-      for square_src in ${spatial_out}/outs/binned_outputs/square_*; do
-        square_dest=${spatial_publish_dir}/binned_outputs/\$(basename \$square_src)
-        mkdir -p \${square_dest}
-
-        # spatial files
-        # currently we copy the full shared spatial files (can't do symlinks)
-        cp -r ${spatial_publish_dir}/spatial \${square_dest}/
-        cp \${square_src}/spatial/scalefactors_json.json \${square_dest}/spatial/ # avoid copying .fusion.symlinks
-        cp \${square_src}/spatial/tissue_positions.parquet \${square_dest}/spatial/
-
-        # count files
-        cp -r \${square_src}/raw_feature_bc_matrix \${square_dest}/
-        cp -r \${square_src}/filtered_feature_bc_matrix \${square_dest}/
-      done
-
-      # segmented_outputs are only present if a brightfield image was supplied, so copy conditionally
-      seg_src=${spatial_out}/outs/segmented_outputs      
-      if [[ -d \${seg_src} ]]; then
-        seg_dest=${spatial_publish_dir}/segmented_outputs
-        mkdir -p \${seg_dest}/spatial
-
-        # top-level files
-        cp \${seg_src}/cell_segmentations.geojson \${seg_dest}
-        cp \${seg_src}/nucleus_segmentations.geojson \${seg_dest}
-
-        # spatial files
-        cp -r ${spatial_publish_dir}/spatial \${seg_dest}
-        cp \${seg_src}/spatial/scalefactors_json.json \${seg_dest}/spatial/
-
-        # count files - these use `cell` instead of `bc` in count directory names
-        cp -r \${seg_src}/raw_feature_cell_matrix \${seg_dest}
-        cp -r \${seg_src}/filtered_feature_cell_matrix \${seg_dest}
-      fi
-
-      # use square_008um to match stats calculated in the R script and spaceranger web summary
-      unfiltered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/raw_feature_bc_matrix/barcodes.tsv.gz"
-      filtered_barcodes_file="${spatial_out}/outs/binned_outputs/square_008um/filtered_feature_bc_matrix/barcodes.tsv.gz"
     fi
 
     generate_spaceranger_metadata.R \
@@ -383,11 +358,9 @@ workflow spaceranger_quant{
       }
 
     // log error about segmented_outputs as needed
-    // don't log for stub libraries
     spaceranger_hd.out
       .subscribe{ meta, out_dir ->
-        def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
-        if (meta.visium_image_type == "image" && !segmented_dir_exists) { 
+        if (meta.visium_image_type == "image" && !file("${out_dir}/segmented_exists.txt").exists()) { 
           log.error("Expected segmented_outputs directory for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
         }
       }

--- a/modules/spaceranger.nf
+++ b/modules/spaceranger.nf
@@ -358,7 +358,10 @@ workflow spaceranger_quant{
     // log error about segmented_outputs as needed
     spaceranger_hd.out
       .subscribe{ meta, out_dir ->
+        log.info("Checking segmented_outputs at: ${out_dir}/outs/segmented_outputs")
+        log.info("out_dir real path: ${out_dir.toRealPath()}")
         def segmented_dir_exists = file("${out_dir}/outs/segmented_outputs").isDirectory()
+        log.info("isDirectory result: ${segmented_dir_exists}")
         if (meta.visium_image_type == "image" && !segmented_dir_exists) { 
           log.error("Expected segmented_outputs directory for ${meta.library_id} with brightfield image, but Space Ranger did not create it.")
         }


### PR DESCRIPTION
Closes #1223 
Closes #1225 
Stacked on #1228 

Here, I'm updating the spaceranger workflow to compress the `outs/` directory for HD outputs only. For this, I remove files we don't want to keep in `spaceranger_hd`, and then compress `outs` in the publish process. 

Some notes:
- The downloaded outputs look/work as expected. I was able to successfully read this into R with `VisiumIO`.
- I retained `probe_set.csv`, `metrics_summary.csv`, and the original `web_summary.html` file in the `outs/` directory, but I also still copy out the html like we do for non-hd datasets. This means the html is duplicated, but I'm not worried about this (or other related files choices) right now since we plan to do #1224 if/when we get new spatial data for the portal and we can change this more holistically if we'd like.
- I also changed how we check for segmented, since I was still getting that error logged sometimes with the directory check approach. I changed this to use an indicator file with `resolve()` to deal with nextflow symlink business, and it's working reliably for me.
- You can see the most recent successful run here as interested (run at 6ad3de9bce88ee8e7ac30caeda5cd49593023b60)
  - `s3://ccdl-scpca-nf-workdir/logs/main/testing/2026-03-22/2026-03-22T1218_scpca-nf.log`
  - https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch/323rLX0X2thIsf/tasks


An example output from this is in `s3://ccdl-scpca-nf-results-testing/example-data/visium-test-runs/scpca_out/results/SCPCP300000/SCPCS300000/SCPCL300000_spatial/SCPCL300000_outs.tar.gz` and it has these files:

As delivered:

```
SCPCL300000_spatial
├── SCPCL300000_metadata.json
├── SCPCL300000_outs.tar.gz
└── SCPCL300000_spaceranger-summary.html
```

After uncompressing:

```
SCPCL300000_spatial
├── outs
│   ├── barcode_mappings.parquet
│   ├── binned_outputs
│   │   ├── square_002um
│   │   │   ├── filtered_feature_bc_matrix
│   │   │   │   ├── barcodes.tsv.gz
│   │   │   │   ├── features.tsv.gz
│   │   │   │   └── matrix.mtx.gz
│   │   │   ├── raw_feature_bc_matrix
│   │   │   │   ├── barcodes.tsv.gz
│   │   │   │   ├── features.tsv.gz
│   │   │   │   └── matrix.mtx.gz
│   │   │   └── spatial
│   │   │       ├── aligned_fiducials.jpg -> ../../../spatial/aligned_fiducials.jpg
│   │   │       ├── aligned_tissue_image.jpg -> ../../../spatial/aligned_tissue_image.jpg
│   │   │       ├── cytassist_image.tiff -> ../../../spatial/cytassist_image.tiff
│   │   │       ├── detected_tissue_image.jpg -> ../../../spatial/detected_tissue_image.jpg
│   │   │       ├── scalefactors_json.json
│   │   │       ├── tissue_hires_image.png -> ../../../spatial/tissue_hires_image.png
│   │   │       ├── tissue_lowres_image.png -> ../../../spatial/tissue_lowres_image.png
│   │   │       └── tissue_positions.parquet
│   │   ├── square_008um
│   │   │   ├── filtered_feature_bc_matrix
│   │   │   │   ├── barcodes.tsv.gz
│   │   │   │   ├── features.tsv.gz
│   │   │   │   └── matrix.mtx.gz
│   │   │   ├── raw_feature_bc_matrix
│   │   │   │   ├── barcodes.tsv.gz
│   │   │   │   ├── features.tsv.gz
│   │   │   │   └── matrix.mtx.gz
│   │   │   └── spatial
│   │   │       ├── aligned_fiducials.jpg -> ../../../spatial/aligned_fiducials.jpg
│   │   │       ├── aligned_tissue_image.jpg -> ../../../spatial/aligned_tissue_image.jpg
│   │   │       ├── cytassist_image.tiff -> ../../../spatial/cytassist_image.tiff
│   │   │       ├── detected_tissue_image.jpg -> ../../../spatial/detected_tissue_image.jpg
│   │   │       ├── scalefactors_json.json
│   │   │       ├── tissue_hires_image.png -> ../../../spatial/tissue_hires_image.png
│   │   │       ├── tissue_lowres_image.png -> ../../../spatial/tissue_lowres_image.png
│   │   │       └── tissue_positions.parquet
│   │   └── square_016um
│   │       ├── filtered_feature_bc_matrix
│   │       │   ├── barcodes.tsv.gz
│   │       │   ├── features.tsv.gz
│   │       │   └── matrix.mtx.gz
│   │       ├── raw_feature_bc_matrix
│   │       │   ├── barcodes.tsv.gz
│   │       │   ├── features.tsv.gz
│   │       │   └── matrix.mtx.gz
│   │       └── spatial
│   │           ├── aligned_fiducials.jpg -> ../../../spatial/aligned_fiducials.jpg
│   │           ├── aligned_tissue_image.jpg -> ../../../spatial/aligned_tissue_image.jpg
│   │           ├── cytassist_image.tiff -> ../../../spatial/cytassist_image.tiff
│   │           ├── detected_tissue_image.jpg -> ../../../spatial/detected_tissue_image.jpg
│   │           ├── scalefactors_json.json
│   │           ├── tissue_hires_image.png -> ../../../spatial/tissue_hires_image.png
│   │           ├── tissue_lowres_image.png -> ../../../spatial/tissue_lowres_image.png
│   │           └── tissue_positions.parquet
│   ├── metrics_summary.csv
│   ├── probe_set.csv
│   ├── segmented_outputs
│   │   ├── cell_segmentations.geojson
│   │   ├── filtered_feature_cell_matrix
│   │   │   ├── barcodes.tsv.gz
│   │   │   ├── features.tsv.gz
│   │   │   └── matrix.mtx.gz
│   │   ├── nucleus_segmentations.geojson
│   │   ├── raw_feature_cell_matrix
│   │   │   ├── barcodes.tsv.gz
│   │   │   ├── features.tsv.gz
│   │   │   └── matrix.mtx.gz
│   │   └── spatial
│   │       ├── aligned_fiducials.jpg -> ../../spatial/aligned_fiducials.jpg
│   │       ├── aligned_tissue_image.jpg -> ../../spatial/aligned_tissue_image.jpg
│   │       ├── cytassist_image.tiff -> ../../spatial/cytassist_image.tiff
│   │       ├── detected_tissue_image.jpg -> ../../spatial/detected_tissue_image.jpg
│   │       ├── scalefactors_json.json
│   │       ├── tissue_hires_image.png -> ../../spatial/tissue_hires_image.png
│   │       └── tissue_lowres_image.png -> ../../spatial/tissue_lowres_image.png
│   ├── spatial
│   │   ├── aligned_fiducials.jpg
│   │   ├── aligned_tissue_image.jpg
│   │   ├── cytassist_image.tiff
│   │   ├── detected_tissue_image.jpg
│   │   ├── tissue_hires_image.png
│   │   └── tissue_lowres_image.png
│   └── web_summary.html
├── SCPCL300000_metadata.json
├── SCPCL300000_outs.tar.gz
└── SCPCL300000_spaceranger-summary.html
```