### PR TITLE
Bump version for release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -14,9 +14,9 @@ assignees: ''
 - [ ] Are all of the issues planned for this release resolved? If there are any issues that are unresolved, mark this issue as blocked by those in the Science Team GitHub Project.
 - [ ] Update code and documentation with the latest version number in the `development` branch:
   - [ ] [`nextflow.config`](https://github.com/AlexsLemonade/scpca-nf/blob/main/nextflow.config)
-  - [ ] [`internal-instructions.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/internal-instructions.md)
   - [ ] [`external-instructions.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-instructions.md)
-  - [ ] [`sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml) and [`sb_doc.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_doc.md)
+  - [ ] [`cavatica/sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml)
+  - [ ] [`cavatica/sb_doc.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_doc.md)
 - [ ] Update the tag for `scpca-nf` containers in `config/containers.config` and `nextflow-schema.json`
   _Note:_ Any processes that use those containers will not work until the new tag has been created.
 - [ ] Check that the `nextflow-schema.json` is up to date with `pixi run nf-core pipelines schema build`

--- a/cavatica/sb_doc.md
+++ b/cavatica/sb_doc.md
@@ -1,4 +1,4 @@
-# scpca-nf v0.9.3
+# scpca-nf v0.10.0
 
 
 The  `scpca-nf` workflow is used to process 10x single-cell data as part of the [Single-cell Pediatric Cancer Atlas (ScPCA) project](https://scpca.alexslemonade.org/).

--- a/cavatica/sb_nextflow_schema.yaml
+++ b/cavatica/sb_nextflow_schema.yaml
@@ -3,7 +3,7 @@ app_content:
   executor_version: 24.10.6
 class: nextflow
 cwlVersion: None
-doc: "# scpca-nf v0.9.3
+doc: "# scpca-nf v0.10.0
 
 
   The `scpca-nf` workflow is used to process 10x single-cell data as part of the

--- a/config/containers.config
+++ b/config/containers.config
@@ -14,8 +14,8 @@ params {
   scpcatools_scimilarity_container = 'ghcr.io/alexslemonade/scpcatools-scimilarity:edge'
   scpcatools_infercnv_container = 'ghcr.io/alexslemonade/scpcatools-infercnv:edge'
 
-  cellbrowser_container = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.3'
-  vireo_container = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.3'
+  cellbrowser_container = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.10.0'
+  vireo_container = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.10.0'
 
   // External containers
   alevinfry_container = 'quay.io/biocontainers/alevin-fry:0.7.0--h9f5acd7_1'

--- a/config/containers.config
+++ b/config/containers.config
@@ -5,14 +5,14 @@ params {
 
   // Docker container images
   // Data Lab-managed containers
-  scpcatools_container = 'ghcr.io/alexslemonade/scpcatools:edge'
-  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:edge'
-  scpcatools_anndata_container = 'ghcr.io/alexslemonade/scpcatools-anndata:edge'
-  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:edge'
-  scpcatools_seurat_container = 'ghcr.io/alexslemonade/scpcatools-seurat:edge'
-  scpcatools_scvi_container = 'ghcr.io/alexslemonade/scpcatools-scvi:edge'
-  scpcatools_scimilarity_container = 'ghcr.io/alexslemonade/scpcatools-scimilarity:edge'
-  scpcatools_infercnv_container = 'ghcr.io/alexslemonade/scpcatools-infercnv:edge'
+  scpcatools_container = 'ghcr.io/alexslemonade/scpcatools:v0.4.5'
+  scpcatools_slim_container = 'ghcr.io/alexslemonade/scpcatools-slim:v0.4.5'
+  scpcatools_anndata_container = 'ghcr.io/alexslemonade/scpcatools-anndata:v0.4.5'
+  scpcatools_reports_container = 'ghcr.io/alexslemonade/scpcatools-reports:v0.4.5'
+  scpcatools_seurat_container = 'ghcr.io/alexslemonade/scpcatools-seurat:v0.4.5'
+  scpcatools_scvi_container = 'ghcr.io/alexslemonade/scpcatools-scvi:v0.4.5'
+  scpcatools_scimilarity_container = 'ghcr.io/alexslemonade/scpcatools-scimilarity:v0.4.5'
+  scpcatools_infercnv_container = 'ghcr.io/alexslemonade/scpcatools-infercnv:v0.4.5'
 
   cellbrowser_container = 'ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.10.0'
   vireo_container = 'ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.10.0'

--- a/external-instructions.md
+++ b/external-instructions.md
@@ -96,12 +96,12 @@ Using the above command will run the workflow from the `main` branch of the work
 To update to the latest released version you can run `nextflow pull AlexsLemonade/scpca-nf` before the `nextflow run` command.
 
 To be sure that you are using a consistent version, you can specify use of a release tagged version of the workflow, set below with the `-r` flag.
-The command below will pull the `scpca-nf` workflow directly from Github using the `v0.9.3` version.
+The command below will pull the `scpca-nf` workflow directly from Github using the `v0.10.0` version.
 Released versions can be found on the [`scpca-nf` repository releases page](https://github.com/AlexsLemonade/scpca-nf/releases).
 
 ```sh
 nextflow run AlexsLemonade/scpca-nf \
-  -r v0.9.3 \
+  -r v0.10.0 \
   -config {path to config file}  \
   -profile {name of profile}
 ```
@@ -332,7 +332,7 @@ If you will be analyzing spatial expression data, you will also need the Cell Ra
 
 If your compute nodes do not have internet access, you will likely have to pre-pull the required container images as well.
 When doing this, it is important to be sure that you also specify the revision (version tag) of the `scpca-nf` workflow that you are using.
-For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.9.3`, then you will want to set `-r v0.9.3` for `get_refs.py` as well to be sure you have the correct containers.
+For example, if you would run `nextflow run AlexsLemonade/scpca-nf -r v0.10.0`, then you will want to set `-r v0.10.0` for `get_refs.py` as well to be sure you have the correct containers.
 By default, `get_refs.py` will download files and images associated with the latest release.
 
 If your system uses Docker, you can add the `--docker` flag:

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   mainScript = 'main.nf'
   defaultBranch = 'main'
   nextflowVersion = '>=24.09'
-  version = 'v0.9.3'
+  version = 'v0.10.0'
   contributors = [
     [
       name: "Allegra Hawkins",


### PR DESCRIPTION
Towards #1236 

This PR updates v0.9.3 -> v0.10.0 in a variety of spots to prep for* release. I also updated the release template since apparently version info is no longer in internal-instructions.

Also, it looks to me like we need an `scpcaTools` release, so I will do that before updating the schema files - just want to confirm you agree! We did some pullthrough stuff. https://github.com/AlexsLemonade/scpcaTools/compare/v0.4.4...main