### PR TITLE
Add process for AnnData formatting checks

### DIFF
--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -31,9 +31,9 @@ _DTYPE_CHECKERS = {
 
 _BUILTIN_TYPES = {
     "str": str,
-    "int": int,
-    "float": float,
-    "bool": bool,
+    "int": (int, np.integer),  # covers int64, int32, etc.
+    "float": (float, np.floating),  # covers float64, float32, etc.
+    "bool": (bool, np.bool_),  # covers numpy.bool_
     "NoneType": type(None),
     "dict": dict,
     "numpy.ndarray": np.ndarray,
@@ -64,7 +64,7 @@ def _check_type(obj, expected_type):
             return False
         return checker(obj)
     else:
-        # otherwise check against built in python types
+        # otherwise check against built in python or numpy types
         # account for expected_type being a single type or a comma-separated list of types in the reference
         allowed = (
             expected_type

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -84,7 +84,7 @@ def check_names_and_types(data, ref, label, slot):
     numpy arrays, or pandas Series — _check_type handles all cases.
     """
     errors = []
-    keys = data.keys() if slot == "uns" else data.columns
+    keys = data.keys() if hasattr(data, "keys") else data.columns
 
     for key, expected_type in ref.items():
         if key not in keys:
@@ -301,9 +301,7 @@ def main():
         output_path.touch()
     else:
         library_id = adata.uns.get("library_id", "unknown")
-        header = (
-            f"Formatting errors found for {library_id} {args.object_type} {modality}:"
-        )
+        header = f"Formatting errors found for {library_id} {args.object_type} {modality} AnnData object:"
         with open(output_path, "w") as error_file:
             error_file.write(f"{header}\n\n")
             for error in errors:

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -353,6 +353,6 @@ if (opt$object_type == "processed") {
 if (length(errors) == 0) {
   fs::file_create(opt$output_file)
 } else {
-  header <- glue::glue("Formatting errors found for {metadata(sce)$library_id} {opt$object_type}:")
+  header <- glue::glue("Formatting errors found for {metadata(sce)$library_id} {opt$object_type} SingleCellExperiment:")
   writeLines(c(header, "", errors, ""), opt$output_file)
 }

--- a/main.nf
+++ b/main.nf
@@ -461,14 +461,19 @@ workflow {
     file(params.validation_palette_file)
   )
 
-  // check formatting for published sce files and generate error reports
-  format_checks(qc_publish_sce.out.data, file(params.sce_format_reference_file))
-
   // convert SCE object to anndata
   anndata_ch = qc_publish_sce.out.data
     // skip multiplexed libraries
     .filter{ !(it[0].library_id in multiplex_libs.getVal()) }
   sce_to_anndata(anndata_ch)
+
+  // check formatting for published sce and anndata files and generate error reports
+  format_checks(
+    qc_publish_sce.out.data, 
+    sce_to_anndata.out.complete,
+    file(params.sce_format_reference_file),
+    file(params.anndata_format_reference_file)
+  )
 
 
 }

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -42,7 +42,7 @@ process check_anndata {
   script:
     def object_type = anndata_file.baseName.replace("${meta.library_id}_", "").replaceAll(/_(rna|adt)$/, "")
     """
-    anndata_formatting_checks.R \
+    anndata_formatting_checks.py \
         --anndata_file ${anndata_file} \
         --object_type ${object_type} \
         --reference_file ${reference_anndata_file} \

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -28,6 +28,32 @@ process check_sce {
     """
 }
 
+process check_anndata {
+  container "${pullthroughContainer(params.scpcatools_anndata_container, params.pullthrough_registry)}"
+  label 'mem_16'
+  tag "${meta.unique_id}"
+  input:
+    tuple val(meta), 
+          path(anndata_file)
+    path(reference_anndata_file)
+  output:
+    tuple val(meta), 
+          path("${meta.unique_id}_formatting_errors.txt")
+  script:
+    def object_type = anndata_file.baseName.replace("${meta.library_id}_", "").replaceAll(/_(rna|adt)$/, "")
+    """
+    anndata_formatting_checks.R \
+        --anndata_file ${anndata_file} \
+        --object_type ${object_type} \
+        --reference_file ${reference_anndata_file} \
+        --output_file ${meta.unique_id}_formatting_errors.txt
+    """
+  stub:
+    """
+    touch ${meta.unique_id}_formatting_errors.txt
+    """
+}
+
 process compile_errors {
   container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
   publishDir "${params.outdir}", mode: 'copy'
@@ -57,7 +83,9 @@ process compile_errors {
 workflow format_checks {
   take: 
     sce_ch // [ meta, unfiltered sce, filtered sce, processed sce, metadata json]
+    anndata_ch // [ meta, h5ad files]
     sce_format_reference_file
+    anndata_format_reference_file
   main: 
 
     sce_format_ch = sce_ch
@@ -69,8 +97,14 @@ workflow format_checks {
 
     check_sce(sce_format_ch, sce_format_reference_file)
 
+    anndata_format_ch = anndata_ch
+      .transpose() // [ [meta, unfiltered rna h5ad], [meta, unfiltered adt h5ad]  ... ] 
+
+    check_anndata(anndata_format_ch, anndata_format_reference_file)
+
     // collect all error files and concatenate to print to a formatting errors output file
     error_input_ch = check_sce.out
+      .mix(check_anndata.out) // mix with the anndata error files
       .collect{ meta, error_file -> error_file } // collect into a list of just the error files
     
     compile_errors(error_input_ch)

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -23,9 +23,8 @@
                 "gene_ids": "string",
                 "gene_symbol": "string",
                 "mean": "float",
-                "detected": "int",
-                "feature_is_filtered": "bool",
-                "highly_variable": "bool"
+                "detected": "float",
+                "feature_is_filtered": "bool"
             },
             "obs_conditional": {
                 "has_submitter": {
@@ -60,7 +59,6 @@
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "sample_metadata": "pandas.DataFrame",
                 "sample_type": "str",
                 "X_name": "str",
                 "schema_version": "str"
@@ -122,9 +120,8 @@
                 "gene_ids": "string",
                 "gene_symbol": "string",
                 "mean": "float",
-                "detected": "int",
-                "feature_is_filtered": "bool",
-                "highly_variable": "bool"
+                "detected": "float",
+                "feature_is_filtered": "bool"
             },
             "obs_conditional": {
                 "has_submitter": {
@@ -173,7 +170,6 @@
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "sample_metadata": "pandas.DataFrame",
                 "sample_type": "str",
                 "filtering_method": "str",
                 "prob_compromised_cutoff": [
@@ -272,7 +268,7 @@
                 "gene_ids": "string",
                 "gene_symbol": "string",
                 "mean": "float",
-                "detected": "int",
+                "detected": "float",
                 "feature_is_filtered": "bool",
                 "highly_variable": "bool"
             },
@@ -355,7 +351,6 @@
                 "assay_ontology_term_id": "str",
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
-                "sample_metadata": "pandas.DataFrame",
                 "sample_type": "str",
                 "filtering_method": "str",
                 "prob_compromised_cutoff": "NoneType,float",

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -86,7 +86,7 @@
             "var": {
                 "adt_id": "string",
                 "mean": "float",
-                "detected": "int",
+                "detected": "float",
                 "target_type": "string"
             }
         }
@@ -211,7 +211,7 @@
             "var": {
                 "adt_id": "string",
                 "mean": "float",
-                "detected": "int",
+                "detected": "float",
                 "target_type": "string"
             },
             "obs_conditional": {
@@ -431,7 +431,7 @@
             "var": {
                 "adt_id": "string",
                 "mean": "float",
-                "detected": "int",
+                "detected": "float",
                 "target_type": "string"
             },
             "obs_conditional": {

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -538,12 +538,16 @@ processed_obs_metadata_conditional = {
 }
 
 # row metadata ----------
-# same for all object types
-var_metadata = {
+# same for unfilterd and filtered
+unfiltered_var_metadata = {
     **convert_cell_row_metadata_types(copy.deepcopy(feature_metadata)),
     "feature_is_filtered": "bool",
-    "highly_variable": "bool",
+    # overwrite detected since its a float in var but an int in obs
+    "detected": "float",
 }
+
+# highly variable is only in the processed object
+processed_var_metadata = {**unfiltered_var_metadata, "highly_variable": "bool"}
 
 # reduced dimensionality ----------
 processed_obsm = ["X_pca", "X_umap"]
@@ -558,6 +562,8 @@ unfiltered_uns_metadata = {
     **convert_experiment_metadata_types(copy.deepcopy(unfiltered_experiment_metadata)),
     **anndata_uns_metadata,
 }
+# drop sample_metadata since we don't keep it in AnnData objects
+unfiltered_uns_metadata.pop("sample_metadata", None)
 
 # also used for all adt object types
 unfiltered_uns_metadata_conditional = convert_experiment_metadata_types(
@@ -570,6 +576,8 @@ filtered_uns_metadata = {
     # this is NA or numeric so account for both possibilities in the reference
     "prob_compromised_cutoff": ["NoneType", "float"],
 }
+# drop sample_metadata since we don't keep it in AnnData objects
+filtered_uns_metadata.pop("sample_metadata", None)
 
 filtered_uns_metadata_conditional = {
     **convert_experiment_metadata_types(
@@ -592,6 +600,8 @@ processed_uns_metadata = {
         "variance_ratio": "float",
     },
 }
+# again remove sample metadata
+processed_uns_metadata.pop("sample_metadata", None)
 
 processed_uns_metadata_conditional = convert_experiment_metadata_types(
     copy.deepcopy(processed_experiment_metadata_conditional)
@@ -628,7 +638,7 @@ unfiltered_anndata = {
         "has_raw.X": False,
         "layers": layers,
         "obs": obs_metadata,
-        "var": var_metadata,
+        "var": unfiltered_var_metadata,
         "obs_conditional": obs_metadata_conditional,
         "uns": unfiltered_uns_metadata,
         "uns_conditional": unfiltered_uns_metadata_conditional,
@@ -646,7 +656,7 @@ filtered_anndata = {
         "has_raw.X": False,
         "layers": layers,
         "obs": filtered_obs_metadata,
-        "var": var_metadata,
+        "var": unfiltered_var_metadata,
         "obs_conditional": filtered_cell_metadata_conditional,
         "uns": filtered_uns_metadata,
         "uns_conditional": filtered_uns_metadata_conditional,
@@ -666,7 +676,7 @@ processed_anndata = {
         "has_raw.X": True,
         "layers": layers,
         "obs": filtered_obs_metadata,
-        "var": var_metadata,
+        "var": processed_var_metadata,
         "obs_conditional": processed_obs_metadata_conditional,
         "obsm": processed_obsm,
         "uns": processed_uns_metadata,

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -421,11 +421,6 @@ CELL_ROW_METADATA_MAP = {
     "factor": "category",
 }
 
-# outlier types for cell and row metadata
-CELL_ROW_METADATA_EXCEPTIONS = {
-    "detected": "int",
-}
-
 
 def convert_cell_row_metadata_types(metadata):
     for key, value in metadata.items():
@@ -433,9 +428,6 @@ def convert_cell_row_metadata_types(metadata):
         # use recursion to do this
         if isinstance(value, dict):
             convert_cell_row_metadata_types(value)
-        # check if the key is one of the exceptions where the types aren't what we expect
-        elif key in CELL_ROW_METADATA_EXCEPTIONS.keys():
-            metadata[key] = CELL_ROW_METADATA_EXCEPTIONS[key]
         # otherwise convert the value as long as the value is in the CELL_ROW_METADATA_MAP
         elif value in CELL_ROW_METADATA_MAP.keys():
             metadata[key] = CELL_ROW_METADATA_MAP[value]
@@ -507,6 +499,8 @@ anndata_specific_obs_metadata_conditional = {
 obs_metadata = {
     **convert_cell_row_metadata_types(copy.deepcopy(cell_metadata)),
     **anndata_specific_obs_metadata,
+    # detected in cell metadata only is int
+    "detected": "int",
 }
 
 obs_metadata_conditional = {
@@ -519,6 +513,8 @@ obs_metadata_conditional = {
 filtered_obs_metadata = {
     **convert_cell_row_metadata_types(copy.deepcopy(filtered_cell_metadata)),
     **anndata_specific_obs_metadata,
+    # detected in cell metadata only is int
+    "detected": "int",
 }
 
 filtered_cell_metadata_conditional = {
@@ -542,8 +538,6 @@ processed_obs_metadata_conditional = {
 unfiltered_var_metadata = {
     **convert_cell_row_metadata_types(copy.deepcopy(feature_metadata)),
     "feature_is_filtered": "bool",
-    # overwrite detected since its a float in var but an int in obs
-    "detected": "float",
 }
 
 # highly variable is only in the processed object


### PR DESCRIPTION
Closes #1295 

This PR adds in the process for running the script to check formatting of AnnData for every object. The process itself was very straightforward and followed the same setup as the SCE process. 

For outputting the final combined file, I ended up just putting all the error files in one channel and then exporting as a single file. The problem with that is we could have errors for a library in both the AnnData and SCE version of an object. To get around that, I added the type of object to the header that gets printed for each object with errors. Are we okay with that, or should we make two separate formatting results files, one for AnnData and one for SCE? 

The first time this ran through successfully, I got a file with a decent amount of errors shown here: 
[format_check_results_test.txt](https://github.com/user-attachments/files/28409998/format_check_results_test.txt)

I then updated the reference to account for those errors and now the output is empty with no reported errors. 

- We don't include `sample_metadata` in the `uns` of AnnData objects, so that is removed entirely. 
- Some of the `uns` contents seem to be stored as numpy type objects (so int64, float64, etc). To account for that, I added the numpy types to the `_BUILTIN_TYPES` dictionary. 
- `highly_variable` in the `var` should only be in the processed objects, so I removed it from unfiltered and filtered. 
- And finally, the `detected` column in the `var` slot should be a float, but because we have `detected` in the `obs` column that's an `int`, we are overwriting it during our conversion. Since the `obs` one is the one that has the weird type, I ended up overwriting that for each of the `obs` dictionary and removing the exception. 