### PR TITLE
Add merged object information to reference SCE and AnnData files

### DIFF
--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -585,9 +585,9 @@
                 "X_umap"
             ],
             "uns": {
-                "library_id": "numpy.ndarray",
-                "sample_id": "numpy.ndarray",
-                "merged_highly_variable_genes": "numpy.ndarray"
+                "library_id": "string",
+                "sample_id": "string",
+                "merged_highly_variable_genes": "string"
             }
         },
         "adt": {
@@ -615,9 +615,9 @@
                 "sizeFactor": "float"
             },
             "uns": {
-                "library_id": "numpy.ndarray",
-                "sample_id": "numpy.ndarray",
-                "library_metadata": "numpy.ndarray"
+                "library_id": "string",
+                "sample_id": "string",
+                "library_metadata": "string"
             }
         }
     }

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -13,10 +13,10 @@
                 "subsets_mito_detected": "int",
                 "subsets_mito_percent": "float",
                 "total": "float",
-                "library_id": "category",
-                "sample_id": "category",
-                "assay_ontology_term_id": "category",
-                "suspension_type": "category",
+                "library_id": "string",
+                "sample_id": "string",
+                "assay_ontology_term_id": "string",
+                "suspension_type": "string",
                 "is_primary_data": "bool"
             },
             "var": {
@@ -110,10 +110,10 @@
                 "scpca_filter": "string",
                 "scDblFinder_class": "string",
                 "scDblFinder_score": "float",
-                "library_id": "category",
-                "sample_id": "category",
-                "assay_ontology_term_id": "category",
-                "suspension_type": "category",
+                "library_id": "string",
+                "sample_id": "string",
+                "assay_ontology_term_id": "string",
+                "suspension_type": "string",
                 "is_primary_data": "bool"
             },
             "var": {
@@ -258,10 +258,10 @@
                 "scpca_filter": "string",
                 "scDblFinder_class": "string",
                 "scDblFinder_score": "float",
-                "library_id": "category",
-                "sample_id": "category",
-                "assay_ontology_term_id": "category",
-                "suspension_type": "category",
+                "library_id": "string",
+                "sample_id": "string",
+                "assay_ontology_term_id": "string",
+                "suspension_type": "string",
                 "is_primary_data": "bool"
             },
             "var": {
@@ -457,6 +457,167 @@
                 "seq_unit": "str",
                 "transcript_type": "numpy.ndarray",
                 "ambient_profile": "float"
+            }
+        }
+    },
+    "merged": {
+        "rna": {
+            "has_raw.X": true,
+            "layers": [
+                "spliced"
+            ],
+            "obs": {
+                "barcodes": "string",
+                "sum": "float",
+                "detected": "int",
+                "subsets_mito_sum": "float",
+                "subsets_mito_detected": "int",
+                "subsets_mito_percent": "float",
+                "total": "float",
+                "prob_compromised": "float",
+                "miQC_pass": "bool",
+                "scpca_filter": "string",
+                "scDblFinder_class": "string",
+                "scDblFinder_score": "float",
+                "additional_modalities": "string",
+                "library_id": "string",
+                "cell_id": "string",
+                "sample_id": "string",
+                "scpca_project_id": "string",
+                "submitter_id": "string",
+                "participant_id": "string",
+                "submitter": "string",
+                "age": "string",
+                "age_timing": "string",
+                "sex": "string",
+                "diagnosis": "string",
+                "subdiagnosis": "string",
+                "tissue_location": "string",
+                "disease_timing": "string",
+                "organism": "string",
+                "is_xenograft": "bool",
+                "is_cell_line": "bool",
+                "development_stage_ontology_term_id": "string",
+                "sex_ontology_term_id": "string",
+                "organism_ontology_term_id": "string",
+                "self_reported_ethnicity_ontology_term_id": "string",
+                "disease_ontology_term_id": "string",
+                "tissue_ontology_term_id": "string",
+                "tech_version": "string",
+                "assay_ontology_term_id": "string",
+                "suspension_type": "string",
+                "is_primary_data": "bool"
+            },
+            "var": {
+                "gene_ids": "string",
+                "gene_symbol": "string",
+                "mean": "float",
+                "detected": "float",
+                "feature_is_filtered": "bool",
+                "highly_variable": "bool"
+            },
+            "obs_conditional": {
+                "has_submitter": {
+                    "submitter_celltype_annotation": "string"
+                },
+                "has_openscpca": {
+                    "openscpca_celltype_annotation": "string",
+                    "openscpca_celltype_ontology": "string"
+                },
+                "has_adt": {
+                    "adt_scpca_filter": "string"
+                },
+                "has_cellhash": {
+                    "altexps_cellhash_sum": "float",
+                    "altexps_cellhash_detected": "int",
+                    "altexps_cellhash_percent": "float"
+                },
+                "has_hashedDrops": {
+                    "hashedDrops_sampleid": "string"
+                },
+                "has_HTODemux": {
+                    "HTODemux_sampleid": "string"
+                },
+                "has_vireo": {
+                    "vireo_sampleid": "string",
+                    "vireo_donor_id": "string",
+                    "vireo_prob_max": "float",
+                    "vireo_prob_doublet": "float",
+                    "vireo_n_vars": "float",
+                    "vireo_best_singlet": "string",
+                    "vireo_best_doublet": "string",
+                    "vireo_doublet_logLikRatio": "float"
+                },
+                "has_normalization": {
+                    "sizeFactor": "float"
+                },
+                "has_clusters": {
+                    "cluster": "category"
+                },
+                "has_singler": {
+                    "singler_celltype_annotation": "string",
+                    "singler_celltype_ontology": "string"
+                },
+                "has_cellassign": {
+                    "cellassign_celltype_annotation": "string",
+                    "cellassign_celltype_ontology": "string",
+                    "cellassign_max_prediction": "float"
+                },
+                "has_scimilarity": {
+                    "scimilarity_celltype_annotation": "string",
+                    "scimilarity_celltype_ontology": "string",
+                    "scimilarity_min_distance": "float"
+                },
+                "has_consensus": {
+                    "consensus_celltype_annotation": "string",
+                    "consensus_celltype_ontology": "string"
+                },
+                "has_infercnv": {
+                    "is_infercnv_reference": "bool",
+                    "infercnv_total_cnv": "int"
+                },
+                "is_multiplexed": {
+                    "sample_id": null
+                }
+            },
+            "obsm": [
+                "X_pca",
+                "X_umap"
+            ],
+            "uns": {
+                "library_id": "numpy.ndarray",
+                "sample_id": "numpy.ndarray",
+                "merged_highly_variable_genes": "numpy.ndarray"
+            }
+        },
+        "adt": {
+            "obs": {
+                "zero.ambient": "bool",
+                "discard": "bool",
+                "library_id": "string",
+                "cell_id": "string"
+            },
+            "var": {
+                "adt_id": "string",
+                "mean": "float",
+                "detected": "float",
+                "target_type": "string"
+            },
+            "obs_conditional": {
+                "has_negative_control": {
+                    "sum.controls": "int",
+                    "high.control": "bool"
+                },
+                "no_negative_control": {
+                    "ambient.scale": "float",
+                    "high.ambient": "bool"
+                },
+                "sizeFactor": "float"
+            },
+            "uns": {
+                "library_id": "numpy.ndarray",
+                "sample_id": "numpy.ndarray",
+                "library_metadata": "numpy.ndarray"
             }
         }
     }

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -319,7 +319,8 @@
     "processed": {
         "assayNames": [
             "counts",
-            "spliced"
+            "spliced",
+            "logcounts"
         ],
         "colData": {
             "barcodes": "character",
@@ -572,6 +573,166 @@
                         "HTODemux_maxsample": "character",
                         "HTODemux_sampleid": "character"
                     }
+                }
+            }
+        }
+    },
+    "merged": {
+        "assayNames": [
+            "counts",
+            "spliced",
+            "logcounts"
+        ],
+        "colData": {
+            "barcodes": "character",
+            "sum": "numeric",
+            "detected": "numeric",
+            "subsets_mito_sum": "numeric",
+            "subsets_mito_detected": "integer",
+            "subsets_mito_percent": "numeric",
+            "total": "numeric",
+            "prob_compromised": "numeric",
+            "miQC_pass": "logical",
+            "scpca_filter": "character",
+            "scDblFinder_class": "character",
+            "scDblFinder_score": "numeric",
+            "additional_modalities": "character",
+            "library_id": "character",
+            "cell_id": "character",
+            "sample_id": "character",
+            "scpca_project_id": "character",
+            "submitter_id": "character",
+            "participant_id": "character",
+            "submitter": "character",
+            "age": "character",
+            "age_timing": "character",
+            "sex": "character",
+            "diagnosis": "character",
+            "subdiagnosis": "character",
+            "tissue_location": "character",
+            "disease_timing": "character",
+            "organism": "character",
+            "is_xenograft": "logical",
+            "is_cell_line": "logical",
+            "development_stage_ontology_term_id": "character",
+            "sex_ontology_term_id": "character",
+            "organism_ontology_term_id": "character",
+            "self_reported_ethnicity_ontology_term_id": "character",
+            "disease_ontology_term_id": "character",
+            "tissue_ontology_term_id": "character",
+            "tech_version": "character",
+            "assay_ontology_term_id": "character",
+            "suspension_type": "character"
+        },
+        "rowData": {
+            "gene_ids": "character",
+            "gene_symbol": "character",
+            "mean": "numeric",
+            "detected": "numeric"
+        },
+        "colData_conditional": {
+            "has_submitter": {
+                "submitter_celltype_annotation": "character"
+            },
+            "has_openscpca": {
+                "openscpca_celltype_annotation": "character",
+                "openscpca_celltype_ontology": "character"
+            },
+            "has_adt": {
+                "adt_scpca_filter": "character"
+            },
+            "has_cellhash": {
+                "altexps_cellhash_sum": "numeric",
+                "altexps_cellhash_detected": "integer",
+                "altexps_cellhash_percent": "numeric"
+            },
+            "has_hashedDrops": {
+                "hashedDrops_sampleid": "character"
+            },
+            "has_HTODemux": {
+                "HTODemux_sampleid": "character"
+            },
+            "has_vireo": {
+                "vireo_sampleid": "character",
+                "vireo_donor_id": "character",
+                "vireo_prob_max": "numeric",
+                "vireo_prob_doublet": "numeric",
+                "vireo_n_vars": "numeric",
+                "vireo_best_singlet": "character",
+                "vireo_best_doublet": "character",
+                "vireo_doublet_logLikRatio": "numeric"
+            },
+            "has_normalization": {
+                "sizeFactor": "numeric"
+            },
+            "has_clusters": {
+                "cluster": "factor"
+            },
+            "has_singler": {
+                "singler_celltype_annotation": "character",
+                "singler_celltype_ontology": "character"
+            },
+            "has_cellassign": {
+                "cellassign_celltype_annotation": "character",
+                "cellassign_celltype_ontology": "character",
+                "cellassign_max_prediction": "numeric"
+            },
+            "has_scimilarity": {
+                "scimilarity_celltype_annotation": "character",
+                "scimilarity_celltype_ontology": "character",
+                "scimilarity_min_distance": "numeric"
+            },
+            "has_consensus": {
+                "consensus_celltype_annotation": "character",
+                "consensus_celltype_ontology": "character"
+            },
+            "has_infercnv": {
+                "is_infercnv_reference": "logical",
+                "infercnv_total_cnv": "integer"
+            }
+        },
+        "reducedDimNames": [
+            "PCA",
+            "UMAP"
+        ],
+        "metadata": {
+            "library_id": "character",
+            "sample_id": "character",
+            "library_metadata": "list",
+            "merged_highly_variable_genes": "character"
+        },
+        "altExp": {
+            "adt": {
+                "assayNames": [
+                    "counts"
+                ],
+                "colData": {
+                    "zero.ambient": "logical",
+                    "discard": "logical",
+                    "library_id": "character",
+                    "cell_id": "character"
+                },
+                "rowData": {
+                    "adt_id": "character",
+                    "mean": "numeric",
+                    "detected": "numeric",
+                    "target_type": "character"
+                },
+                "colData_conditional": {
+                    "has_negative_control": {
+                        "sum.controls": "integer",
+                        "high.control": "logical"
+                    },
+                    "no_negative_control": {
+                        "ambient.scale": "numeric",
+                        "high.ambient": "logical"
+                    },
+                    "sizeFactor": "numeric"
+                },
+                "metadata": {
+                    "library_id": "character",
+                    "sample_id": "character",
+                    "library_metadata": "list"
                 }
             }
         }

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -13,7 +13,7 @@ anndata_ref_file = "../anndata-formatting-reference.json"
 # --------------------- SCE ---------------------------
 # assays
 assays = ["counts", "spliced"]
-processed_assays = ["counts", "spliced", "logcounts"]
+processed_assays = ["logcounts"]
 adt_assays = ["counts"]
 cellhash_assays = ["counts"]
 
@@ -430,7 +430,7 @@ filtered_sce = {
 # build processed SCE  ------
 
 processed_sce = {
-    "assayNames": processed_assays,
+    "assayNames": assays + processed_assays,
     "colData": filtered_cell_metadata,
     "rowData": feature_metadata,
     "colData_conditional": processed_cell_metadata_conditional,
@@ -457,7 +457,7 @@ processed_sce = {
 # build merged sce -----
 
 merged_sce = {
-    "assayNames": processed_assays,
+    "assayNames": assays + processed_assays,
     "colData": merged_cell_metadata,
     "rowData": feature_metadata,
     "colData_conditional": processed_cell_metadata_conditional,

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -139,7 +139,8 @@ merged_cell_metadata = {
 
 # row metadata ----------
 # this is the same for all object types
-# for merged objects, check that library_id-mean and library_id-detected are correct in the script
+# for merged objects, check that {library_id}-mean and {library_id}-detected are correct in the script
+# these will use the same types as `mean` and `detected`
 feature_metadata = {
     "gene_ids": "character",
     "gene_symbol": "character",

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -13,7 +13,7 @@ anndata_ref_file = "../anndata-formatting-reference.json"
 # --------------------- SCE ---------------------------
 # assays
 assays = ["counts", "spliced"]
-processed_assays = ["logcounts"]
+processed_assays = ["counts", "spliced", "logcounts"]
 adt_assays = ["counts"]
 cellhash_assays = ["counts"]
 
@@ -105,8 +105,41 @@ processed_cell_metadata_conditional = {
     },
 }
 
+
+merged_cell_metadata = {
+    **filtered_cell_metadata,
+    "additional_modalities": "character",
+    "library_id": "character",
+    "cell_id": "character",
+    "sample_id": "character",
+    "scpca_project_id": "character",
+    "submitter_id": "character",
+    "participant_id": "character",
+    "submitter": "character",
+    "age": "character",
+    "age_timing": "character",
+    "sex": "character",
+    "diagnosis": "character",
+    "subdiagnosis": "character",
+    "tissue_location": "character",
+    "disease_timing": "character",
+    "organism": "character",
+    "is_xenograft": "logical",
+    "is_cell_line": "logical",
+    "development_stage_ontology_term_id": "character",
+    "sex_ontology_term_id": "character",
+    "organism_ontology_term_id": "character",
+    "self_reported_ethnicity_ontology_term_id": "character",
+    "disease_ontology_term_id": "character",
+    "tissue_ontology_term_id": "character",
+    "tech_version": "character",
+    "assay_ontology_term_id": "character",
+    "suspension_type": "character",
+}
+
 # row metadata ----------
 # this is the same for all object types
+# for merged objects, check that library_id-mean and library_id-detected are correct in the script
 feature_metadata = {
     "gene_ids": "character",
     "gene_symbol": "character",
@@ -234,9 +267,17 @@ processed_experiment_metadata_conditional = {
     },
 }
 
+merged_experiment_metadata = {
+    "library_id": "character",
+    "sample_id": "character",
+    "library_metadata": "list",
+    "merged_highly_variable_genes": "character",
+}
+
 # alt exps gell/gene metadata ------------
 # adt specific items
 # same for all object types
+# again, for merged objects, check that library_id-mean and library_id-detected are correct in the script
 altexp_adt_feature_metadata = {
     "adt_id": "character",
     "mean": "numeric",
@@ -268,6 +309,12 @@ processed_altexp_adt_cell_metadata_conditional = {
     "sizeFactor": "numeric",
 }
 
+merged_altexp_adt_cell_metadata = {
+    **filtered_altexp_adt_cell_metadata,
+    "library_id": "character",
+    "cell_id": "character",
+}
+
 unfiltered_altexp_adt_experiment_metadata = {
     key: value
     for key, value in unfiltered_experiment_metadata.items()
@@ -279,6 +326,13 @@ unfiltered_altexp_adt_experiment_metadata = {
 filtered_altexp_adt_experiment_metadata = {
     **unfiltered_altexp_adt_experiment_metadata,
     "ambient_profile": "numeric",
+}
+
+# merged objects only have library_id, sample_id, and library_metdata as a list of the metadata from the original objects
+merged_altexp_adt_experiment_metadata = {
+    "library_id": "character",
+    "sample_id": "character",
+    "library_metadata": "list",
 }
 
 # cellhash specific items
@@ -375,7 +429,7 @@ filtered_sce = {
 # build processed SCE  ------
 
 processed_sce = {
-    "assayNames": assays,
+    "assayNames": processed_assays,
     "colData": filtered_cell_metadata,
     "rowData": feature_metadata,
     "colData_conditional": processed_cell_metadata_conditional,
@@ -399,11 +453,33 @@ processed_sce = {
     },
 }
 
+# build merged sce -----
+
+merged_sce = {
+    "assayNames": processed_assays,
+    "colData": merged_cell_metadata,
+    "rowData": feature_metadata,
+    "colData_conditional": processed_cell_metadata_conditional,
+    "reducedDimNames": reduced_dims,
+    "metadata": merged_experiment_metadata,
+    "altExp": {
+        "adt": {
+            "assayNames": adt_assays,
+            "colData": merged_altexp_adt_cell_metadata,
+            "rowData": altexp_adt_feature_metadata,
+            "colData_conditional": processed_altexp_adt_cell_metadata_conditional,
+            "metadata": merged_altexp_adt_experiment_metadata,
+        }
+    },
+}
+
+
 # build and export sce schema --------------
 sce_schema = {
     "unfiltered": unfiltered_sce,
     "filtered": filtered_sce,
     "processed": processed_sce,
+    "merged": merged_sce,
 }
 
 with open(sce_ref_file, "w") as f:
@@ -481,11 +557,11 @@ layers = ["spliced"]
 anndata_specific_obs_metadata = {
     # sample metadata is present in obs for anndata
     # this minimally includes library id and sample id
-    "library_id": "category",
-    "sample_id": "category",
+    "library_id": "string",
+    "sample_id": "string",
     # columns that we explicitly add in sce_to_annndata
-    "assay_ontology_term_id": "category",
-    "suspension_type": "category",
+    "assay_ontology_term_id": "string",
+    "suspension_type": "string",
     "is_primary_data": "bool",
 }
 
@@ -531,6 +607,13 @@ processed_obs_metadata_conditional = {
         copy.deepcopy(processed_cell_metadata_conditional)
     ),
     **anndata_specific_obs_metadata_conditional,
+}
+
+# merged cell metadata ------------
+merged_obs_metadata = {
+    **convert_cell_row_metadata_types(copy.deepcopy(merged_cell_metadata)),
+    **anndata_specific_obs_metadata,
+    "detected": "int",
 }
 
 # row metadata ----------
@@ -601,6 +684,14 @@ processed_uns_metadata_conditional = convert_experiment_metadata_types(
     copy.deepcopy(processed_experiment_metadata_conditional)
 )
 
+# merged metadata is the same as sce but no library_metadata list
+# these are character vectors in R which get converted to numpy.ndarrays in Python
+merged_uns_metadata = {
+    "library_id": "numpy.ndarray",
+    "sample_id": "numpy.ndarray",
+    "merged_highly_variable_genes": "numpy.ndarray",
+}
+
 # alt exps gell/gene metadata ------------
 # adt specific items
 altexp_adt_var_metadata = convert_cell_row_metadata_types(
@@ -620,10 +711,20 @@ processed_altexp_adt_obs_metadata_conditional = convert_cell_row_metadata_types(
     copy.deepcopy(processed_altexp_adt_cell_metadata_conditional)
 )
 
+merged_altexp_adt_obs_metadata = convert_cell_row_metadata_types(
+    copy.deepcopy(merged_altexp_adt_cell_metadata)
+)
+
 # used in both filtered and processed
 filtered_altexp_adt_uns_metadata = convert_experiment_metadata_types(
     copy.deepcopy(filtered_altexp_adt_experiment_metadata)
 )
+
+merged_altexp_adt_uns_metadata = {
+    "library_id": "numpy.ndarray",
+    "sample_id": "numpy.ndarray",
+    "library_metadata": "numpy.ndarray",
+}
 
 # build unfiltered AnnData -----------------
 
@@ -684,11 +785,32 @@ processed_anndata = {
     },
 }
 
+# build merged AnnData  ------
+
+merged_anndata = {
+    "rna": {
+        "has_raw.X": True,
+        "layers": layers,
+        "obs": merged_obs_metadata,
+        "var": processed_var_metadata,
+        "obs_conditional": processed_obs_metadata_conditional,
+        "obsm": processed_obsm,
+        "uns": merged_uns_metadata,
+    },
+    "adt": {
+        "obs": merged_altexp_adt_obs_metadata,
+        "var": altexp_adt_var_metadata,
+        "obs_conditional": processed_altexp_adt_obs_metadata_conditional,
+        "uns": merged_altexp_adt_uns_metadata,
+    },
+}
+
 # build and export anndata schema --------------
 anndata_schema = {
     "unfiltered": unfiltered_anndata,
     "filtered": filtered_anndata,
     "processed": processed_anndata,
+    "merged": merged_anndata,
 }
 
 with open(anndata_ref_file, "w") as f:

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -686,11 +686,10 @@ processed_uns_metadata_conditional = convert_experiment_metadata_types(
 )
 
 # merged metadata is the same as sce but no library_metadata list
-# these are character vectors in R which get converted to numpy.ndarrays in Python
 merged_uns_metadata = {
-    "library_id": "numpy.ndarray",
-    "sample_id": "numpy.ndarray",
-    "merged_highly_variable_genes": "numpy.ndarray",
+    "library_id": "string",
+    "sample_id": "string",
+    "merged_highly_variable_genes": "string",
 }
 
 # alt exps gell/gene metadata ------------
@@ -722,9 +721,9 @@ filtered_altexp_adt_uns_metadata = convert_experiment_metadata_types(
 )
 
 merged_altexp_adt_uns_metadata = {
-    "library_id": "numpy.ndarray",
-    "sample_id": "numpy.ndarray",
-    "library_metadata": "numpy.ndarray",
+    "library_id": "string",
+    "sample_id": "string",
+    "library_metadata": "string",
 }
 
 # build unfiltered AnnData -----------------


### PR DESCRIPTION
Closes #1195 

This PR updates the existing reference files for SCE and AnnData objects to now include a slot for merged objects. I would like to use the same scripts that we have set up for checking these objects, which would mean just providing these reference files and the appropriate object type, which in this case is `merged`. 

- The cell metadata should have everything present in the processed objects, plus some additional sample metadata information that we ported over from the `sample_metadata` that was originally saved in `metadata(sce)`. 
- The feature metadata is the same, except we now have `library_id-mean` (`library_id.mean` in python) and `library_id-detected`. I think what we need to do is update the script to check all these columns if the object type is merged rather than try and address that in the reference file here. 
- The experiment metadata now only has `sample_id`, `library_id`, `library_metadata` (which is a list of metadata for each library), and then `merged_highly_variable_genes` for SCE objects only. For the `library_metadata`, I chose not to check each of the individual slots since that should be the same as what's in the processed metadata for each object. Again, this is something I think we can adjust in the script itself if we want to check this information.

I think everything else was fairly straightforward, except I noticed that I was manually using `category` as the type for the AnnData specific cell metadata columns. Using `string` consistently for all cell metadata column types that are characters in R seems to be okay. I did a few manual checks using our dtype checker and it worked. The only time we should see `category` is for factors. 