### PR TITLE
Make sure methods without any classified cells are not included in the Jaccard heatmaps

### DIFF
--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -396,8 +396,15 @@ Note that due to different annotations references, these methods may use differe
 ```
 
 ```{r, eval = has_consensus}
+# remove any cell types that have 0 cells left after removing unclassified cells
+# the show_<method> variables are true when this is the case
+celltypes_to_show <- names(automated_celltype_names)[c(show_singler, show_cellassign, show_scimilarity)]
+
 # celltypes used to generate consensus, all automated - consensus
-consensus_input_celltypes <- automated_celltypes_available[!(automated_celltypes_available == "Consensus")]
+# remove any celltypes with show_<method> = FALSE 
+# consensus also gets removed from the list since it's not part of the automated_celltype_names
+consensus_input_celltypes <- automated_celltypes_available[automated_celltypes_available %in% celltypes_to_show] 
+
 
 # calculate matrices comparing to consensus
 jaccard_consensus_matrices <- consensus_input_celltypes |>

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -398,7 +398,7 @@ Note that due to different annotations references, these methods may use differe
 ```{r, eval = has_consensus}
 # remove any cell types that have 0 cells left after removing unclassified cells
 # the show_<method> variables are true when this is the case
-celltypes_to_show <- names(automated_celltype_names)[c(show_singler, show_cellassign, show_scimilarity)]
+celltypes_to_show <- c("SingleR", "CellAssign", "SCimilarity")[c(show_singler, show_cellassign, show_scimilarity)]
 
 # celltypes used to generate consensus, all automated - consensus
 # remove any celltypes with show_<method> = FALSE 


### PR DESCRIPTION
As a follow up to #1340, I ran into one more error where we were still trying to make a Jaccard matrix using a matrix with 0 cells as input. This adds a fix to make sure that when we make the heatmap comparing automated celltype annotations to consensus, we don't include any methods where all cells are considered "unclassified". These cells are those that were skipped when re-processing because we don't repeat cell typing. I've never seen this in practice but have only seen it with the test data that we have setup since the numbers are small. 

Once this goes in, I will again try to regenerate test data, which can only be done using the `main` or `development` branches. 