### PR TITLE
Fix all Jaccard heatmaps

### DIFF
--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -398,15 +398,8 @@ Note that due to different annotations references, these methods may use differe
 ```
 
 ```{r, eval = has_consensus}
-# remove any cell types that have 0 cells left after removing unclassified cells
-# the show_<method> variables are true when this is the case
-celltypes_to_show <- c("SingleR", "CellAssign", "SCimilarity")[c(show_singler, show_cellassign, show_scimilarity)]
-
 # celltypes used to generate consensus, all automated - consensus
-# remove any celltypes with show_<method> = FALSE 
-# consensus also gets removed from the list since it's not part of the automated_celltype_names
-consensus_input_celltypes <- automated_celltypes_available[automated_celltypes_available %in% celltypes_to_show] 
-
+consensus_input_celltypes <- automated_celltypes_available[!(automated_celltypes_available == "Consensus")]
 
 # calculate matrices comparing to consensus
 jaccard_consensus_matrices <- consensus_input_celltypes |>

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -89,9 +89,11 @@ available_celltypes <- c(
   if (has_submitter) "Submitter",
   if (has_openscpca) "OpenScPCA",
   if (has_consensus) "Consensus",
-  if (has_singler) "SingleR",
-  if (has_cellassign) "CellAssign",
-  if (has_scimilarity) "SCimilarity"
+  # only include methods that have 0 cells left after removing unclassified cells
+  # the show_<method> variables are true when this is the case
+  if (show_singler) "SingleR",
+  if (show_cellassign) "CellAssign",
+  if (show_scimilarity) "SCimilarity"
 )
 
 # use an empty character vector if no celltypes present

--- a/templates/qc_report/celltypes_supplemental_report.rmd
+++ b/templates/qc_report/celltypes_supplemental_report.rmd
@@ -399,7 +399,7 @@ Note that due to different annotations references, these methods may use differe
 
 ```{r, eval = has_consensus}
 # celltypes used to generate consensus, all automated - consensus
-consensus_input_celltypes <- automated_celltypes_available[!(automated_celltypes_available == "Consensus")]
+consensus_input_celltypes <- automated_celltypes_available[automated_celltypes_available != "Consensus"]
 
 # calculate matrices comparing to consensus
 jaccard_consensus_matrices <- consensus_input_celltypes |>


### PR DESCRIPTION
This is a better version of the fix I made in #1341 that just sets the vector of `available_celltypes` directly based on which methods have cells left. This should fix the new error I was seeing from the later heatmaps in the plot. I also reverted the changes in #1341. 