### PR TITLE
Fix errors in formatting checks

### DIFF
--- a/bin/sce_formatting_checks.R
+++ b/bin/sce_formatting_checks.R
@@ -389,7 +389,7 @@ if (opt$object_type == "processed") {
 
 if (opt$object_type == "merged") {
   # if the object type is merged, then grab the project id from the filename to print in the header for error messages
-  header_id <- stringr::remove(basename(opt$sce_file), "_merged.rds")
+  header_id <- stringr::str_remove(basename(opt$sce_file), "_merged.rds")
 } else {
   # otherwise just grab the library id from the metadata
   header_id <- metadata(sce)$library_id

--- a/merge.nf
+++ b/merge.nf
@@ -344,9 +344,13 @@ workflow {
   // export merged objects to AnnData
   export_anndata(merged_ch)
 
+  // transpose so each h5ad file is checked separately
+  anndata_format_ch = export_anndata.out
+    .transpose()  // [merge_group_id, rna.h5ad], [merge_group_id, adt.h5ad]
+
   // check formatting of merged objects 
   check_sce(merged_ch, file(params.sce_format_reference_file))
-  check_anndata(export_anndata.out, file(params.anndata_format_reference_file))
+  check_anndata(anndata_format_ch, file(params.anndata_format_reference_file))
 
   // collect all error files and concatenate to print to a formatting errors output file
   error_output_ch = check_sce.out

--- a/modules/export-anndata.nf
+++ b/modules/export-anndata.nf
@@ -96,7 +96,7 @@ workflow sce_to_anndata {
       // pull out just 1 meta object and h5ad files
       // [meta, [h5ad files]]
       .map{ _unique_id, meta_list, h5ad_files ->
-        [meta_list[0], h5ad_files]
+        [meta_list[0], h5ad_files.flatten()]  // flatten to get a single list of all h5ad files
       }
 
   emit:


### PR DESCRIPTION
Some more errors showing up in test data that we didn't catch before. The main change here is that we need to flatten the list of anndata objects so that we have `[meta, unfiltered rna, unfiltered adt, ... ]` instead of nested lists for each object type. This makes it so we are only passing one file into the anndata formatting checks. I made this fix for both the individual processing and merged objects. 