### PR TITLE
Handle failures in scDblFinder

### DIFF
--- a/bin/detect_doublets.R
+++ b/bin/detect_doublets.R
@@ -64,24 +64,37 @@ if (file.size(opt$input_sce_file) == 0) {
 sce <- readr::read_rds(opt$input_sce_file)
 
 # run scDblFinder -----------
-doublet_result <- scDblFinder::scDblFinder(
-  sce,
-  BPPARAM = bp_param,
-  returnType = "table" # keep as table in case we eventually want to provide additional output
+doublet_result <- tryCatch(
+  scDblFinder::scDblFinder(
+    sce,
+    BPPARAM = bp_param,
+    returnType = "table" # keep as table in case we eventually want to provide additional output
+  ),
+  error = function(e) {
+    message("scDblFinder failed: doublet columns will be NA")
+    message(conditionMessage(e))
+    NULL
+  }
 )
 
-# store the `score` and `class` columns in the colData
-doublet_result_cells <- doublet_result |>
-  as.data.frame() |>
-  tibble::rownames_to_column("barcodes") |>
-  # keep only actual barcodes to remove the artificial doublets
-  dplyr::filter(barcodes %in% colnames(sce)) |>
-  dplyr::select(barcodes, scDblFinder_class = class, scDblFinder_score = score)
+if (is.null(doublet_result)) {
+  # if scDblFinder fails, fill columns with NA
+  sce$scDblFinder_class <- NA_character_
+  sce$scDblFinder_score <- NA_real_
+} else {
+  # store the `score` and `class` columns in the colData
+  doublet_result_cells <- doublet_result |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcodes") |>
+    # keep only actual barcodes to remove the artificial doublets
+    dplyr::filter(barcodes %in% colnames(sce)) |>
+    dplyr::select(barcodes, scDblFinder_class = class, scDblFinder_score = score)
 
-colData(sce) <- colData(sce) |>
-  as.data.frame() |>
-  dplyr::left_join(doublet_result_cells, by = "barcodes") |>
-  DataFrame(row.names = colnames(sce))
+  colData(sce) <- colData(sce) |>
+    as.data.frame() |>
+    dplyr::left_join(doublet_result_cells, by = "barcodes") |>
+    DataFrame(row.names = colnames(sce))
+}
 
 # Export updated SCE with doublet information
 readr::write_rds(sce, opt$output_sce_file, compress = "bz2")

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -214,11 +214,17 @@ process filter_sce {
       ${params.seed ? "--random_seed ${params.seed}" : ""} \
       --no_sce_compression
 
-    detect_doublets.R \
-      --input_sce_file "filtered.rds" \
-      --output_sce_file ${filtered_rds} \
-      ${params.seed ? "--random_seed ${params.seed}" : ""} \
-      --threads ${task.cpus}
+    # only run doublet detection if the filtered file is not empty
+    if [ -s "filtered.rds" ]; then
+      detect_doublets.R \
+        --input_sce_file "filtered.rds" \
+        --output_sce_file ${filtered_rds} \
+        ${params.seed ? "--random_seed ${params.seed}" : ""} \
+        --threads ${task.cpus}
+    else
+      mv filtered.rds ${filtered_rds}
+    fi
+    
     """
   stub:
     filtered_rds = "${meta.unique_id}_filtered.rds"

--- a/modules/sce-processing.nf
+++ b/modules/sce-processing.nf
@@ -214,17 +214,11 @@ process filter_sce {
       ${params.seed ? "--random_seed ${params.seed}" : ""} \
       --no_sce_compression
 
-    # only run doublet detection if the filtered file is not empty
-    if [ -s "filtered.rds" ]; then
-      detect_doublets.R \
-        --input_sce_file "filtered.rds" \
-        --output_sce_file ${filtered_rds} \
-        ${params.seed ? "--random_seed ${params.seed}" : ""} \
-        --threads ${task.cpus}
-    else
-      mv filtered.rds ${filtered_rds}
-    fi
-    
+    detect_doublets.R \
+      --input_sce_file "filtered.rds" \
+      --output_sce_file ${filtered_rds} \
+      ${params.seed ? "--random_seed ${params.seed}" : ""} \
+      --threads ${task.cpus}
     """
   stub:
     filtered_rds = "${meta.unique_id}_filtered.rds"


### PR DESCRIPTION
I received a report with the following error after trying to run `scpca-nf` indicating a failure in `scDblFinder` because of too few cells. 

> Creating ~1500 artificial doublets...
Error in fixupDN.if.valid(value, x@Dim) :
  length of Dimnames[[2]] (1) is not equal to Dim[2] (0)
Calls: <Anonymous> ... colnames<- -> dimnames<- -> dimnames<- -> fixupDN.if.valid
In addition: Warning message:
In scDblFinder::scDblFinder(sce, BPPARAM = bp_param, returnType = "table") :
  scDblFinder might not work well with very low numbers of cells.

We don't want the whole workflow to fail if this is the case, so we should handle this failure with a `tryCatch`. I do that here and then set the added `scDblFinder` columns to `NA` in the `colData`. Let me know if you prefer we use something other than NA to indicate an actual failure rather than just NA. 