### PR TITLE
Additional updates to format checks and more

### DIFF
--- a/bin/filter_sce.R
+++ b/bin/filter_sce.R
@@ -123,8 +123,13 @@ try({
     posterior_cutoff = opt$prob_compromised_cutoff,
     enforce_left_cutoff = opt$enforce_left_cutoff
   )
-  metadata(filtered_sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
-  metadata(filtered_sce)$has_miQC <- TRUE
+  # if it failed to fit a mixture model,
+  # all the prob_compromised values will be NA.
+  # so, only set to TRUE if values are not all NA
+  if (!all(is.na(filtered_sce$prob_compromised))) {
+    metadata(filtered_sce)$prob_compromised_cutoff <- opt$prob_compromised_cutoff
+    metadata(filtered_sce)$has_miQC <- TRUE
+  }
 })
 # set prob_compromised to NA if miQC failed
 if (!metadata(filtered_sce)$has_miQC) {
@@ -134,6 +139,8 @@ if (!metadata(filtered_sce)$has_miQC) {
   metadata(filtered_sce)$prob_compromised_cutoff <- NA_real_
   metadata(filtered_sce)$has_miQC <- FALSE
 }
+
+
 # grab names of altExp, if any
 alt_names <- altExpNames(filtered_sce)
 for (alt in alt_names) {

--- a/bin/filter_sce.R
+++ b/bin/filter_sce.R
@@ -139,8 +139,6 @@ if (!metadata(filtered_sce)$has_miQC) {
   metadata(filtered_sce)$prob_compromised_cutoff <- NA_real_
   metadata(filtered_sce)$has_miQC <- FALSE
 }
-
-
 # grab names of altExp, if any
 alt_names <- altExpNames(filtered_sce)
 for (alt in alt_names) {

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -354,5 +354,5 @@ if (length(errors) == 0) {
   fs::file_create(opt$output_file)
 } else {
   header <- glue::glue("Formatting errors found for {metadata(sce)$library_id} {opt$object_type}:")
-  writeLines(c(header, "", errors), opt$output_file)
+  writeLines(c(header, "", errors, ""), opt$output_file)
 }

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -42,10 +42,10 @@ process compile_errors {
     # check if all files are empty, if so print a success message
     # otherwise concatenate all error files into one output file
     errors="\$(cat ${error_files})"
-    if [ -z \${errors} ]; then
+    if [ -z "\${errors}" ]; then
       echo "No formatting errors found." > format_check_results.txt
     else
-      echo \${errors} > format_check_results.txt
+      echo "\${errors}" > format_check_results.txt
     fi
     """
   stub: 

--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -115,7 +115,9 @@ if (is.null(filtered_sce$subsets_mito_percent)) {
 
 # try to add miQC if it is missing
 if (is.null(metadata(filtered_sce)$miQC_model) && !skip_miQC) {
-  filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+  suppressWarnings({
+    filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+  })
 }
 
 ## Check for additional modalities


### PR DESCRIPTION
After running SCPCP000031 through scpca-nf, I had a look at the `format_errors_check.txt` file (attached here: [format_check_results.txt](https://github.com/user-attachments/files/28075666/format_check_results.txt)), and saw some surprising items:

1. No new lines - pretty sure this is because we need to quote the variable in the bash script portion so I added that here. I also added a new line to the end of `writeLines()` so we get line breaks when concatenating.
2. Formatting errors related to miQC for the library whose qc report I am also attaching: [SCPCL001319_qc.html](https://github.com/user-attachments/files/28075645/SCPCL001319_qc.html). It seemed to me that this was a miQC failure, so I wondered why that formatting check was happening. I _think_ it's actually coming from `filter_sce.R` itself where we are incorrectly setting `has_miQC` as TRUE when a mixture model can't be fit. `miQC` itself gives a warning, not an error, when a mixture model can't be fit so I'm not sure `try()` is enough to catch what we consider errors: https://github.com/greenelab/miQC/blob/a31358e533dc0eccab31f08acaae70eba531b0fd/R/mixtureModel.R#L65 . I was very hesitant to remove the `try` though, so I added an if to only set miQC to TRUE if the prob_compromised is not all `NA`. I put in a suppressWarnings for good measure into the report as well, something I've always wanted to do ;) 

Does this all seem reasonable to you?



