### PR TITLE
Update the schema file and other pre-release miscellany

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -19,7 +19,7 @@ assignees: ''
   - [ ] [`cavatica/sb_doc.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_doc.md)
 - [ ] Update the tag for `scpca-nf` containers in `config/containers.config` and `nextflow_schema.json`
   _Note:_ Any processes that use those containers will not work until the new tag has been created.
-- [ ] Check that the `nextflow-schema.json` is up to date with `pixi run nf-core pipelines schema build`
+- [ ] Check that the `nextflow_schema.json` is up to date with `pixi run nf-core pipelines schema build`
 - [ ] Check that [`sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml) entries are up to date (sadly, no automated tool for this)
 - [ ] Test that the workflow is in good working order by running the workflow in `testing` mode from the `development` branch using [the `run-scpca-nf.yaml` workflow](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/.github/workflows/run-scpca-nf.yaml)
 - [ ] File a PR from the `development` branch to the `main` branch. This should include all of the changes that will be associated with the next release.

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -20,7 +20,7 @@ assignees: ''
 - [ ] Update the tag for `scpca-nf` containers in `config/containers.config` and `nextflow_schema.json`
   _Note:_ Any processes that use those containers will not work until the new tag has been created.
 - [ ] Check that the `nextflow_schema.json` is up to date with `pixi run nf-core pipelines schema build`
-- [ ] Check that [`sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml) entries are up to date (sadly, no automated tool for this)
+- [ ] Check that [`cavatica/sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml) entries are up to date (sadly, no automated tool for this)
 - [ ] Test that the workflow is in good working order by running the workflow in `testing` mode from the `development` branch using [the `run-scpca-nf.yaml` workflow](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/.github/workflows/run-scpca-nf.yaml)
 - [ ] File a PR from the `development` branch to the `main` branch. This should include all of the changes that will be associated with the next release.
 - [ ] (Optional) Generate new example `scpca-nf` output files.

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -17,7 +17,7 @@ assignees: ''
   - [ ] [`external-instructions.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/external-instructions.md)
   - [ ] [`cavatica/sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml)
   - [ ] [`cavatica/sb_doc.md`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_doc.md)
-- [ ] Update the tag for `scpca-nf` containers in `config/containers.config` and `nextflow-schema.json`
+- [ ] Update the tag for `scpca-nf` containers in `config/containers.config` and `nextflow_schema.json`
   _Note:_ Any processes that use those containers will not work until the new tag has been created.
 - [ ] Check that the `nextflow-schema.json` is up to date with `pixi run nf-core pipelines schema build`
 - [ ] Check that [`sb_nextflow_schema.yaml`](https://github.com/AlexsLemonade/scpca-nf/blob/main/cavatica/sb_nextflow_schema.yaml) entries are up to date (sadly, no automated tool for this)

--- a/main.nf
+++ b/main.nf
@@ -147,6 +147,7 @@ workflow {
     'visium-hd-3prime',
     // use probes
     'visium1_v1',
+    'visium2_v1', // mouse v1 goes with visium2; mouse v2 does with hd
     'visium2_v2',
     'visium2_v2.1',
     'visium-hd_v2',

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -684,5 +684,13 @@
     {
       "$ref": "#/$defs/containers"
     }
-  ]
+  ],
+  "properties": {
+    "pullthrough_registry": {
+      "type": "string",
+      "hidden": true, 
+      "description": "Container registry for image pullthrough caching; disabled by default.",
+      "default": ""
+    }
+  }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -544,49 +544,49 @@
       "properties": {
         "scpcatools_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_slim_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-slim:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-slim:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_anndata_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-anndata:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_reports_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-reports:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-reports:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_seurat_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-seurat:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-seurat:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_scvi_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-scvi:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-scvi:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_infercnv_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-infercnv:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-infercnv:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },
         "scpcatools_scimilarity_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpcatools-scimilarity:v0.4.4",
+          "default": "ghcr.io/alexslemonade/scpcatools-scimilarity:v0.4.5",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -640,12 +640,12 @@
         },
         "cellbrowser_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.9.3",
+          "default": "ghcr.io/alexslemonade/scpca-nf/cellbrowser:v0.10.0",
           "fa_icon": "fab fa-docker"
         },
         "vireo_container": {
           "type": "string",
-          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.9.3",
+          "default": "ghcr.io/alexslemonade/scpca-nf/vireo-snp:v0.10.0",
           "hidden": true,
           "fa_icon": "fab fa-docker"
         },


### PR DESCRIPTION
Towards #1236

This PR updates the nextflow schema file for the new release. I also fixed a few more release template spots (mostly change a typo `-` to `_`).

I looked over the cavatica schema yaml as well but I didn't see any spots to change. As part of review it would be helpful if you could have a glance and confirm that you agree no changes were needed there: https://github.com/AlexsLemonade/scpca-nf/blob/development/cavatica/sb_nextflow_schema.yaml

After this, I'll proceed to test the workflow and file a PR from `development` -> `main` for releasing early next week. Based on the [full diff](https://github.com/AlexsLemonade/scpca-nf/compare/main...development?expand=1), I don't think the example output needs to be re-run. But, when looking at this diff, I did catch one spot we need to fix - I didn't account in #1254 for this new tech string in `main.nf`, so that is also done here along with a comment because it really seems like a typo otherwise 🥴 