### PR TITLE
Add process for checking format of merged objects

### DIFF
--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -208,7 +208,9 @@ def expand_merged_var_ref(var, ref_var):
     mean_type = ref_var.get("mean")
     detected_type = ref_var.get("detected")
 
-    expanded = dict(ref_var)
+    # remove mean and detected so they don't get flagged as missing
+    expanded = {k: v for k, v in ref_var.items() if k not in ("mean", "detected")}
+
     for col in var.columns:
         if col.endswith(".mean"):
             expanded[col] = mean_type

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -206,7 +206,7 @@ def expand_merged_var_ref(var, ref_var):
     with the same expected types as `mean` and `detected`.
     """
     expanded = ref_var.copy()
-    
+
     # get mean and detected values, while removing them so they don't get flagged as missing
     mean_type = expanded.pop("mean")
     detected_type = expanded.pop("detected")

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -196,7 +196,29 @@ def get_conditionals(adata):
     return set(cond for cond, is_true in condition_tests.items() if is_true)
 
 
-def check_anndata(adata, ref, label):
+def expand_merged_var_ref(var, ref_var):
+    """
+    Expand the var reference for merged AnnData objects to include per-library columns.
+
+    For merged objects, var contains `libraryid.mean` and `libraryid.detected`
+    columns for each library.
+    This function finds those columns and adds them to the reference
+    with the same expected types as `mean` and `detected`.
+    """
+    mean_type = ref_var.get("mean")
+    detected_type = ref_var.get("detected")
+
+    expanded = dict(ref_var)
+    for col in var.columns:
+        if col.endswith(".mean"):
+            expanded[col] = mean_type
+        elif col.endswith(".detected"):
+            expanded[col] = detected_type
+
+    return expanded
+
+
+def check_anndata(adata, ref, label, object_type):
     """Run all formatting checks for an AnnData object."""
     errors = []
 
@@ -227,6 +249,8 @@ def check_anndata(adata, ref, label):
                 )
 
     if "var" in ref:
+        if object_type == "merged":
+            ref["var"] = expand_merged_var_ref(adata.var, ref["var"])
         errors.extend(check_names_and_types(adata.var, ref["var"], label, "var"))
 
     if "uns" in ref:
@@ -250,8 +274,8 @@ def main():
     parser.add_argument(
         "--object_type",
         required=True,
-        choices=["unfiltered", "filtered", "processed"],
-        help="Type of object: unfiltered, filtered, or processed",
+        choices=["unfiltered", "filtered", "processed", "merged"],
+        help="Type of object: unfiltered, filtered, processed, or merged",
     )
     parser.add_argument(
         "--reference_file", required=True, type=Path, help="Path to reference JSON"
@@ -293,7 +317,7 @@ def main():
     label = f"{modality.upper()} AnnData"
 
     # check contents of the anndata object against a reference
-    errors = check_anndata(adata, ref, label)
+    errors = check_anndata(adata, ref, label, args.object_type)
 
     # export errors to output file, or create empty file if no errors
     output_path = Path(args.output_file)

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -205,11 +205,11 @@ def expand_merged_var_ref(var, ref_var):
     This function finds those columns and adds them to the reference
     with the same expected types as `mean` and `detected`.
     """
-    mean_type = ref_var.get("mean")
-    detected_type = ref_var.get("detected")
-
-    # remove mean and detected so they don't get flagged as missing
-    expanded = {k: v for k, v in ref_var.items() if k not in ("mean", "detected")}
+    expanded = ref_var.copy()
+    
+    # get mean and detected values, while removing them so they don't get flagged as missing
+    mean_type = expanded.pop("mean")
+    detected_type = expanded.pop("detected")
 
     for col in var.columns:
         if col.endswith(".mean"):

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -274,6 +274,11 @@ def main():
         "--anndata_file", required=True, type=Path, help="Path to .h5ad file"
     )
     parser.add_argument(
+        "--object_id",
+        required=True,
+        help="Identifier for the object (e.g. library ID) to include in error messages",
+    )
+    parser.add_argument(
         "--object_type",
         required=True,
         choices=["unfiltered", "filtered", "processed", "merged"],
@@ -326,8 +331,7 @@ def main():
     if not errors:
         output_path.touch()
     else:
-        library_id = adata.uns.get("library_id", "unknown")
-        header = f"Formatting errors found for {library_id} {args.object_type} {modality} AnnData object:"
+        header = f"Formatting errors found for {args.object_id} {args.object_type} {modality} AnnData object:"
         with open(output_path, "w") as error_file:
             error_file.write(f"{header}\n\n")
             for error in errors:

--- a/bin/anndata_formatting_checks.py
+++ b/bin/anndata_formatting_checks.py
@@ -274,11 +274,6 @@ def main():
         "--anndata_file", required=True, type=Path, help="Path to .h5ad file"
     )
     parser.add_argument(
-        "--object_id",
-        required=True,
-        help="Identifier for the object (e.g. library ID) to include in error messages",
-    )
-    parser.add_argument(
         "--object_type",
         required=True,
         choices=["unfiltered", "filtered", "processed", "merged"],
@@ -331,7 +326,13 @@ def main():
     if not errors:
         output_path.touch()
     else:
-        header = f"Formatting errors found for {args.object_id} {args.object_type} {modality} AnnData object:"
+        if args.object_type == "merged":
+            # get project identifier from filename for merged objects
+            header_id = Path(args.anndata_file).name.split("_merged")[0]
+        else:
+            # otherwise use the library id stored in the object
+            header_id = adata.uns.get("library_id", "unknown")
+        header = f"Formatting errors found for {header_id} {args.object_type} {modality} AnnData object:"
         with open(output_path, "w") as error_file:
             error_file.write(f"{header}\n\n")
             for error in errors:

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -102,6 +102,9 @@ expand_merged_rowdata_ref <- function(rowdata, ref_rowdata) {
     purrr::set_names(rep(list(detected_type), length(detected_cols)), detected_cols)
   )
 
+  # remove mean and detected from ref so they don't get flagged as missing
+  ref_rowdata[c("mean", "detected")] <- NULL
+
   return(
     c(ref_rowdata, extra_ref)
   )

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -238,12 +238,6 @@ option_list <- list(
     help = "Path to RDS file containing a SingleCellExperiment object from scpca-nf"
   ),
   make_option(
-    opt_str = c("--object_id"),
-    type = "character",
-    default = "",
-    help = "Identifier for the object (e.g. library ID) to include in error messages"
-  ),
-  make_option(
     opt_str = c("--object_type"),
     type = "character",
     help = "Type of object from scpca-nf, either unfiltered, filtered, processed, or merged"
@@ -393,10 +387,18 @@ if (opt$object_type == "processed") {
 
 # Write output -----------------------------------------------------------------
 
+if (opt$object_type == "merged") {
+  # if the object type is merged, then grab the project id from the filename to print in the header for error messages
+  header_id <- stringr::remove(basename(opt$sce_file), "_merged.rds")
+} else {
+  # otherwise just grab the library id from the metadata
+  header_id <- metadata(sce)$library_id
+}
+
 # make sure that if there are no errors we have an empty file
 if (length(errors) == 0) {
   fs::file_create(opt$output_file)
 } else {
-  header <- glue::glue("Formatting errors found for {opt$object_id} {opt$object_type} SingleCellExperiment:")
+  header <- glue::glue("Formatting errors found for {header_id} {opt$object_type} SingleCellExperiment:")
   writeLines(c(header, "", errors, ""), opt$output_file)
 }

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -77,6 +77,36 @@ check_conditional_names_and_type <- function(conditions_present, data, ref) {
 }
 
 
+#' Expand rowData reference for merged objects to include per-library columns
+#'
+#' For merged SCE objects, rowData contains `libraryid-mean` and
+#' `libraryid-detected` columns for each library.
+#' This function finds those columns and adds them to the reference
+#' with the same expected types as `mean` and `detected`.
+#'
+#' @param rowdata The rowData slot from the SCE object
+#' @param ref_rowdata The rowData reference list from the JSON
+#'
+#' @return An updated rowData reference list including per-library columns
+expand_merged_rowdata_ref <- function(rowdata, ref_rowdata) {
+  # grab the expected type
+  mean_type <- ref_rowdata[["mean"]]
+  detected_type <- ref_rowdata[["detected"]]
+
+  # find all libraryid-mean and libraryid-detected columns
+  mean_cols <- grep("-mean$", names(rowdata), value = TRUE)
+  detected_cols <- grep("-detected$", names(rowdata), value = TRUE)
+
+  extra_ref <- c(
+    purrr::set_names(rep(list(mean_type), length(mean_cols)), mean_cols),
+    purrr::set_names(rep(list(detected_type), length(detected_cols)), detected_cols)
+  )
+
+  return(
+    c(ref_rowdata, extra_ref)
+  )
+}
+
 #' Check required and conditional col/row/metadata slots of an SCE object
 #'
 #' Runs both required and conditional checks against a reference list,
@@ -207,7 +237,7 @@ option_list <- list(
   make_option(
     opt_str = c("--object_type"),
     type = "character",
-    help = "Type of object from scpca-nf, either unfiltered, filtered, or processed"
+    help = "Type of object from scpca-nf, either unfiltered, filtered, processed, or merged"
   ),
   make_option(
     opt_str = c("--reference_file"),
@@ -229,7 +259,7 @@ opt <- parse_args(OptionParser(option_list = option_list))
 
 stopifnot(
   "sce file does not exist" = file.exists(opt$sce_file),
-  "Object type must be one of unfiltered, filtered, or processed" = opt$object_type %in% c("unfiltered", "filtered", "processed"),
+  "Object type must be one of unfiltered, filtered, processed, or merged" = opt$object_type %in% c("unfiltered", "filtered", "processed", "merged"),
   "Reference file does not exist" = file.exists(opt$reference_file),
   "output file must end in `.txt`" = stringr::str_ends(opt$output_file, "\\.txt")
 )
@@ -239,6 +269,11 @@ all_ref_list <- jsonlite::read_json(opt$reference_file)[[opt$object_type]]
 
 # initialize empty error string
 errors <- character(0)
+
+# For merged objects, expand rowData ref to include per-library columns
+if (opt$object_type == "merged") {
+  all_ref_list$rowData <- expand_merged_rowdata_ref(rowData(sce), all_ref_list$rowData)
+}
 
 # Check main SCE assays --------------------------------------------------------
 

--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -238,6 +238,12 @@ option_list <- list(
     help = "Path to RDS file containing a SingleCellExperiment object from scpca-nf"
   ),
   make_option(
+    opt_str = c("--object_id"),
+    type = "character",
+    default = "",
+    help = "Identifier for the object (e.g. library ID) to include in error messages"
+  ),
+  make_option(
     opt_str = c("--object_type"),
     type = "character",
     help = "Type of object from scpca-nf, either unfiltered, filtered, processed, or merged"
@@ -391,6 +397,6 @@ if (opt$object_type == "processed") {
 if (length(errors) == 0) {
   fs::file_create(opt$output_file)
 } else {
-  header <- glue::glue("Formatting errors found for {metadata(sce)$library_id} {opt$object_type} SingleCellExperiment:")
+  header <- glue::glue("Formatting errors found for {opt$object_id} {opt$object_type} SingleCellExperiment:")
   writeLines(c(header, "", errors, ""), opt$output_file)
 }

--- a/merge.nf
+++ b/merge.nf
@@ -139,6 +139,7 @@ process check_sce {
     """
     sce_formatting_checks.R \
         --sce_file ${merged_sce_file} \
+        --object_id ${merge_group_id} \
         --object_type merged \
         --reference_file ${reference_sce_file} \
         --output_file ${merge_group_id}_formatting_errors.txt
@@ -164,6 +165,7 @@ process check_anndata {
     """
     anndata_formatting_checks.py \
         --anndata_file ${anndata_file} \
+        --object_id ${merge_group_id} \
         --object_type merged \
         --reference_file ${reference_anndata_file} \
         --output_file ${merge_group_id}_formatting_errors.txt

--- a/merge.nf
+++ b/merge.nf
@@ -124,6 +124,82 @@ process export_anndata {
     """
 }
 
+process check_sce {
+  container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
+  label 'mem_16'
+  tag "${merge_group_id}"
+  input:
+    tuple val(merge_group_id), 
+          path(merged_sce_file)
+    path(reference_sce_file)
+  output:
+    tuple val(merge_group_id), 
+          path("${merge_group_id}_formatting_errors.txt")
+  script:
+    """
+    sce_formatting_checks.R \
+        --sce_file ${merged_sce_file} \
+        --object_type merged \
+        --reference_file ${reference_sce_file} \
+        --output_file ${merge_group_id}_formatting_errors.txt
+    """
+  stub:
+    """
+    touch ${merge_group_id}_formatting_errors.txt
+    """
+}
+
+process check_anndata {
+  container "${pullthroughContainer(params.scpcatools_anndata_container, params.pullthrough_registry)}"
+  label 'mem_16'
+  tag "${merge_group_id}"
+  input:
+    tuple val(merge_group_id), 
+          path(anndata_file)
+    path(reference_anndata_file)
+  output:
+    tuple val(merge_group_id), 
+          path("${merge_group_id}_formatting_errors.txt")
+  script:
+    """
+    anndata_formatting_checks.py \
+        --anndata_file ${anndata_file} \
+        --object_type merged \
+        --reference_file ${reference_anndata_file} \
+        --output_file ${merge_group_id}_formatting_errors.txt
+    """
+  stub:
+    """
+    touch ${merge_group_id}_formatting_errors.txt
+    """
+}
+
+process compile_errors {
+  container "${pullthroughContainer(params.scpcatools_slim_container, params.pullthrough_registry)}"
+  publishDir "${params.outdir}", mode: 'copy'
+  label 'mem_8'
+  input:
+   // more than one error file per library (unfiltered, filtered, processed), so use stageAs
+   path error_files, stageAs: "error_file_*.txt"
+  output:
+    path "format_check_results.txt"
+  script:
+    """
+    # check if all files are empty, if so print a success message
+    # otherwise concatenate all error files into one output file
+    errors="\$(cat ${error_files})"
+    if [ -z "\${errors}" ]; then
+      echo "No formatting errors found." > format_check_results.txt
+    else
+      echo "\${errors}" > format_check_results.txt
+    fi
+    """
+  stub: 
+    """
+    touch format_check_results.txt
+    """
+}
+
 workflow {
   check_parameters()
 
@@ -267,4 +343,24 @@ workflow {
 
   // export merged objects to AnnData
   export_anndata(merged_ch)
+
+  // check formatting of merged objects 
+  check_sce(merged_ch, file(params.sce_format_reference_file))
+  check_anndata(export_anndata.out, file(params.anndata_format_reference_file))
+
+  // collect all error files and concatenate to print to a formatting errors output file
+  error_output_ch = check_sce.out
+    .mix(check_anndata.out) // mix with the anndata error files
+
+  error_files_ch = error_output_ch
+    .collect{ merge_group_id, error_file -> error_file } // collect into a list of just the error files
+  
+  compile_errors(error_files_ch)
+  
+  // collect all error files and print out an error to the log file
+  error_output_ch
+    .filter{ meta, error_file -> error_file.size() > 0 } // only warn about libraries with errors
+    .subscribe{ meta, error_file -> 
+      log.error "Formatting errors for ${error_file.text}"
+    }
 }

--- a/merge.nf
+++ b/merge.nf
@@ -139,7 +139,6 @@ process check_sce {
     """
     sce_formatting_checks.R \
         --sce_file ${merged_sce_file} \
-        --object_id ${merge_group_id} \
         --object_type merged \
         --reference_file ${reference_sce_file} \
         --output_file ${merge_group_id}_formatting_errors.txt
@@ -165,7 +164,6 @@ process check_anndata {
     """
     anndata_formatting_checks.py \
         --anndata_file ${anndata_file} \
-        --object_id ${merge_group_id} \
         --object_type merged \
         --reference_file ${reference_anndata_file} \
         --output_file ${merge_group_id}_formatting_errors.txt

--- a/merge.nf
+++ b/merge.nf
@@ -182,21 +182,21 @@ process compile_errors {
    // more than one error file per library (unfiltered, filtered, processed), so use stageAs
    path error_files, stageAs: "error_file_*.txt"
   output:
-    path "format_check_results.txt"
+    path "merged-format_check_results.txt"
   script:
     """
     # check if all files are empty, if so print a success message
     # otherwise concatenate all error files into one output file
     errors="\$(cat ${error_files})"
     if [ -z "\${errors}" ]; then
-      echo "No formatting errors found." > format_check_results.txt
+      echo "No formatting errors found." > merged-format_check_results.txt
     else
-      echo "\${errors}" > format_check_results.txt
+      echo "\${errors}" > merged-format_check_results.txt
     fi
     """
   stub: 
     """
-    touch format_check_results.txt
+    touch merged-format_check_results.txt
     """
 }
 
@@ -356,10 +356,10 @@ workflow {
     .collect{ merge_group_id, error_file -> error_file } // collect into a list of just the error files
   
   compile_errors(error_files_ch)
-  
+
   // collect all error files and print out an error to the log file
   error_output_ch
-    .filter{ meta, error_file -> error_file.size() > 0 } // only warn about libraries with errors
+    .filter{ meta, error_file -> error_file.size() > 0 } // only warn about objects with errors
     .subscribe{ meta, error_file -> 
       log.error "Formatting errors for ${error_file.text}"
     }

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -18,7 +18,6 @@ process check_sce {
     """
     sce_formatting_checks.R \
         --sce_file ${sce_file} \
-        --object_id ${meta.library_id} \
         --object_type ${object_type} \
         --reference_file ${reference_sce_file} \
         --output_file ${meta.unique_id}_formatting_errors.txt
@@ -45,7 +44,6 @@ process check_anndata {
     """
     anndata_formatting_checks.py \
         --anndata_file ${anndata_file} \
-        --object_id ${meta.library_id} \
         --object_type ${object_type} \
         --reference_file ${reference_anndata_file} \
         --output_file ${meta.unique_id}_formatting_errors.txt

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -18,6 +18,7 @@ process check_sce {
     """
     sce_formatting_checks.R \
         --sce_file ${sce_file} \
+        --object_id ${meta.library_id} \
         --object_type ${object_type} \
         --reference_file ${reference_sce_file} \
         --output_file ${meta.unique_id}_formatting_errors.txt
@@ -44,6 +45,7 @@ process check_anndata {
     """
     anndata_formatting_checks.py \
         --anndata_file ${anndata_file} \
+        --object_id ${meta.library_id} \
         --object_type ${object_type} \
         --reference_file ${reference_anndata_file} \
         --output_file ${meta.unique_id}_formatting_errors.txt

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -105,10 +105,10 @@ workflow format_checks {
     check_anndata(anndata_format_ch, anndata_format_reference_file)
 
     // collect all error files and concatenate to print to a formatting errors output file
-    error_input_ch = check_sce.out
+    error_output_ch = check_sce.out
       .mix(check_anndata.out) // mix with the anndata error files
 
-    error_files_ch = error_input_ch
+    error_files_ch = error_output_ch
       .collect{ meta, error_file -> error_file } // collect into a list of just the error files
     
     compile_errors(error_files_ch)

--- a/modules/format-checks.nf
+++ b/modules/format-checks.nf
@@ -105,12 +105,14 @@ workflow format_checks {
     // collect all error files and concatenate to print to a formatting errors output file
     error_input_ch = check_sce.out
       .mix(check_anndata.out) // mix with the anndata error files
+
+    error_files_ch = error_input_ch
       .collect{ meta, error_file -> error_file } // collect into a list of just the error files
     
-    compile_errors(error_input_ch)
+    compile_errors(error_files_ch)
 
     // collect all error files and print out an error to the log file
-    check_sce.out
+    error_output_ch
       .filter{ meta, error_file -> error_file.size() > 0 } // only warn about libraries with errors
       .subscribe{ meta, error_file -> 
         log.error "Formatting errors for ${error_file.text}"

--- a/references/anndata-formatting-reference.json
+++ b/references/anndata-formatting-reference.json
@@ -499,21 +499,19 @@
                 "is_cell_line": "bool",
                 "development_stage_ontology_term_id": "string",
                 "sex_ontology_term_id": "string",
-                "organism_ontology_term_id": "string",
+                "organism_ontology_id": "string",
                 "self_reported_ethnicity_ontology_term_id": "string",
                 "disease_ontology_term_id": "string",
                 "tissue_ontology_term_id": "string",
                 "tech_version": "string",
                 "assay_ontology_term_id": "string",
-                "suspension_type": "string",
-                "is_primary_data": "bool"
+                "suspension_type": "string"
             },
             "var": {
                 "gene_ids": "string",
                 "gene_symbol": "string",
                 "mean": "float",
                 "detected": "float",
-                "feature_is_filtered": "bool",
                 "highly_variable": "bool"
             },
             "obs_conditional": {

--- a/references/sce-formatting-reference.json
+++ b/references/sce-formatting-reference.json
@@ -616,7 +616,7 @@
             "is_cell_line": "logical",
             "development_stage_ontology_term_id": "character",
             "sex_ontology_term_id": "character",
-            "organism_ontology_term_id": "character",
+            "organism_ontology_id": "character",
             "self_reported_ethnicity_ontology_term_id": "character",
             "disease_ontology_term_id": "character",
             "tissue_ontology_term_id": "character",

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -128,7 +128,7 @@ merged_cell_metadata = {
     "is_cell_line": "logical",
     "development_stage_ontology_term_id": "character",
     "sex_ontology_term_id": "character",
-    "organism_ontology_term_id": "character",
+    "organism_ontology_id": "character",
     "self_reported_ethnicity_ontology_term_id": "character",
     "disease_ontology_term_id": "character",
     "tissue_ontology_term_id": "character",
@@ -616,6 +616,9 @@ merged_obs_metadata = {
     **anndata_specific_obs_metadata,
     "detected": "int",
 }
+merged_obs_metadata.pop(
+    "is_primary_data", None
+)  # this column gets dropped for merged objects
 
 # row metadata ----------
 # same for unfilterd and filtered
@@ -626,6 +629,11 @@ unfiltered_var_metadata = {
 
 # highly variable is only in the processed object
 processed_var_metadata = {**unfiltered_var_metadata, "highly_variable": "bool"}
+
+# merged var contains everything but feature_is_filtered
+merged_var_metadata = {
+    k: v for k, v in processed_var_metadata.items() if k != "feature_is_filtered"
+}
 
 # reduced dimensionality ----------
 processed_obsm = ["X_pca", "X_umap"]
@@ -792,7 +800,7 @@ merged_anndata = {
         "has_raw.X": True,
         "layers": layers,
         "obs": merged_obs_metadata,
-        "var": processed_var_metadata,
+        "var": merged_var_metadata,
         "obs_conditional": processed_obs_metadata_conditional,
         "obsm": processed_obsm,
         "uns": merged_uns_metadata,

--- a/references/scripts/create-formatting-reference.py
+++ b/references/scripts/create-formatting-reference.py
@@ -631,9 +631,8 @@ unfiltered_var_metadata = {
 processed_var_metadata = {**unfiltered_var_metadata, "highly_variable": "bool"}
 
 # merged var contains everything but feature_is_filtered
-merged_var_metadata = {
-    k: v for k, v in processed_var_metadata.items() if k != "feature_is_filtered"
-}
+merged_var_metadata = processed_var_metadata.copy()
+merged_var_metadata.pop("feature_is_filtered", None)
 
 # reduced dimensionality ----------
 processed_obsm = ["X_pca", "X_umap"]


### PR DESCRIPTION
Closes #1168 

This PR adds the processes to the merge workflow to check and report formatting errors. The actual process is the same as what happens in the main workflow, but instead of extracting the object type from the input file, we just use merged as the object type. 

The trickiest part here was figuring out how to deal with checking the `libraryid-mean` and `libraryid-detected` columns. I ended up adding a helper function that finds all `mean` and `detected` columns and expands the reference file to include the exact column names that are present and then do the checking. This is done for both the SCE and AnnData checks. 

When I first ran this through, I was getting this output: 
```
Formatting errors found for SCPCL000001 merged SingleCellExperiment:
Formatting errors found for SCPCL000002 merged SingleCellExperiment:
Formatting errors found for SCPCL000003 merged SingleCellExperiment:

Missing 'organism_ontology_term_id' from main SCE colData.

Formatting errors found for ['SCPCL000001' 'SCPCL000002' 'SCPCL000003'] merged rna AnnData object:

Missing 'organism_ontology_term_id' from RNA AnnData obs.
Missing 'is_primary_data' from RNA AnnData obs.
Missing 'feature_is_filtered' from RNA AnnData var.
```

So I updated the scripts to pass in the `object_id` which is either the library ID or project ID and edited the header for the error messages so we don't print out a bunch of ids. 

I also fixed the reference file to remove `is_primary_data` and `feature_is_filtered` from the AnnData merged objects only and fixed the typo for `organism_ontology_term_id`, which is just `organism_ontology_id`. For the project that I tested (SCPCP000001), there are no formatting errors now. 