### PR TITLE
Remove dash in cellranger-multi mapping tool in report

### DIFF
--- a/templates/qc_report/main_qc_report.rmd
+++ b/templates/qc_report/main_qc_report.rmd
@@ -340,7 +340,7 @@ if (mapping_tool == "alevin-fry") {
       "Percent of RNA-seq reads mapped to transcripts" =
         paste0(round((unfiltered_meta$mapped_reads / unfiltered_meta$total_reads) * 100, 2), "%"),
     )
-} else if (mapping_tool == "cellranger-multi") {
+} else if (mapping_tool == "cellranger multi") {
   library_information <- library_information |>
     mutate(
       "Cells reported by cellranger multi" =
@@ -419,7 +419,7 @@ if (mapping_tool == "alevin-fry") {
   ) |>
     reformat_nulls() |>
     t()
-} else if (mapping_tool == "cellranger-multi") {
+} else if (mapping_tool == "cellranger multi") {
   processing_info <- tibble::tibble(
     "Cellranger version" = format(unfiltered_meta$cellranger_version),
     "Transcriptome index" = format(unfiltered_meta$reference_index),


### PR DESCRIPTION
In working on the test data, I was getting an error where the `mapping_tool` was not `cellranger-multi` but it's `cellranger multi` with the space. We changed this when writing docs a little while ago and I changed it in the place where we add the information to the metadata, but not in the report: https://github.com/AlexsLemonade/scpca-nf/blob/89d3f11c65900f93d4ea9df4d4018fdbad34e600/bin/generate_unfiltered_sce_cellranger.R#L164

This makes the change in the report. I also searched the repo for other instances and this should be the only one.