### PR TITLE
Add max nextflow version

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   doi = '10.1101/2024.04.19.590243'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  nextflowVersion = '>=24.09, !<26'
+  nextflowVersion = '!>=24.09, <26'
   version = 'v0.10.3'
   contributors = [
     [

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   doi = '10.1101/2024.04.19.590243'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  nextflowVersion = '>=24.09'
+  nextflowVersion = '>=24.09, !<26'
   version = 'v0.10.3'
   contributors = [
     [


### PR DESCRIPTION
Because we do not support strict syntax yet, (see #1279), I wanted to put a hard upper bound on versions so we get a version error rather than a mysterious one when the syntax is off. 