### PR TITLE
Update Cell Browser naming

### DIFF
--- a/.github/workflows/nextflow-config-check.yaml
+++ b/.github/workflows/nextflow-config-check.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - development
+      - manuscript
 jobs:
   nf-config-check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -31,21 +31,17 @@ jobs:
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check Nextflow with checkpoints from previous run
-        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log
-          false
+        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check Nextflow workflow for building cell type references
-        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile
-          stub -ansi-log false
+        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile stub -ansi-log false
 
       - name: Check Nextflow workflow for merging objects
-        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log
-          false --project STUBP01
+        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log false --project STUBP01
 
       - name: Join log files
         if: ${{ !cancelled() }}
-        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log >
-          nextflow-runs.log
+        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log > nextflow-runs.log
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -21,27 +21,29 @@ jobs:
           distribution: "corretto"
 
       - name: Setup Nextflow
-        #   uses: nf-core/setup-nextflow@v2
-        # manual install as the action is currently broken
-        run: |
-          wget -qO- get.nextflow.io | bash
-          sudo mv nextflow /usr/local/bin/
+        uses: nf-core/setup-nextflow@v3
+        with:
+          version: "25.10.4"
 
       - name: Check Nextflow workflow
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check Nextflow with checkpoints from previous run
-        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log false
+        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log
+          false
 
       - name: Check Nextflow workflow for building cell type references
-        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile stub -ansi-log false
+        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile
+          stub -ansi-log false
 
       - name: Check Nextflow workflow for merging objects
-        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log false --project STUBP01
+        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log
+          false --project STUBP01
 
       - name: Join log files
         if: ${{ !cancelled() }}
-        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log > nextflow-runs.log
+        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log >
+          nextflow-runs.log
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}

--- a/.github/workflows/nextflow-stub-check.yaml
+++ b/.github/workflows/nextflow-stub-check.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - development
+      - manuscript
 
 jobs:
   nf-stub-check:
@@ -30,17 +31,21 @@ jobs:
         run: nextflow -log stub-run.log run main.nf -stub -profile stub -ansi-log false
 
       - name: Check Nextflow with checkpoints from previous run
-        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log false
+        run: nextflow -log checkpoint-run.log run main.nf -stub -profile stub -ansi-log
+          false
 
       - name: Check Nextflow workflow for building cell type references
-        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile stub -ansi-log false
+        run: nextflow -log celltype-ref-run.log run build-celltype-ref.nf -stub -profile
+          stub -ansi-log false
 
       - name: Check Nextflow workflow for merging objects
-        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log false --project STUBP01
+        run: nextflow -log merge-run.log run merge.nf -stub -profile stub -ansi-log
+          false --project STUBP01
 
       - name: Join log files
         if: ${{ !cancelled() }}
-        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log > nextflow-runs.log
+        run: cat stub-run.log checkpoint-run.log celltype-ref-run.log merge-run.log >
+          nextflow-runs.log
 
       - name: Upload nextflow log
         if: ${{ !cancelled() }}

--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -733,5 +733,5 @@ if (length(automated_methods) > 1) {
 readr::write_rds(sce, opt$output_sce_file, compress = "bz2")
 
 # export normal cell count and hash
-readr::write_file(reference_cell_count, opt$reference_cell_count_file)
-readr::write_file(reference_cell_hash, opt$reference_cell_hash_file)
+readr::write_lines(reference_cell_count, opt$reference_cell_count_file)
+readr::write_lines(reference_cell_hash, opt$reference_cell_hash_file)

--- a/bin/cellbrowser_config.py
+++ b/bin/cellbrowser_config.py
@@ -18,7 +18,7 @@ def write_project_configs(
     title = project_metadata.get("project_title", project)
     abstract = project_metadata.get("abstract", "No abstract available.")
     project_cb_file = project_dir / "cellbrowser.conf"
-    project_cb_file.write_text(f"name='{project}'\nshortLabel='{project}'\n")
+    project_cb_file.write_text(f"name='{project}'\nshortLabel='{project}: {title}'\n")
     # desc.conf
     project_desc_file = project_dir / "desc.conf"
     project_desc_contents = f"{title=}\n{abstract=}\nhideDownload=True\n"

--- a/bin/cellbrowser_config.py
+++ b/bin/cellbrowser_config.py
@@ -135,11 +135,11 @@ def main():
         if args.h5ad_file:
             ad = anndata.read_h5ad(args.h5ad_file, backed="r")
             if default_label not in ad.obs.columns:
-                default_label = "cluster"  # fall back to cluster
                 print(
                     f"Warning: Label field {default_label} not found in H5AD metadata.",
                     file=sys.stderr,
                 )
+                default_label = "cluster"  # fall back to cluster
 
             # get all cell type annotations
             label_fields += [

--- a/bin/cellbrowser_rewritemarkers.py
+++ b/bin/cellbrowser_rewritemarkers.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+"""
+Regenerate per-cluster marker files in a built Cell Browser site.
+
+cbBuild's splitMarkerTable filters out annotated genes because it fails to correctly match
+gene symbols to ids, so this script rewrites the marker files using the original annotated marker table and
+the features.tsv.gz file to map gene symbols to ids.
+
+Also optionally removes the expression links, as they are not so relevant to these datasets
+"""
+
+import argparse
+import gzip
+import pathlib
+import re
+import sys
+
+import pandas as pd
+
+
+def make_cluster_filename(name: str) -> str:
+    """
+    Sanitize cluster name for use as a filename.
+    Mirrors cbBuild's sanitizeName: + to Plus, - to Minus, % to Perc, then strip remaining non-word chars
+    """
+
+    # mirrors cbBuild's sanitizeName: + to Plus, - to Minus, % to Perc, then strip remaining non-word chars
+    name = name.replace("+", "Plus").replace("-", "Minus").replace("%", "Perc")
+    return re.sub(r"[^a-zA-Z_0-9]", "", name)
+
+
+def make_symbol_dict(features_path: pathlib.Path) -> dict[str, str]:
+    """Read features.tsv.gz and return a dict mapping gene symbol to ensembl id."""
+    # features.tsv.gz rows:  Ensembl ID, gene symbol
+    symbol_dict = {}
+    with gzip.open(features_path, "rt") as f:
+        for line in f:
+            parts = line.rstrip().split("\t")
+            if len(parts) >= 2:
+                # symbol is the key, id is the value (reverse of features file) for lookup when rewriting markers
+                symbol_dict[parts[1]] = parts[0]
+    return symbol_dict
+
+
+def rewrite_markers(
+    library_id: str,
+    project_id: str,
+    cb_data_dir: pathlib.Path,
+    outdir: pathlib.Path,
+    keep_expression: bool = False,
+) -> bool:
+    annotated_path = cb_data_dir / project_id / library_id / "markers_annotated.tsv"
+    features_path = cb_data_dir / project_id / library_id / "features.tsv.gz"
+    markers_out_dir = outdir / project_id / library_id / "markers" / "markers_0"
+
+    if not annotated_path.is_file():
+        print(
+            f"Skipping {library_id}: no markers_annotated.tsv found at {annotated_path}",
+            file=sys.stderr,
+        )
+        return False
+    if not markers_out_dir.is_dir():
+        print(
+            f"Skipping {library_id}: marker output directory not found at {markers_out_dir}",
+            file=sys.stderr,
+        )
+        return False
+
+    symbol_dict = make_symbol_dict(features_path)
+
+    markers = pd.read_csv(annotated_path, sep="\t")
+    cluster_col = markers.columns[0]
+    other_cols = [
+        c
+        for c in markers.columns
+        if c not in [cluster_col, "gene", "z_score"]
+        # remove expression links (_expr column) unless --keep-expression is set
+        and (keep_expression or not c == "_expr")
+    ]
+
+    # add id column (Ensembl ID), falling back to the symbol itself if not in the dict
+    markers.insert(0, "id", markers["gene"].map(symbol_dict).fillna(markers["gene"]))
+    # rename to match cbBuild's expected column names (id, symbol, z_score|float) and preserve other columns
+    markers = markers.rename(columns={"gene": "symbol", "z_score": "z_score|float"})
+    out_cols = ["id", "symbol", "z_score|float"] + other_cols
+
+    for cluster_name, group in markers.groupby(cluster_col, sort=False):
+        out_path = markers_out_dir / (make_cluster_filename(cluster_name) + ".tsv.gz")
+        group[out_cols].to_csv(out_path, sep="\t", index=False, compression="gzip")
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--library-ids",
+        required=True,
+        metavar="ID1,ID2,...",
+        help="Comma-separated library IDs to process.",
+    )
+    parser.add_argument(
+        "--project-ids",
+        required=True,
+        metavar="ID1,ID2,...",
+        help="Comma-separated project IDs paired with --library-ids (must be same length).",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the built Cell Browser site directory (cbBuild --outDir).",
+    )
+    parser.add_argument(
+        "--cb-data",
+        type=pathlib.Path,
+        default=pathlib.Path("cb_data"),
+        help="Path to the cb_data staging directory (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--keep-expression",
+        action="store_true",
+        help="Keep the annotation expression links in the marker files (default removes them).",
+    )
+    args = parser.parse_args()
+
+    library_ids = args.library_ids.split(",")
+    project_ids = args.project_ids.split(",")
+
+    if len(library_ids) != len(project_ids):
+        parser.error(
+            f"--library-ids ({len(library_ids)}) and --project-ids "
+            f"({len(project_ids)}) must have the same number of values."
+        )
+
+    success = 0
+    for library_id, project_id in zip(library_ids, project_ids):
+        if rewrite_markers(
+            library_id, project_id, args.cb_data, args.outdir, args.keep_expression
+        ):
+            success += 1
+
+    print(f"Rewrote marker files for {success}/{len(library_ids)} libraries.")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -68,6 +68,12 @@ process cellbrowser_site {
     library_dirs=(${library_dirs.join(" ")})
     project_ids=(${project_ids.join(" ")})
     for i in \${!library_dirs[@]}; do
+      # annotate the marker file and if it succeeds, replace the unannotated version with the annotated version.
+      cbAnnotateMarkers "\${library_dirs[\$i]}/markers.tsv" "\${library_dirs[\$i]}/markers_annotated.tsv" \
+        && mv "\${library_dirs[\$i]}/markers_annotated.tsv" "\${library_dirs[\$i]}/markers.tsv" \
+        || true # if annotation fails, keep the original file and continue with the build
+
+      # move files into place for cellbrowser build
       library_id=\$(basename \${library_dirs[\$i]})
       mv \${library_dirs[\$i]} "cb_data/\${project_ids[\$i]}/\${library_id}"
     done

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -84,7 +84,7 @@ process cellbrowser_site {
     library_dirs=(${library_dirs.join(" ")})
     project_ids=(${project_ids.join(" ")})
     for i in \${!library_dirs[@]}; do
-      # copy files into place for cellbrowser build
+      # move files into place for cellbrowser build
       library_id=\$(basename \${library_dirs[\$i]})
       project_dir="cb_data/\${project_ids[\$i]}/"
       mkdir -p "\${project_dir}"
@@ -103,7 +103,7 @@ process cellbrowser_site {
 
     # fix the marker files to be complete (annotated gene symbols were lost in the cbBuild process)
     cellbrowser_rewritemarkers.py \
-      --library-ids "${library_dirs.collect{it.name}.join(",")}" \
+      --library-ids "${library_dirs.collect{d -> d.name}.join(",")}" \
       --project-ids "${project_ids.join(",")}" \
       --outdir ${params.cellbrowser_dirname}
     """
@@ -130,7 +130,7 @@ workflow cellbrowser_build {
     // create single channel of [[project_ids], [library_dirs]]
     project_libs_ch = cellbrowser_library.out
     // only include libraries with umap
-     .filter{ it[2] == "true" }
+     .filter{ it -> it[2] == "true" }
      // use dummy value to group everything together into tuples
      .map{ meta, library_dir, _has_umap ->
         [1, meta.project_id, library_dir]

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -49,6 +49,7 @@ process cellbrowser_library {
 process cellbrowser_site {
   container "${pullthroughContainer(params.cellbrowser_container, params.pullthrough_registry)}"
   publishDir "${params.outdir}"
+  stageInMode 'copy'
   input:
     tuple val(project_ids), path(library_dirs)
     path project_metadata

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -78,7 +78,7 @@ process cellbrowser_site {
       # annotate the marker file and if it succeeds, replace the unannotated version with the annotated version.
       cbMarkerAnnotate "\${project_dir}/\${library_id}/markers.tsv" "\${project_dir}/\${library_id}/markers_annotated.tsv"
       if [ -f "\${project_dir}/\${library_id}/markers_annotated.tsv" ]; then
-        mv "\${project_dir}/\${library_id}/markers_annotated.tsv" "\${project_dir}/\${library_id}/markers.tsv"
+        sed 's/markers.tsv/markers_annotated.tsv/g' -i "\${project_dir}/\${library_id}/cellbrowser.conf"
       fi
     done
 

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -69,14 +69,17 @@ process cellbrowser_site {
     library_dirs=(${library_dirs.join(" ")})
     project_ids=(${project_ids.join(" ")})
     for i in \${!library_dirs[@]}; do
-      # annotate the marker file and if it succeeds, replace the unannotated version with the annotated version.
-      cbAnnotateMarkers "\${library_dirs[\$i]}/markers.tsv" "\${library_dirs[\$i]}/markers_annotated.tsv" \
-        && mv "\${library_dirs[\$i]}/markers_annotated.tsv" "\${library_dirs[\$i]}/markers.tsv" \
-        || true # if annotation fails, keep the original file and continue with the build
-
-      # move files into place for cellbrowser build
+      # copy files into place for cellbrowser build
       library_id=\$(basename \${library_dirs[\$i]})
-      mv \${library_dirs[\$i]} "cb_data/\${project_ids[\$i]}/\${library_id}"
+      project_dir="cb_data/\${project_ids[\$i]}/"
+      mkdir -p "\${project_dir}"
+      mv \${library_dirs[\$i]} "\${project_dir}/\${library_id}"
+
+      # annotate the marker file and if it succeeds, replace the unannotated version with the annotated version.
+      cbMarkerAnnotate "\${project_dir}/\${library_id}/markers.tsv" "\${project_dir}/\${library_id}/markers_annotated.tsv"
+      if [ -f "\${project_dir}/\${library_id}/markers_annotated.tsv" ]; then
+        mv "\${project_dir}/\${library_id}/markers_annotated.tsv" "\${project_dir}/\${library_id}/markers.tsv"
+      fi
     done
 
     # build the site

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -21,12 +21,27 @@ process cellbrowser_library {
       --sample-ids "${meta.sample_id}" \
       --h5ad-file "${h5ad_file}"
 
+    # Rename columns so cbImportScanpy uses the gene_symbols branch in geneStringsFromVar:
+    # with gene_ids absent and gene_symbols present it writes features.tsv.gz as ENSG<tab>symbol.
+    python3 << 'EOF'
+import anndata
+adata = anndata.read_h5ad("${h5ad_file}")
+adata.var = adata.var.rename(columns={"gene_ids": "ensembl_id"})
+if "gene_symbol" in adata.var.columns:
+    adata.var["gene_symbols"] = [
+        symbol if isinstance(symbol, str) else ensembl_id
+        for symbol, ensembl_id in zip(adata.var["gene_symbol"], adata.var["ensembl_id"])
+    ]
+adata.uns = {}  # remove uns to prevent export error
+adata.write_h5ad("cb_input.h5ad")
+EOF
+
     # import data to library directory
     # --proc flag uses the processed expression matrix (lognormalized)
-    cbImportScanpy -i "${h5ad_file}" -o "${meta.library_id}" --clusterField="${params.cellbrowser_default_label}" --proc
+    cbImportScanpy -i "cb_input.h5ad" -o "${meta.library_id}" --clusterField="${params.cellbrowser_default_label}" --proc
 
-    # remove the h5ad from the imported files as we won't use it
-    rm "${meta.library_id}"/*_processed_rna.h5ad
+    # remove the h5ad files from export
+    rm -f "${meta.library_id}"/*.h5ad
 
     # Check that the umap coordinates were output
     if [ -f "${meta.library_id}/umap_coords.tsv" ]; then

--- a/modules/cellbrowser.nf
+++ b/modules/cellbrowser.nf
@@ -100,6 +100,12 @@ process cellbrowser_site {
     # build the site
     CBDATAROOT=cb_data cbBuild -r -i cb_data/cellbrowser.conf \
       --outDir ${params.cellbrowser_dirname}
+
+    # fix the marker files to be complete (annotated gene symbols were lost in the cbBuild process)
+    cellbrowser_rewritemarkers.py \
+      --library-ids "${library_dirs.collect{it.name}.join(",")}" \
+      --project-ids "${project_ids.join(",")}" \
+      --outdir ${params.cellbrowser_dirname}
     """
   stub:
     """


### PR DESCRIPTION
I made a few small changes to the CellBrowser build script to address the following two issues:
- https://github.com/AlexsLemonade/ScPCA-admin/issues/1375
- https://github.com/AlexsLemonade/ScPCA-admin/issues/1377

The changes are 
- add the project title to the short name so the main page is more descriptive when selecting projects
- run `cbMarkerAnnotate` on the marker list (generated from the primary cell type/cluster annotation)

The second of these was the easiest way to convert and get the marker gene list to show gene symbols instead of Ensembl IDs. It comes with a number of extras that we don't necessarily care about, like linking genes to the expression in the Allen Brain Atlas, but I couldn't find a way to easily turn those things off, so I didn't. I don't think they hurt anything at all. 

Originally, I was planning to do the annotation step at the library level for parallelization, but it includes downloading some reference databases, and I preferred to do that only once, rather than for every library separately. It would be possible to pre-fetch these references, and maintain a copy ourselves, but that really felt like more than was necessary at this point. If we want to revisit that decision later, we could, but I wanted to have a working version up as soon as possible. It isn't too slow anyway. 

In testing this I did find some other little changes to the process to make sure the input data isn't modified, mostly by using the `stageInMode 'copy'` flag for the final build process. 

Finally, I made a few little changes so checks will run when we merge to the `manuscript` branch, which I created as the location for any files being modified before publication. I did _not_ update the docker images we are using, despite the expectation that there will be a new release/tag this is partly because of testing, but also because we are not making any changes that should affect the images. 

Note that a test run is running at https://cloud.seqera.io/orgs/CCDL/workspaces/ScPCA/watch/1Om7MHa42y5dAk/tasks, but it is losing the scheduling battle for now with the full run in progress. 