### PR TITLE
Remove true defaults for celltype & cnv in ccdl config

### DIFF
--- a/config/ccdl_profiles.config
+++ b/config/ccdl_profiles.config
@@ -40,10 +40,6 @@ profiles {
       // paths to output folders, redefined to use `outdir` above
       checkpoints_dir = "${params.outdir}/checkpoints"
       results_dir = "${params.outdir}/results"
-
-      // staging runs always include celltyping and CNV
-      perform_celltyping = true
-      perform_cnv_inference = true
     }
   }
 
@@ -62,10 +58,6 @@ profiles {
       // paths to output folders, redefined to use `outdir` above
       checkpoints_dir = "${params.outdir}/checkpoints"
       results_dir = "${params.outdir}/results"
-
-      // production runs always include celltyping and CNV
-      perform_celltyping = true
-      perform_cnv_inference = true
     }
   }
 
@@ -88,7 +80,6 @@ profiles {
 
       // portal test projects
       project = "SCPCP999990,SCPCP999991,SCPCP999992"
-      perform_celltyping = true
     }
   }
 }


### PR DESCRIPTION
We currently have set celltype annotation and cnv inference set to defaults `true` in the ccdl_profile config (note the latter is still at its nextflow.config false for testing mode).

This ends up conflicting with settings used when submitting jobs via `scpca-admin`. Even if you turn off those flags when issuing the nextflow command, as setting those to false just means the flags aren't provided in the nextflow command - but the config turns these settings right back on. 

Previously, the only projects we did not run cell typing on are cell lines, so this has not been an issue. But now as we are starting to process other projects (e.g. mouse data) where we currently don't want to perform cell typing, we have hit this config conflict.

Other notes:
- I can see leaving this set to true by default for testing mode, but I also like the idea of letting the GHA control it since this parameter doesn't take a value but is a flag
- Seems to me the prod profile isn't actually used anymore since the handoff instructions for prod are now to actually copy over, not run the workflow again https://github.com/AlexsLemonade/ScPCA-admin/tree/main/data-processing-and-handoff#moving-results-to-production. 
  - Can we remove this wholesale or am I missing something? 