### PR TITLE
Skip infercnv if no gene order file 

### DIFF
--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -111,9 +111,10 @@ workflow call_cnvs {
         meta.infercnv_heatmap_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-heatmap.png"
         meta.infercnv_results_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-results.rds"
         meta.infercnv_table_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-table.txt"
+        gene_order_file = meta.infercnv_gene_order ? file(meta.infercnv_gene_order, checkIfExists: true) : []
 
         // return simplified input with gene order file
-        [meta, processed_sce, file(meta.infercnv_gene_order, checkIfExists: true)]
+        [meta, processed_sce, gene_order_file]
       }
 
 
@@ -125,14 +126,16 @@ workflow call_cnvs {
         def stored_cell_hash = getMetaVal(file("${it[0].infercnv_checkpoints_dir}/scpca-meta.json"), "infercnv_reference_cell_hash")
 
         skip_infercnv: (
-        (
-          !params.repeat_cnv_inference
-          && file(it[0].infercnv_heatmap_file).exists()
-          && file(it[0].infercnv_results_file).exists()
-          && file(it[0].infercnv_table_file).exists()
-          && it[0].infercnv_reference_cell_hash == stored_cell_hash
-        ) || it[0].infercnv_reference_cell_count < params.infercnv_min_reference_cells
-        )
+          (
+            !params.repeat_cnv_inference
+            && file(it[0].infercnv_heatmap_file).exists()
+            && file(it[0].infercnv_results_file).exists()
+            && file(it[0].infercnv_table_file).exists()
+            && it[0].infercnv_reference_cell_hash == stored_cell_hash
+          )
+          || it[0].infercnv_reference_cell_count < params.infercnv_min_reference_cells
+          || !it[2].exists() // if the gene order file doesn't exist, we can't run infercnv
+       )
         run_infercnv: true
       }
 

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -134,7 +134,7 @@ workflow call_cnvs {
             && it[0].infercnv_reference_cell_hash == stored_cell_hash
           )
           || it[0].infercnv_reference_cell_count < params.infercnv_min_reference_cells
-          || !it[2].exists() // if the gene order file doesn't exist, we can't run infercnv
+          || !(it[2] in Path && it[2].exists()) // if the gene order file doesn't exist, we can't run infercnv
        )
         run_infercnv: true
       }

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -112,8 +112,9 @@ workflow call_cnvs {
         meta.infercnv_results_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-results.rds"
         meta.infercnv_table_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-table.txt"
         gene_order_file = meta.infercnv_gene_order ? file(meta.infercnv_gene_order, checkIfExists: true) : []
-        if not gene_order_file {
-          log.warn("Gene order file for ${meta.unique_id} was not found. inferCNV will be skipped for this library.")
+
+        if  (!gene_order_file){
+          log.warn("Gene order file for '${meta.unique_id}' was not found. inferCNV will be skipped for this library.")
         }
 
         // return simplified input with gene order file

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -112,6 +112,9 @@ workflow call_cnvs {
         meta.infercnv_results_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-results.rds"
         meta.infercnv_table_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-table.txt"
         gene_order_file = meta.infercnv_gene_order ? file(meta.infercnv_gene_order, checkIfExists: true) : []
+        if not gene_order_file {
+          log.warn("Gene order file for ${meta.unique_id} was not found. inferCNV will be skipped for this library.")
+        }
 
         // return simplified input with gene order file
         [meta, processed_sce, gene_order_file]

--- a/modules/call-cnvs.nf
+++ b/modules/call-cnvs.nf
@@ -113,7 +113,7 @@ workflow call_cnvs {
         meta.infercnv_table_file = "${meta.infercnv_checkpoints_dir}/${meta.unique_id}_infercnv-table.txt"
         gene_order_file = meta.infercnv_gene_order ? file(meta.infercnv_gene_order, checkIfExists: true) : []
 
-        if  (!gene_order_file){
+        if (!gene_order_file) {
           log.warn("Gene order file for '${meta.unique_id}' was not found. inferCNV will be skipped for this library.")
         }
 


### PR DESCRIPTION
closes #1273 (but importantly https://github.com/AlexsLemonade/ScPCA-admin/issues/1358)

Here I am adding a couple of little checks to make sure the workflow doesn't fail if the gene order file doesn't exit.

The first is our usual pattern of replacing the file object with `[]` if the file path does not exist or is blank. The second part skips infercnv if the file object doesn't exist. 

This adds to the robustness of the workflow, though it can result in infercnv being "silently" skipped if we don't pay attention. I still think that is better than the workflow failing with an error that doesn't say where it happened!