### PR TITLE
Fix mouse visium probes

### DIFF
--- a/references/scpca-refs.json
+++ b/references/scpca-refs.json
@@ -101,7 +101,6 @@
       "10xflex_v1.1.1_multi": "mus_musculus/ensembl-110/flex-probe-refs/Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv"
     },
     "visium_probe_files": {
-      "visium2_v2.1": "mus_musculus/ensembl-110/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv",
       "visium-hd_v2.1": "mus_musculus/ensembl-110/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv"
     }
   },
@@ -127,7 +126,7 @@
     },
     "visium_probe_files": {
       "visium1_v1": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
-      "visium2_v2": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv",
+      "visium2_v1": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
       "visium-hd_v2": "mus_musculus/ensembl-98/visium-probe-refs/Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv"
     }
   }

--- a/references/visium-probes.json
+++ b/references/visium-probes.json
@@ -10,11 +10,10 @@
   },
   "Mus_musculus.GRCm38.98": {
     "visium1_v1":   "Visium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
-    "visium2_v2":   "Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv",
+    "visium2_v1":   "Visium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv",
     "visium-hd_v2": "Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv"
   },
   "Mus_musculus.GRCm39.110": {
-    "visium2_v2.1":   "Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv",
     "visium-hd_v2.1": "Visium_Mouse_Transcriptome_Probe_Set_v2.1.0_GRCm39-2024-A.csv"
   }
 }


### PR DESCRIPTION
I caught this while preparing the next public project metadata which includes a mouse visium sample. Because 10x likes to keep us on our toes, the breakdown v1/v2 visium probes is different per species.

See this table: https://www.10xgenomics.com/support/spatial-gene-expression-hd/documentation/steps/probe-sets/visium-ffpe-probe-sets-overview

What this tells us is:
- for **human**
  - v1 probes go with ONLY visium v1   ---> `visium1_v1`
  - v2 probes go with visium v2 or hd   --> `visium{2/-hd}_v{2/2.1}`
- but, this is not so for **mouse** where
  - v1 probes go with BOTH visium v1 and visium v2 ---> `visium1_v1`, `visium2_v1`. NOT `visium2_v2`.
  - v2 probes always and only go with visium hd --> `visium-hd_v2` (mouse doesn't have a 2.1)

I updated the visium probe json and scpca-refs.json accordingly. This shouldn't require any changes on S3 though since probes are already placed based on the reference, not technology.

Please check my work carefully! So many versions 😬 