### PR TITLE
Add additional flex probes

### DIFF
--- a/references/flex-probes.json
+++ b/references/flex-probes.json
@@ -1,6 +1,20 @@
 {
+  "Homo_sapiens.GRCh38.98": {
+    "10xflex_v1.0_single": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+    "10xflex_v1.0_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+    "10xflex_v1.0.1_single": "Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv",
+    "10xflex_v1.0.1_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv"
+  },
   "Homo_sapiens.GRCh38.110": {
     "10xflex_v1.1_single": "Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv",
     "10xflex_v1.1_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv"
+  },
+  "Mus_musculus.GRCm38.98": {
+    "10xflex_v1.0.1_single": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv",
+    "10xflex_v1.0.1_multi": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv"
+  },
+  "Mus_musculus.GRCm39.110": {
+    "10xflex_v1.1.1_single": "Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv",
+    "10xflex_v1.1.1_multi": "Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv"
   }
 }

--- a/references/flex-probes.json
+++ b/references/flex-probes.json
@@ -1,7 +1,7 @@
 {
   "Homo_sapiens.GRCh38.98": {
-    "10xflex_v1.0_single": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
-    "10xflex_v1.0_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+    "10xflex_v1_single": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+    "10xflex_v1_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
     "10xflex_v1.0.1_single": "Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv",
     "10xflex_v1.0.1_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv"
   },

--- a/references/flex-probes.json
+++ b/references/flex-probes.json
@@ -10,6 +10,8 @@
     "10xflex_v1.1_multi": "Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.csv"
   },
   "Mus_musculus.GRCm38.98": {
+    "10xflex_v1_single": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
+    "10xflex_v1_multi": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
     "10xflex_v1.0.1_single": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv",
     "10xflex_v1.0.1_multi": "Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv"
   },

--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -70,7 +70,12 @@
     "star_index": "",
     "infercnv_gene_order": "",
     "cytoband": "",
-    "flex_probe_files": {},
+    "flex_probe_files": {
+      "10xflex_v1.0_single": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+      "10xflex_v1.0_multi": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+      "10xflex_v1.0.1_single": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv",
+      "10xflex_v1.0.1_multi": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv"
+    },
     "visium_probe_files": {
       "visium1_v1": "homo_sapiens/ensembl-98/visium-probe-refs/Visium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
       "visium2_v2": "homo_sapiens/ensembl-98/visium-probe-refs/Visium_Human_Transcriptome_Probe_Set_v2.0_GRCh38-2020-A.csv",
@@ -91,7 +96,10 @@
     "star_index": "",
     "infercnv_gene_order": "",
     "cytoband": "",
-    "flex_probe_files": {},
+    "flex_probe_files": {
+      "10xflex_v1.1.1_single": "mus_musculus/ensembl-110/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv",
+      "10xflex_v1.1.1_multi": "mus_musculus/ensembl-110/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv"
+    },
     "visium_probe_files": {
       "visium2_v2.1": "mus_musculus/ensembl-110/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv",
       "visium-hd_v2.1": "mus_musculus/ensembl-110/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv"
@@ -111,7 +119,10 @@
     "star_index": "",
     "infercnv_gene_order": "",
     "cytoband": "",
-    "flex_probe_files": {},
+    "flex_probe_files": {
+      "10xflex_v1.0.1_single": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv",
+      "10xflex_v1.0.1_multi": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv"
+    },
     "visium_probe_files": {
       "visium1_v1": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
       "visium2_v2": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv",

--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -120,6 +120,8 @@
     "infercnv_gene_order": "",
     "cytoband": "",
     "flex_probe_files": {
+      "10xflex_v1_single": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
+      "10xflex_v1_multi": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
       "10xflex_v1.0.1_single": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv",
       "10xflex_v1.0.1_multi": "mus_musculus/ensembl-98/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv"
     },

--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -71,8 +71,8 @@
     "infercnv_gene_order": "",
     "cytoband": "",
     "flex_probe_files": {
-      "10xflex_v1.0_single": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
-      "10xflex_v1.0_multi": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+      "10xflex_v1_single": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
+      "10xflex_v1_multi": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0_GRCh38-2020-A.csv",
       "10xflex_v1.0.1_single": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv",
       "10xflex_v1.0.1_multi": "homo_sapiens/ensembl-98/flex-probe-refs/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv"
     },


### PR DESCRIPTION
Towards #1237 (will be closed once probes have been uploaded to S3 references bucket).

This PR updates the flex probes to include all of the probes that can be used with cellranger9. All the files I added to the references JSON are locally on my computer for upload to S3 after this goes in, but no new references need to be added (aka we don't need to run `build-index.nf`)

To determine which probe sets to get, I used the table at the bottom of this page: https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-frp-probe-sets-overview

Some details about this:
- To get older probe sets, I had to download cellranger7 & 8 and instead of being able to grab directly. Harumph. 
- It looks like there's a discrepancy with v1.1.0 probes between species, but there isn't - 
  - The mouse v1.1.0 had a bug so this was immediately patched to v1.1.1. The mouse v1.1.0 is no longer disseminated anywhere it seems. See the [2nd info box here](https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-frp-mouse-transcriptome-probe-set-1-1)
  - But, human had no such problem, so there is a human v1.1.0 but there is no human v1.1.1
- Note how I named tech versions (where my shorthand of new = newer genome and old = older genome) - 
  - NEW: `v1` (old human only)  <----- trailing 0 stripped off as we do for flex `v1.1` and visium `v1`, `v2`, `v2.1`
  - NEW: `v1.0.1` (old human & mouse)
  - `v1.1` (new human only)  <---- This is the one we have had already, and we don't expect a patch release for this
  - NEW `v1.1.1` (new mouse only) 
 - Finally, forward-thinking FYIs
   - Worth noting that we'll need to bump to cellranger10 if we get flex v2 data
   - But, if/when we move to cellranger10, `v1.0` and `v1.0.1` probes won't be supported but `v1.1` (used for skc) will be supported
   - Seems fine to put all this in now and circle back later if version changes are needed, since probe files are easy to manage!