### PR TITLE
Script for checking formatting of AnnData objects

### DIFF
--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -18,38 +18,23 @@ import numpy
 import pandas
 
 
-# Maps reference type strings to Python types for uns value checking.
-# The reference uses these strings but actual uns values are numpy scalars/arrays,
-# so isinstance is needed rather than comparing type names directly.
-_UNS_TYPE_MAP = {
+_BUILTIN_TYPES = {
     "str": str,
-    "int": (int, numpy.integer),
-    "float": (float, numpy.floating),
-    "bool": (bool, numpy.bool_),
-    "numpy.ndarray": numpy.ndarray,
-    "pandas.DataFrame": pandas.DataFrame,
+    "int": int,
+    "float": float,
+    "bool": bool,
     "NoneType": type(None),
     "dict": dict,
 }
 
 
-def _uns_type_matches(val, expected):
-    """Check a uns value against one or more expected type strings."""
-    allowed = expected if isinstance(expected, list) else [expected]
-    for t in allowed:
-        if t is None:
-            continue
-        # float64 in nested uns (e.g. pca variance/variance_ratio) is a numpy float64 array
-        if t == "float64" and isinstance(val, numpy.ndarray):
-            if val.dtype == numpy.float64:
-                return True
-            continue
-        types = _UNS_TYPE_MAP.get(t)
-        if types is None:
-            return True  # unknown type string, skip
-        if isinstance(val, types):
-            return True
-    return False
+def _resolve_type(type_str):
+    """Resolve a reference type string to a Python type for isinstance checking."""
+    if type_str.startswith("numpy."):
+        return getattr(numpy, type_str[6:], None)
+    if type_str.startswith("pandas."):
+        return getattr(pandas, type_str[7:], None)
+    return _BUILTIN_TYPES.get(type_str)
 
 
 def check_names_and_types(data, ref, label, slot):
@@ -71,7 +56,13 @@ def check_names_and_types(data, ref, label, slot):
 
         elif expected_type is not None:
             if slot_is_uns:
-                if not _uns_type_matches(data[col], expected_type):
+                allowed = (
+                    expected_type
+                    if isinstance(expected_type, list)
+                    else [t.strip() for t in str(expected_type).split(",")]
+                )
+                py_types = [_resolve_type(t) for t in allowed if t]
+                if not any(isinstance(data[col], t) for t in py_types if t is not None):
                     obs_type = type(data[col]).__name__
                     errors.append(
                         f"Type mismatch in '{col}' from {label} {slot}. "

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -14,9 +14,20 @@ import sys
 from pathlib import Path
 
 import anndata
-import numpy
-import pandas
+import numpy as np
+import pandas as pd
 
+
+# Maps simplified type names to pandas dtype-checking functions.
+# These work for both numpy arrays and pandas Series regardless of backend.
+_DTYPE_CHECKERS = {
+    "int": pd.api.types.is_integer_dtype,
+    "float": pd.api.types.is_float_dtype,
+    "string": pd.api.types.is_string_dtype,
+    "bool": pd.api.types.is_bool_dtype,
+    # account for deprecated pd.CategoricalDtype in older pandas versions
+    "category": lambda obj: isinstance(getattr(obj, "dtype", obj), pd.CategoricalDtype),
+}
 
 _BUILTIN_TYPES = {
     "str": str,
@@ -25,57 +36,77 @@ _BUILTIN_TYPES = {
     "bool": bool,
     "NoneType": type(None),
     "dict": dict,
+    "numpy.ndarray": np.ndarray,
 }
 
 
-def _resolve_type(type_str):
-    """Resolve a reference type string to a Python type for isinstance checking."""
-    if type_str.startswith("numpy."):
-        return getattr(numpy, type_str[6:], None)
-    if type_str.startswith("pandas."):
-        return getattr(pandas, type_str[7:], None)
-    return _BUILTIN_TYPES.get(type_str)
+def _check_type(obj, expected_type):
+    """
+    Check whether obj matches expected_type.
+
+    For pandas Series and numpy arrays, uses pd.api.types functions so that
+    type checking is robust across pandas backends and numpy dtype variations.
+    For plain Python objects, falls back to isinstance with built-in types.
+
+    Returns True if the type matches, False otherwise.
+    """
+
+    # first check for numpy arrays, since these can be present in uns
+    # and require a different check than plain Python objects or pandas Series
+    if expected_type == "numpy.ndarray":
+        return isinstance(obj, np.ndarray)
+
+    # if the object is a Series or array, use the dtype checker
+    # this runs pd.api.types to check the dtype
+    if isinstance(obj, (pd.Series, np.ndarray)):
+        checker = _DTYPE_CHECKERS.get(expected_type)
+        if checker is None:
+            return False
+        return checker(obj)
+    else:
+        # otherwise check against built in python types
+        # account for expected_type being a single type or a comma-separated list of types in the reference
+        allowed = (
+            expected_type
+            if isinstance(expected_type, list)
+            else [t.strip() for t in str(expected_type).split(",")]
+        )
+        py_types = [_BUILTIN_TYPES.get(t) for t in allowed]
+        return any(isinstance(obj, t) for t in py_types if t is not None)
 
 
 def check_names_and_types(data, ref, label, slot):
     """
-    Check obs or var columns or uns dict for presence and correct type.
-    If slot == "uns", data is a dict and types are checked with isinstance.
-    If slot == "obs" or "var", data is a DataFrame and types are checked via dtype.name.
+    Check obs/var columns or uns dict for presence and correct type.
+
+    For obs/var slots, data is a DataFrame; column values are pd.Series.
+    For uns slot, data is a dict; values may be plain Python objects,
+    numpy arrays, or pandas Series — _check_type handles all cases.
     """
     errors = []
-    slot_is_uns = slot == "uns"
+    keys = data.keys() if slot == "uns" else data.columns
 
-    for col, expected_type in ref.items():
-        if col not in (data.keys() if slot_is_uns else data.columns):
-            errors.append(f"Missing '{col}' from {label} {slot}.")
+    for key, expected_type in ref.items():
+        if key not in keys:
+            errors.append(f"Missing '{key}' from {label} {slot}.")
 
         elif isinstance(expected_type, dict):
             # nested dict: recurse (used for uns keys like "pca")
-            errors.extend(check_names_and_types(data[col], expected_type, label, slot))
+            errors.extend(check_names_and_types(data[key], expected_type, label, slot))
 
         elif expected_type is not None:
-            if slot_is_uns:
-                allowed = (
-                    expected_type
-                    if isinstance(expected_type, list)
-                    else [t.strip() for t in str(expected_type).split(",")]
+            obj = data[key]
+            if not _check_type(obj, expected_type):
+                # get the observed type based on if the object is a Series/array or a plain Python object
+                obs_type = (
+                    obj.dtype.name
+                    if isinstance(obj, (pd.Series, np.ndarray))
+                    else type(obj).__name__
                 )
-                py_types = [_resolve_type(t) for t in allowed if t]
-                if not any(isinstance(data[col], t) for t in py_types if t is not None):
-                    obs_type = type(data[col]).__name__
-                    errors.append(
-                        f"Type mismatch in '{col}' from {label} {slot}. "
-                        f"Expected {expected_type}, but found {obs_type}."
-                    )
-            else:
-                # need to use dtype.name for obs/var columns since they are numpy dtypes
-                obs_type = data[col].dtype.name
-                if obs_type != expected_type:
-                    errors.append(
-                        f"Type mismatch in '{col}' from {label} {slot}. "
-                        f"Expected {expected_type}, but found {obs_type}."
-                    )
+                errors.append(
+                    f"Type mismatch in '{key}' from {label} {slot}. "
+                    f"Expected {expected_type}, but found {obs_type}."
+                )
 
     return errors
 
@@ -92,7 +123,7 @@ def safe_uns_array(uns, key):
     val = uns.get(key)
     if val is None:
         return []
-    if isinstance(val, numpy.ndarray):
+    if isinstance(val, np.ndarray):
         return val.tolist()
     if isinstance(val, list):
         return val
@@ -117,7 +148,7 @@ def get_conditionals(adata):
         or "adt_scpca_filter" in obs_cols
     )
     # is multiplexed if sample_id in uns is a list/array (indicating multiple samples), rather than a single string for non-multiplexed data
-    is_multiplexed = isinstance(uns.get("sample_id"), (list, numpy.ndarray))
+    is_multiplexed = isinstance(uns.get("sample_id"), (list, np.ndarray))
 
     # check for submitter annotations based on column and all not being NA
     has_submitter = "submitter" in celltype_methods and (
@@ -125,6 +156,7 @@ def get_conditionals(adata):
         and not adata.obs["submitter_celltype_annotation"].isna().all()
     )
 
+    # set neg post control based on target types if adt
     has_neg_ctrl = False
     no_neg_ctrl = False
     if "target_type" in adata.var.columns:
@@ -176,15 +208,13 @@ def check_anndata(adata, ref, label):
 
     # get conditionals dict based on adata contents and uns values, to determine which conditional checks to run
     conditions = get_conditionals(adata)
-    # only keep true conditions and return as a list of conditionals
-    true_conditions = [cond for cond, is_true in conditions.items() if is_true]
 
     if "obs" in ref:
         errors.extend(check_names_and_types(adata.obs, ref["obs"], label, "obs"))
 
     if "obs_conditional" in ref:
         for condition, cols_dict in ref["obs_conditional"].items():
-            if isinstance(cols_dict, dict) and condition in true_conditions:
+            if isinstance(cols_dict, dict) and condition in conditions:
                 errors.extend(check_names_and_types(adata.obs, cols_dict, label, "obs"))
             elif isinstance(cols_dict, str):
                 # condition key is also the column name; always check when present in ref
@@ -202,7 +232,7 @@ def check_anndata(adata, ref, label):
 
     if "uns_conditional" in ref:
         for condition, keys_dict in ref["uns_conditional"].items():
-            if isinstance(keys_dict, dict) and condition in true_conditions:
+            if isinstance(keys_dict, dict) and condition in conditions:
                 errors.extend(check_names_and_types(adata.uns, keys_dict, label, "uns"))
 
     return errors

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# anndata_formatting_checks.py
+# Usage: python anndata_formatting_checks.py --anndata_file <file.h5ad>
+#            --object_type <unfiltered|filtered|processed>
+#            --reference_file <ref.json>
+#            [--output_file <output.txt>]
+#
+# Checks formatting of an AnnData object against a reference JSON.
+# Modality (rna or adt) is inferred from the filename.
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import anndata
+import numpy
+import pandas
+
+
+# Maps reference type strings to Python types for uns value checking.
+# The reference uses these strings but actual uns values are numpy scalars/arrays,
+# so isinstance is needed rather than comparing type names directly.
+_UNS_TYPE_MAP = {
+    "str": str,
+    "int": (int, numpy.integer),
+    "float": (float, numpy.floating),
+    "bool": (bool, numpy.bool_),
+    "numpy.ndarray": numpy.ndarray,
+    "pandas.DataFrame": pandas.DataFrame,
+    "NoneType": type(None),
+    "dict": dict,
+}
+
+
+def _uns_type_matches(val, expected):
+    """Check a uns value against one or more expected type strings."""
+    allowed = expected if isinstance(expected, list) else [expected]
+    for t in allowed:
+        if t is None:
+            continue
+        # float64 in nested uns (e.g. pca variance/variance_ratio) is a numpy float64 array
+        if t == "float64" and isinstance(val, numpy.ndarray):
+            if val.dtype == numpy.float64:
+                return True
+            continue
+        types = _UNS_TYPE_MAP.get(t)
+        if types is None:
+            return True  # unknown type string, skip
+        if isinstance(val, types):
+            return True
+    return False
+
+
+def check_names_and_types(data, ref, label, slot):
+    """
+    Check obs or var columns or uns dict for presence and correct type.
+    If slot == "uns", data is a dict and types are checked with isinstance.
+    If slot == "obs" or "var", data is a DataFrame and types are checked via dtype.name.
+    """
+    errors = []
+    slot_is_uns = slot == "uns"
+
+    for col, expected_type in ref.items():
+        if col not in (data.keys() if slot_is_uns else data.columns):
+            errors.append(f"Missing '{col}' from {label} {slot}.")
+
+        elif isinstance(expected_type, dict):
+            # nested dict: recurse (used for uns keys like "pca")
+            errors.extend(check_names_and_types(data[col], expected_type, label, slot))
+
+        elif expected_type is not None:
+            if slot_is_uns:
+                if not _uns_type_matches(data[col], expected_type):
+                    obs_type = type(data[col]).__name__
+                    errors.append(
+                        f"Type mismatch in '{col}' from {label} {slot}. "
+                        f"Expected {expected_type}, but found {obs_type}."
+                    )
+            else:
+                # need to use dtype.name for obs/var columns since they are numpy dtypes
+                obs_type = data[col].dtype.name
+                if obs_type != expected_type:
+                    errors.append(
+                        f"Type mismatch in '{col}' from {label} {slot}. "
+                        f"Expected {expected_type}, but found {obs_type}."
+                    )
+
+    return errors
+
+
+# for any uns key that is not always present, we want to safely check it's value
+# used to set conditionals
+def safe_uns_str(uns, key):
+    val = uns.get(key)
+    return val if isinstance(val, str) else None
+
+
+# for any uns key (cell type methods) that may be a list or array, we want to safely check and convert to list for conditional checks
+def safe_uns_array(uns, key):
+    val = uns.get(key)
+    if val is None:
+        return []
+    if isinstance(val, numpy.ndarray):
+        return val.tolist()
+    if isinstance(val, list):
+        return val
+    return []
+
+
+def get_conditionals(adata):
+    """
+    Build the conditionals dict for an RNA AnnData object.
+    Returns a dict where keys are condition names and values are booleans indicating whether the condition is met
+
+    """
+    obs_cols = set(adata.obs.columns)
+    uns = adata.uns
+    # get a list of cell type methods that may be present
+    # if not present, then returns [] and all the "has_" conditionals will be False
+    celltype_methods = safe_uns_array(uns, "celltype_methods")
+
+    # has adt should be true if any adt-related obs columns are present, or if "altexps_adt_" prefix is used for adt data in uns
+    has_adt = (
+        any(c.startswith("altexps_adt_") for c in obs_cols)
+        or "adt_scpca_filter" in obs_cols
+    )
+    # is multiplexed if sample_id in uns is a list/array (indicating multiple samples), rather than a single string for non-multiplexed data
+    is_multiplexed = isinstance(uns.get("sample_id"), (list, numpy.ndarray))
+
+    # check for submitter annotations based on column and all not being NA
+    has_submitter = "submitter" in celltype_methods and (
+        "submitter_celltype_annotation" in obs_cols
+        and not adata.obs["submitter_celltype_annotation"].isna().all()
+    )
+
+    has_neg_ctrl = False
+    no_neg_ctrl = False
+    if "target_type" in adata.var.columns:
+        target_types = adata.var["target_type"]
+        has_neg_ctrl = (target_types == "neg_control").any()
+        no_neg_ctrl = target_types.isin(["pos_control", "target"]).all()
+
+    return {
+        # mapping tools
+        "alevin-fry": uns.get("mapping_tool") == "alevin-fry",
+        "cellranger-multi": uns.get("mapping_tool") == "cellranger multi",
+        # preprocessing steps
+        "umi_filtering": uns.get("filtering_method") == "UMI cutoff",
+        "has_normalization": "sizeFactor" in obs_cols,
+        # clustering and cell type annotation
+        "has_clusters": "cluster" in obs_cols,
+        "has_consensus": "consensus_celltype_annotation" in obs_cols,
+        "has_singler": "singler" in celltype_methods,
+        "has_cellassign": "cellassign" in celltype_methods,
+        "has_scimilarity": "scimilarity" in celltype_methods,
+        "has_openscpca": "openscpca" in celltype_methods,
+        "has_submitter": has_submitter,
+        "has_infercnv": safe_uns_str(uns, "infercnv_status") == "success",
+        # additional modalities
+        "has_adt": has_adt,
+        "has_cellhash": False,
+        "has_hashedDrops": any("hashedDrops" in c for c in obs_cols),
+        "has_HTODemux": any("HTODemux" in c for c in obs_cols),
+        "has_vireo": any("vireo" in c for c in obs_cols),
+        "is_multiplexed": is_multiplexed,
+        "has_negative_control": bool(has_neg_ctrl),
+        "no_negative_control": bool(no_neg_ctrl),
+    }
+
+
+def check_anndata(adata, ref, label):
+    """Run all formatting checks for an AnnData object."""
+    errors = []
+
+    # check for contents, raw.X, layers, and obsm keys that are required regardless of conditionals
+    if ref.get("has_raw.X") and adata.raw is None:
+        errors.append(f"Missing raw.X from {label}.")
+
+    for layer in ref.get("layers", []):
+        if layer not in adata.layers:
+            errors.append(f"Missing layer '{layer}' from {label}.")
+
+    # get conditionals dict based on adata contents and uns values, to determine which conditional checks to run
+    conditions = get_conditionals(adata)
+    # only keep true conditions and return as a list of conditionals
+    true_conditions = [cond for cond, is_true in conditions.items() if is_true]
+
+    if "obs" in ref:
+        errors.extend(check_names_and_types(adata.obs, ref["obs"], label, "obs"))
+
+    if "obs_conditional" in ref:
+        for condition, cols_dict in ref["obs_conditional"].items():
+            if isinstance(cols_dict, dict) and condition in true_conditions:
+                errors.extend(check_names_and_types(adata.obs, cols_dict, label, "obs"))
+            elif isinstance(cols_dict, str):
+                # condition key is also the column name; always check when present in ref
+                errors.extend(
+                    check_names_and_types(
+                        adata.obs, {condition: cols_dict}, label, "obs"
+                    )
+                )
+
+    if "var" in ref:
+        errors.extend(check_names_and_types(adata.var, ref["var"], label, "var"))
+
+    if "uns" in ref:
+        errors.extend(check_names_and_types(adata.uns, ref["uns"], label, "uns"))
+
+    if "uns_conditional" in ref:
+        for condition, keys_dict in ref["uns_conditional"].items():
+            if isinstance(keys_dict, dict) and condition in true_conditions:
+                errors.extend(check_names_and_types(adata.uns, keys_dict, label, "uns"))
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check AnnData formatting against a reference JSON."
+    )
+    parser.add_argument(
+        "--anndata_file", required=True, type=Path, help="Path to .h5ad file"
+    )
+    parser.add_argument(
+        "--object_type",
+        required=True,
+        choices=["unfiltered", "filtered", "processed"],
+        help="Type of object: unfiltered, filtered, or processed",
+    )
+    parser.add_argument(
+        "--reference_file", required=True, type=Path, help="Path to reference JSON"
+    )
+    parser.add_argument(
+        "--output_file",
+        default="formatting_errors.txt",
+        type=Path,
+        help=".txt file to save any identified errors",
+    )
+    args = parser.parse_args()
+
+    if not args.anndata_file.exists():
+        sys.exit(f"AnnData file does not exist: {args.anndata_file}")
+    if args.output_file.suffix != ".txt":
+        sys.exit("output_file must end in .txt")
+
+    if not args.reference_file.exists():
+        sys.exit(f"Reference file does not exist: {args.reference_file}")
+
+    # infer modality from filename
+    filename = args.anndata_file.stem
+    if "_rna" in filename:
+        modality = "rna"
+    elif "_adt" in filename:
+        modality = "adt"
+    else:
+        sys.exit(
+            f"Cannot infer modality (rna or adt) from filename: {args.anndata_file.name}"
+        )
+
+    # read in anndata and reference JSON
+    adata = anndata.read_h5ad(args.anndata_file)
+
+    with open(args.reference_file) as f:
+        all_ref = json.load(f)
+
+    ref = all_ref[args.object_type][modality]
+    label = f"{modality.upper()} AnnData"
+
+    # check contents of the anndata object against a reference
+    errors = check_anndata(adata, ref, label)
+
+    # export errors to output file, or create empty file if no errors
+    output_path = Path(args.output_file)
+    if not errors:
+        output_path.touch()
+    else:
+        library_id = adata.uns.get("library_id", "unknown")
+        header = (
+            f"Formatting errors found for {library_id} {args.object_type} {modality}:"
+        )
+        with open(output_path, "w") as error_file:
+            error_file.write(f"{header}\n\n")
+            for error in errors:
+                error_file.write(f"{error}\n")
+            error_file.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -132,7 +132,7 @@ def get_conditionals(adata):
         has_neg_ctrl = (target_types == "neg_control").any()
         no_neg_ctrl = target_types.isin(["pos_control", "target"]).all()
 
-    condition_tests =  {
+    condition_tests = {
         # mapping tools
         "alevin-fry": uns.get("mapping_tool") == "alevin-fry",
         "cellranger-multi": uns.get("mapping_tool") == "cellranger multi",
@@ -158,7 +158,7 @@ def get_conditionals(adata):
         "has_negative_control": bool(has_neg_ctrl),
         "no_negative_control": bool(no_neg_ctrl),
     }
-    
+
     return set(cond for cond, is_true in condition_tests.items() if is_true)
 
 

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -92,7 +92,9 @@ def check_names_and_types(data, ref, label, slot):
 
         elif isinstance(expected_type, dict):
             # nested dict: recurse (used for uns keys like "pca")
-            errors.extend(check_names_and_types(data[key], expected_type, label, f"{slot}:{key}"))
+            errors.extend(
+                check_names_and_types(data[key], expected_type, label, f"{slot}:{key}")
+            )
 
         elif expected_type is not None:
             obj = data[key]

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -132,7 +132,7 @@ def get_conditionals(adata):
         has_neg_ctrl = (target_types == "neg_control").any()
         no_neg_ctrl = target_types.isin(["pos_control", "target"]).all()
 
-    return {
+    condition_tests =  {
         # mapping tools
         "alevin-fry": uns.get("mapping_tool") == "alevin-fry",
         "cellranger-multi": uns.get("mapping_tool") == "cellranger multi",
@@ -158,6 +158,8 @@ def get_conditionals(adata):
         "has_negative_control": bool(has_neg_ctrl),
         "no_negative_control": bool(no_neg_ctrl),
     }
+    
+    return set(cond for cond, is_true in condition_tests.items() if is_true)
 
 
 def check_anndata(adata, ref, label):

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -92,7 +92,7 @@ def check_names_and_types(data, ref, label, slot):
 
         elif isinstance(expected_type, dict):
             # nested dict: recurse (used for uns keys like "pca")
-            errors.extend(check_names_and_types(data[key], expected_type, label, slot))
+            errors.extend(check_names_and_types(data[key], expected_type, label, f"{slot}:{key}"))
 
         elif expected_type is not None:
             obj = data[key]

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -312,7 +312,7 @@
                     "sizeFactor": "float64"
                 },
                 "has_clusters": {
-                    "cluster": "factor"
+                    "cluster": "category"
                 },
                 "has_singler": {
                     "singler_celltype_annotation": "category",

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -54,7 +54,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "int",
+                "total_reads": "numpy.integer",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -68,19 +68,19 @@
             "uns_conditional": {
                 "alevin-fry": {
                     "salmon_version": "str",
-                    "mapped_reads": "int",
+                    "mapped_reads": "numpy.integer",
                     "alevinfry_version": "str",
                     "af_permit_type": "str",
                     "af_resolution": "str",
-                    "usa_mode": "bool",
-                    "af_num_cells": "int",
-                    "include_unspliced": "bool"
+                    "usa_mode": "numpy.bool_",
+                    "af_num_cells": "numpy.integer",
+                    "include_unspliced": "numpy.bool_"
                 },
                 "cellranger-multi": {
                     "cellranger_version": "str",
                     "reference_probeset": "str",
-                    "pct_mapped_reads": "float",
-                    "cellranger_num_cells": "int"
+                    "pct_mapped_reads": "numpy.floating",
+                    "cellranger_num_cells": "numpy.integer"
                 }
             }
         },
@@ -167,7 +167,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "int",
+                "total_reads": "numpy.integer",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -181,26 +181,26 @@
                     "float"
                 ],
                 "scpca_filter_method": "str",
-                "min_gene_cutoff": "int",
+                "min_gene_cutoff": "numpy.integer",
                 "X_name": "str",
                 "schema_version": "str"
             },
             "uns_conditional": {
                 "alevin-fry": {
                     "salmon_version": "str",
-                    "mapped_reads": "int",
+                    "mapped_reads": "numpy.integer",
                     "alevinfry_version": "str",
                     "af_permit_type": "str",
                     "af_resolution": "str",
-                    "usa_mode": "bool",
-                    "af_num_cells": "int",
-                    "include_unspliced": "bool"
+                    "usa_mode": "numpy.bool_",
+                    "af_num_cells": "numpy.integer",
+                    "include_unspliced": "numpy.bool_"
                 },
                 "cellranger-multi": {
                     "cellranger_version": "str",
                     "reference_probeset": "str",
-                    "pct_mapped_reads": "float",
-                    "cellranger_num_cells": "int"
+                    "pct_mapped_reads": "numpy.floating",
+                    "cellranger_num_cells": "numpy.integer"
                 },
                 "umi_filtering": {
                     "umi_cutoff": "float"
@@ -233,13 +233,13 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "int",
+                "total_reads": "numpy.integer",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "ambient_profile": "float"
+                "ambient_profile": "numpy.floating"
             }
         }
     },
@@ -349,7 +349,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "int",
+                "total_reads": "numpy.integer",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -358,22 +358,25 @@
                 "sample_metadata": "pandas.DataFrame",
                 "sample_type": "str",
                 "filtering_method": "str",
-                "prob_compromised_cutoff": "NoneType,float",
+                "prob_compromised_cutoff": [
+                    "NoneType",
+                    "float"
+                ],
                 "scpca_filter_method": "str",
-                "min_gene_cutoff": "int",
+                "min_gene_cutoff": "numpy.integer",
                 "normalization": "str",
                 "highly_variable_genes": "numpy.ndarray",
                 "X_name": "str",
                 "schema_version": "str",
                 "pca": {
                     "param": "dict",
-                    "variance": "float64",
-                    "variance_ratio": "float64"
+                    "variance": "numpy.ndarray",
+                    "variance_ratio": "numpy.ndarray"
                 }
             },
             "uns_conditional": {
                 "umi_filtering": {
-                    "umi_cutoff": "float"
+                    "umi_cutoff": "numpy.floating"
                 },
                 "has_clusters": {
                     "cluster_algorithm": "str",
@@ -416,7 +419,7 @@
                 },
                 "has_infercnv": {
                     "infercnv_reference_celltypes": "numpy.ndarray",
-                    "infercnv_num_reference_cells": "int",
+                    "infercnv_num_reference_cells": "numpy.integer",
                     "infercnv_diagnosis_groups": "str",
                     "infercnv_status": "str",
                     "infercnv_options": "numpy.ndarray",
@@ -455,13 +458,13 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "int",
+                "total_reads": "numpy.integer",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "ambient_profile": "float"
+                "ambient_profile": "numpy.floating"
             }
         }
     }

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -54,7 +54,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "numpy.integer",
+                "total_reads": "int",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -68,19 +68,19 @@
             "uns_conditional": {
                 "alevin-fry": {
                     "salmon_version": "str",
-                    "mapped_reads": "numpy.integer",
+                    "mapped_reads": "int",
                     "alevinfry_version": "str",
                     "af_permit_type": "str",
                     "af_resolution": "str",
-                    "usa_mode": "numpy.bool_",
-                    "af_num_cells": "numpy.integer",
-                    "include_unspliced": "numpy.bool_"
+                    "usa_mode": "bool",
+                    "af_num_cells": "int",
+                    "include_unspliced": "bool"
                 },
                 "cellranger-multi": {
                     "cellranger_version": "str",
                     "reference_probeset": "str",
-                    "pct_mapped_reads": "numpy.floating",
-                    "cellranger_num_cells": "numpy.integer"
+                    "pct_mapped_reads": "float",
+                    "cellranger_num_cells": "int"
                 }
             }
         },
@@ -167,7 +167,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "numpy.integer",
+                "total_reads": "int",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -181,26 +181,26 @@
                     "float"
                 ],
                 "scpca_filter_method": "str",
-                "min_gene_cutoff": "numpy.integer",
+                "min_gene_cutoff": "int",
                 "X_name": "str",
                 "schema_version": "str"
             },
             "uns_conditional": {
                 "alevin-fry": {
                     "salmon_version": "str",
-                    "mapped_reads": "numpy.integer",
+                    "mapped_reads": "int",
                     "alevinfry_version": "str",
                     "af_permit_type": "str",
                     "af_resolution": "str",
-                    "usa_mode": "numpy.bool_",
-                    "af_num_cells": "numpy.integer",
-                    "include_unspliced": "numpy.bool_"
+                    "usa_mode": "bool",
+                    "af_num_cells": "int",
+                    "include_unspliced": "bool"
                 },
                 "cellranger-multi": {
                     "cellranger_version": "str",
                     "reference_probeset": "str",
-                    "pct_mapped_reads": "numpy.floating",
-                    "cellranger_num_cells": "numpy.integer"
+                    "pct_mapped_reads": "float",
+                    "cellranger_num_cells": "int"
                 },
                 "umi_filtering": {
                     "umi_cutoff": "float"
@@ -233,13 +233,13 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "numpy.integer",
+                "total_reads": "int",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "ambient_profile": "numpy.floating"
+                "ambient_profile": "float"
             }
         }
     },
@@ -349,7 +349,7 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "numpy.integer",
+                "total_reads": "int",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
@@ -358,25 +358,22 @@
                 "sample_metadata": "pandas.DataFrame",
                 "sample_type": "str",
                 "filtering_method": "str",
-                "prob_compromised_cutoff": [
-                    "NoneType",
-                    "float"
-                ],
+                "prob_compromised_cutoff": "NoneType,float",
                 "scpca_filter_method": "str",
-                "min_gene_cutoff": "numpy.integer",
+                "min_gene_cutoff": "int",
                 "normalization": "str",
                 "highly_variable_genes": "numpy.ndarray",
                 "X_name": "str",
                 "schema_version": "str",
                 "pca": {
                     "param": "dict",
-                    "variance": "numpy.ndarray",
-                    "variance_ratio": "numpy.ndarray"
+                    "variance": "float64",
+                    "variance_ratio": "float64"
                 }
             },
             "uns_conditional": {
                 "umi_filtering": {
-                    "umi_cutoff": "numpy.floating"
+                    "umi_cutoff": "float"
                 },
                 "has_clusters": {
                     "cluster_algorithm": "str",
@@ -419,7 +416,7 @@
                 },
                 "has_infercnv": {
                     "infercnv_reference_celltypes": "numpy.ndarray",
-                    "infercnv_num_reference_cells": "numpy.integer",
+                    "infercnv_num_reference_cells": "int",
                     "infercnv_diagnosis_groups": "str",
                     "infercnv_status": "str",
                     "infercnv_options": "numpy.ndarray",
@@ -458,13 +455,13 @@
                 "sample_id": "str",
                 "project_id": "str",
                 "reference_index": "str",
-                "total_reads": "numpy.integer",
+                "total_reads": "int",
                 "mapping_tool": "str",
                 "tech_version": "str",
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "ambient_profile": "numpy.floating"
+                "ambient_profile": "float"
             }
         }
     }

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -6,13 +6,13 @@
                 "spliced"
             ],
             "obs": {
-                "barcodes": "object",
-                "sum": "float64",
-                "detected": "int32",
-                "subsets_mito_sum": "float64",
-                "subsets_mito_detected": "int32",
-                "subsets_mito_percent": "float64",
-                "total": "float64",
+                "barcodes": "string",
+                "sum": "float",
+                "detected": "int",
+                "subsets_mito_sum": "float",
+                "subsets_mito_detected": "int",
+                "subsets_mito_percent": "float",
+                "total": "float",
                 "library_id": "category",
                 "sample_id": "category",
                 "assay_ontology_term_id": "category",
@@ -20,30 +20,30 @@
                 "is_primary_data": "bool"
             },
             "var": {
-                "gene_ids": "object",
-                "gene_symbol": "category",
-                "mean": "float64",
-                "detected": "int32",
+                "gene_ids": "string",
+                "gene_symbol": "string",
+                "mean": "float",
+                "detected": "int",
                 "feature_is_filtered": "bool",
                 "highly_variable": "bool"
             },
             "obs_conditional": {
                 "has_submitter": {
-                    "submitter_celltype_annotation": "category"
+                    "submitter_celltype_annotation": "string"
                 },
                 "has_openscpca": {
-                    "openscpca_celltype_annotation": "category",
-                    "openscpca_celltype_ontology": "category"
+                    "openscpca_celltype_annotation": "string",
+                    "openscpca_celltype_ontology": "string"
                 },
                 "has_adt": {
-                    "altexps_adt_sum": "float64",
-                    "altexps_adt_detected": "int32",
-                    "altexps_adt_percent": "float64"
+                    "altexps_adt_sum": "float",
+                    "altexps_adt_detected": "int",
+                    "altexps_adt_percent": "float"
                 },
                 "has_cellhash": {
-                    "altexps_cellhash_sum": "float64",
-                    "altexps_cellhash_detected": "int32",
-                    "altexps_cellhash_percent": "float64"
+                    "altexps_cellhash_sum": "float",
+                    "altexps_cellhash_detected": "int",
+                    "altexps_cellhash_percent": "float"
                 },
                 "is_multiplexed": {
                     "sample_id": null
@@ -86,10 +86,10 @@
         },
         "adt": {
             "var": {
-                "adt_id": "object",
-                "mean": "float64",
-                "detected": "int32",
-                "target_type": "category"
+                "adt_id": "string",
+                "mean": "float",
+                "detected": "int",
+                "target_type": "string"
             }
         }
     },
@@ -100,18 +100,18 @@
                 "spliced"
             ],
             "obs": {
-                "barcodes": "object",
-                "sum": "float64",
-                "detected": "int32",
-                "subsets_mito_sum": "float64",
-                "subsets_mito_detected": "int32",
-                "subsets_mito_percent": "float64",
-                "total": "float64",
-                "prob_compromised": "float64",
+                "barcodes": "string",
+                "sum": "float",
+                "detected": "int",
+                "subsets_mito_sum": "float",
+                "subsets_mito_detected": "int",
+                "subsets_mito_percent": "float",
+                "total": "float",
+                "prob_compromised": "float",
                 "miQC_pass": "bool",
-                "scpca_filter": "category",
-                "scDblFinder_class": "category",
-                "scDblFinder_score": "float64",
+                "scpca_filter": "string",
+                "scDblFinder_class": "string",
+                "scDblFinder_score": "float",
                 "library_id": "category",
                 "sample_id": "category",
                 "assay_ontology_term_id": "category",
@@ -119,44 +119,44 @@
                 "is_primary_data": "bool"
             },
             "var": {
-                "gene_ids": "object",
-                "gene_symbol": "category",
-                "mean": "float64",
-                "detected": "int32",
+                "gene_ids": "string",
+                "gene_symbol": "string",
+                "mean": "float",
+                "detected": "int",
                 "feature_is_filtered": "bool",
                 "highly_variable": "bool"
             },
             "obs_conditional": {
                 "has_submitter": {
-                    "submitter_celltype_annotation": "category"
+                    "submitter_celltype_annotation": "string"
                 },
                 "has_openscpca": {
-                    "openscpca_celltype_annotation": "category",
-                    "openscpca_celltype_ontology": "category"
+                    "openscpca_celltype_annotation": "string",
+                    "openscpca_celltype_ontology": "string"
                 },
                 "has_adt": {
-                    "adt_scpca_filter": "category"
+                    "adt_scpca_filter": "string"
                 },
                 "has_cellhash": {
-                    "altexps_cellhash_sum": "float64",
-                    "altexps_cellhash_detected": "int32",
-                    "altexps_cellhash_percent": "float64"
+                    "altexps_cellhash_sum": "float",
+                    "altexps_cellhash_detected": "int",
+                    "altexps_cellhash_percent": "float"
                 },
                 "has_hashedDrops": {
-                    "hashedDrops_sampleid": "category"
+                    "hashedDrops_sampleid": "string"
                 },
                 "has_HTODemux": {
-                    "HTODemux_sampleid": "category"
+                    "HTODemux_sampleid": "string"
                 },
                 "has_vireo": {
-                    "vireo_sampleid": "category",
-                    "vireo_donor_id": "category",
-                    "vireo_prob_max": "float64",
-                    "vireo_prob_doublet": "float64",
-                    "vireo_n_vars": "float64",
-                    "vireo_best_singlet": "category",
-                    "vireo_best_doublet": "category",
-                    "vireo_doublet_logLikRatio": "float64"
+                    "vireo_sampleid": "string",
+                    "vireo_donor_id": "string",
+                    "vireo_prob_max": "float",
+                    "vireo_prob_doublet": "float",
+                    "vireo_n_vars": "float",
+                    "vireo_best_singlet": "string",
+                    "vireo_best_doublet": "string",
+                    "vireo_doublet_logLikRatio": "float"
                 },
                 "is_multiplexed": {
                     "sample_id": null
@@ -213,18 +213,18 @@
                 "discard": "bool"
             },
             "var": {
-                "adt_id": "object",
-                "mean": "float64",
-                "detected": "int32",
-                "target_type": "category"
+                "adt_id": "string",
+                "mean": "float",
+                "detected": "int",
+                "target_type": "string"
             },
             "obs_conditional": {
                 "has_negative_control": {
-                    "sum.controls": "int32",
+                    "sum.controls": "int",
                     "high.control": "bool"
                 },
                 "no_negative_control": {
-                    "ambient.scale": "float64",
+                    "ambient.scale": "float",
                     "high.ambient": "bool"
                 }
             },
@@ -250,18 +250,18 @@
                 "spliced"
             ],
             "obs": {
-                "barcodes": "object",
-                "sum": "float64",
-                "detected": "int32",
-                "subsets_mito_sum": "float64",
-                "subsets_mito_detected": "int32",
-                "subsets_mito_percent": "float64",
-                "total": "float64",
-                "prob_compromised": "float64",
+                "barcodes": "string",
+                "sum": "float",
+                "detected": "int",
+                "subsets_mito_sum": "float",
+                "subsets_mito_detected": "int",
+                "subsets_mito_percent": "float",
+                "total": "float",
+                "prob_compromised": "float",
                 "miQC_pass": "bool",
-                "scpca_filter": "category",
-                "scDblFinder_class": "category",
-                "scDblFinder_score": "float64",
+                "scpca_filter": "string",
+                "scDblFinder_class": "string",
+                "scDblFinder_score": "float",
                 "library_id": "category",
                 "sample_id": "category",
                 "assay_ontology_term_id": "category",
@@ -269,72 +269,72 @@
                 "is_primary_data": "bool"
             },
             "var": {
-                "gene_ids": "object",
-                "gene_symbol": "category",
-                "mean": "float64",
-                "detected": "int32",
+                "gene_ids": "string",
+                "gene_symbol": "string",
+                "mean": "float",
+                "detected": "int",
                 "feature_is_filtered": "bool",
                 "highly_variable": "bool"
             },
             "obs_conditional": {
                 "has_submitter": {
-                    "submitter_celltype_annotation": "category"
+                    "submitter_celltype_annotation": "string"
                 },
                 "has_openscpca": {
-                    "openscpca_celltype_annotation": "category",
-                    "openscpca_celltype_ontology": "category"
+                    "openscpca_celltype_annotation": "string",
+                    "openscpca_celltype_ontology": "string"
                 },
                 "has_adt": {
-                    "adt_scpca_filter": "category"
+                    "adt_scpca_filter": "string"
                 },
                 "has_cellhash": {
-                    "altexps_cellhash_sum": "float64",
-                    "altexps_cellhash_detected": "int32",
-                    "altexps_cellhash_percent": "float64"
+                    "altexps_cellhash_sum": "float",
+                    "altexps_cellhash_detected": "int",
+                    "altexps_cellhash_percent": "float"
                 },
                 "has_hashedDrops": {
-                    "hashedDrops_sampleid": "category"
+                    "hashedDrops_sampleid": "string"
                 },
                 "has_HTODemux": {
-                    "HTODemux_sampleid": "category"
+                    "HTODemux_sampleid": "string"
                 },
                 "has_vireo": {
-                    "vireo_sampleid": "category",
-                    "vireo_donor_id": "category",
-                    "vireo_prob_max": "float64",
-                    "vireo_prob_doublet": "float64",
-                    "vireo_n_vars": "float64",
-                    "vireo_best_singlet": "category",
-                    "vireo_best_doublet": "category",
-                    "vireo_doublet_logLikRatio": "float64"
+                    "vireo_sampleid": "string",
+                    "vireo_donor_id": "string",
+                    "vireo_prob_max": "float",
+                    "vireo_prob_doublet": "float",
+                    "vireo_n_vars": "float",
+                    "vireo_best_singlet": "string",
+                    "vireo_best_doublet": "string",
+                    "vireo_doublet_logLikRatio": "float"
                 },
                 "has_normalization": {
-                    "sizeFactor": "float64"
+                    "sizeFactor": "float"
                 },
                 "has_clusters": {
                     "cluster": "category"
                 },
                 "has_singler": {
-                    "singler_celltype_annotation": "category",
-                    "singler_celltype_ontology": "category"
+                    "singler_celltype_annotation": "string",
+                    "singler_celltype_ontology": "string"
                 },
                 "has_cellassign": {
-                    "cellassign_celltype_annotation": "category",
-                    "cellassign_celltype_ontology": "category",
-                    "cellassign_max_prediction": "float64"
+                    "cellassign_celltype_annotation": "string",
+                    "cellassign_celltype_ontology": "string",
+                    "cellassign_max_prediction": "float"
                 },
                 "has_scimilarity": {
-                    "scimilarity_celltype_annotation": "category",
-                    "scimilarity_celltype_ontology": "category",
-                    "scimilarity_min_distance": "float64"
+                    "scimilarity_celltype_annotation": "string",
+                    "scimilarity_celltype_ontology": "string",
+                    "scimilarity_min_distance": "float"
                 },
                 "has_consensus": {
-                    "consensus_celltype_annotation": "category",
-                    "consensus_celltype_ontology": "category"
+                    "consensus_celltype_annotation": "string",
+                    "consensus_celltype_ontology": "string"
                 },
                 "has_infercnv": {
                     "is_infercnv_reference": "bool",
-                    "infercnv_total_cnv": "int32"
+                    "infercnv_total_cnv": "int"
                 },
                 "is_multiplexed": {
                     "sample_id": null
@@ -367,8 +367,8 @@
                 "schema_version": "str",
                 "pca": {
                     "param": "dict",
-                    "variance": "float64",
-                    "variance_ratio": "float64"
+                    "variance": "float",
+                    "variance_ratio": "float"
                 }
             },
             "uns_conditional": {
@@ -434,21 +434,21 @@
                 "discard": "bool"
             },
             "var": {
-                "adt_id": "object",
-                "mean": "float64",
-                "detected": "int32",
-                "target_type": "category"
+                "adt_id": "string",
+                "mean": "float",
+                "detected": "int",
+                "target_type": "string"
             },
             "obs_conditional": {
                 "has_negative_control": {
-                    "sum.controls": "int32",
+                    "sum.controls": "int",
                     "high.control": "bool"
                 },
                 "no_negative_control": {
-                    "ambient.scale": "float64",
+                    "ambient.scale": "float",
                     "high.ambient": "bool"
                 },
-                "sizeFactor": "float64"
+                "sizeFactor": "float"
             },
             "uns": {
                 "library_id": "str",

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -449,9 +449,9 @@ def convert_cell_row_metadata_types(metadata):
 # types for uns metadata entries that are not cell or row metadata
 EXPERIMENT_METADATA_MAP = {
     "character": "str",
-    "integer": "numpy.integer",
-    "numeric": "numpy.floating",
-    "logical": "numpy.bool_",
+    "integer": "int",
+    "numeric": "float",
+    "logical": "bool",
     "data.frame": "pandas.DataFrame",
     "DFrame": "pandas.DataFrame",
 }
@@ -588,11 +588,11 @@ processed_uns_metadata = {
     **convert_experiment_metadata_types(copy.deepcopy(processed_experiment_metadata)),
     **anndata_uns_metadata,
     # this is NA or numeric so account for both possibilities in the reference
-    "prob_compromised_cutoff": ["NoneType", "float"],
+    "prob_compromised_cutoff": "NoneType,float",
     "pca": {
         "param": "dict",
-        "variance": "numpy.ndarray",
-        "variance_ratio": "numpy.ndarray",
+        "variance": "float64",
+        "variance_ratio": "float64",
     },
 }
 

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -449,9 +449,9 @@ def convert_cell_row_metadata_types(metadata):
 # types for uns metadata entries that are not cell or row metadata
 EXPERIMENT_METADATA_MAP = {
     "character": "str",
-    "integer": "int",
-    "numeric": "float",
-    "logical": "bool",
+    "integer": "numpy.integer",
+    "numeric": "numpy.floating",
+    "logical": "numpy.bool_",
     "data.frame": "pandas.DataFrame",
     "DFrame": "pandas.DataFrame",
 }
@@ -588,11 +588,11 @@ processed_uns_metadata = {
     **convert_experiment_metadata_types(copy.deepcopy(processed_experiment_metadata)),
     **anndata_uns_metadata,
     # this is NA or numeric so account for both possibilities in the reference
-    "prob_compromised_cutoff": "NoneType,float",
+    "prob_compromised_cutoff": ["NoneType", "float"],
     "pca": {
         "param": "dict",
-        "variance": "float64",
-        "variance_ratio": "float64",
+        "variance": "numpy.ndarray",
+        "variance_ratio": "numpy.ndarray",
     },
 }
 

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -418,6 +418,7 @@ CELL_ROW_METADATA_MAP = {
     "integer": "int32",
     "logical": "bool",
     "character": "category",
+    "factor": "category",
 }
 
 # outlier types for cell and row metadata

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -414,19 +414,16 @@ with open(sce_ref_file, "w") as f:
 
 # cell and row metadata are dtypes
 CELL_ROW_METADATA_MAP = {
-    "numeric": "float64",
-    "integer": "int32",
+    "numeric": "float",
+    "integer": "int",
     "logical": "bool",
-    "character": "category",
+    "character": "string",
     "factor": "category",
 }
 
 # outlier types for cell and row metadata
 CELL_ROW_METADATA_EXCEPTIONS = {
-    "detected": "int32",
-    "barcodes": "object",
-    "gene_ids": "object",
-    "adt_id": "object",
+    "detected": "int",
 }
 
 
@@ -591,8 +588,8 @@ processed_uns_metadata = {
     "prob_compromised_cutoff": "NoneType,float",
     "pca": {
         "param": "dict",
-        "variance": "float64",
-        "variance_ratio": "float64",
+        "variance": "float",
+        "variance_ratio": "float",
     },
 }
 


### PR DESCRIPTION
Closes #1166

This PR adds in a script that will be used to check the formatting of an individual AnnData object. Just like with the SCE object checking, this script takes in a single object and the object type. The main difference here is that we will need to check both the RNA and ADT files. Right now, I'm grabbing that information from the filename, but let me know if you think it would be better to parse that in Nextflow and add that as an argument? 

I tried my best to use `isinstance()` instead of `type()` for the matching, but did hit a few issues along the way. 

- For the `obs` and `var` slots, which are Pandas data frames, `isinstance(data["col"], int)` and `isinstance(data["col"], int32)` both give failures. Because of that we need to use the `series.dtype.name` and then check that against the expected type. 
- For the `uns` slots, the names we have in our reference didn't exactly match what's expected since they are all numpy types. I updated the reference to reflect this so that we could use `isinstance` here. 

There was one other error where we still had factor in the reference as type, so I fixed that to be set to `category`. 