### PR TITLE
Fix export of reference cell count and hash to use write lines

### DIFF
--- a/bin/add_celltypes_to_sce.R
+++ b/bin/add_celltypes_to_sce.R
@@ -733,5 +733,5 @@ if (length(automated_methods) > 1) {
 readr::write_rds(sce, opt$output_sce_file, compress = "bz2")
 
 # export normal cell count and hash
-readr::write_file(reference_cell_count, opt$reference_cell_count_file)
-readr::write_file(reference_cell_hash, opt$reference_cell_hash_file)
+readr::write_lines(reference_cell_count, opt$reference_cell_count_file)
+readr::write_lines(reference_cell_hash, opt$reference_cell_hash_file)


### PR DESCRIPTION
Possibly closes #1277 

Here I switched to using `write_lines` for exporting the reference cell count and hash to hopefully fix the issue with skipping inferCNV. I tested this locally by exporting the file and running `cat` and it now just prints out the correct string without the `%` at the end. 