### PR TITLE
Make plotting genes more flexible in report

### DIFF
--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -663,7 +663,7 @@ gene_exp_df <- scuttle::makePerCellDF(
   use.dimred = FALSE
 ) |>
   tidyr::pivot_longer(
-    dplyr::all_of(expressed_markers), 
+    dplyr::all_of(expressed_markers),
     names_to = "ensembl_gene_id",
     values_to = "logcounts"
   ) |>

--- a/templates/qc_report/celltypes_qc.rmd
+++ b/templates/qc_report/celltypes_qc.rmd
@@ -662,7 +662,11 @@ gene_exp_df <- scuttle::makePerCellDF(
   use.coldata = "barcodes",
   use.dimred = FALSE
 ) |>
-  tidyr::pivot_longer(starts_with("ENSG"), names_to = "ensembl_gene_id", values_to = "logcounts") |>
+  tidyr::pivot_longer(
+    dplyr::all_of(expressed_markers), 
+    names_to = "ensembl_gene_id",
+    values_to = "logcounts"
+  ) |>
   dplyr::mutate(
     detected = logcounts > 0,
     unique_id = params$unique_id

--- a/templates/qc_report/umap_qc.rmd
+++ b/templates/qc_report/umap_qc.rmd
@@ -119,7 +119,7 @@ if (!is.null(processed_meta$highly_variable_genes)) {
     left_join(umap_df, by = "barcode") |>
     # combine all genes into a single column for easy faceting
     tidyr::pivot_longer(
-      cols = starts_with("ENSG"),
+      cols = dplyr::all_of(top_genes),
       names_to = "ensembl_id",
       values_to = "gene_expression"
     ) |>


### PR DESCRIPTION
Another bug discovered when processing mouse data - we hardcoded `ENSG` to refer to hvgs in the report for UMAP plotting, but we no longer have this prefix with mouse ids. So I just updated this to be generally flexible and use all the genes, regardless of the prefix.

I made an analogous change in the celltype report for future-proofing just in case.

I tested changes locally with both the mouse library that failed and SCPCL000001 (aka a library with cell types), and it renders as expected.